### PR TITLE
IEnumerable integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ A type-safe and space-efficient sum type for C# (comparable to unions in C or C+
   - [Custom Value Types](#custom-value-types)
   - [Nullability](#nullability)
   - [Emptiness](#emptiness)
+- [Generated Code Features](#generated-code-features)
+  - [Extension Methods](#extension-methods)
 - [Customization](#customization)
-- [Additional Considerations in Generated Code](#additional-considerations-in-generated-code)
 - [Compatibility](#compatibility)
 - [License](#license)
 
@@ -180,10 +181,39 @@ variant.Match(
     () => "empty"); // Fourth option called when empty
 ```
 
-## Customization
-TODO
+## Generated Code Features
+The generated implemenation provides some additional features depending on the types you provide it, or third-party libraris available to you.
 
-## Additional Considerations in Generated Code
+### Foreign Extension Methods
+If your type is declared in such a way that providing extensions methods is possible you will get additional integration with .NET facilities, or popular external libraries, listed in this section. The visibility (`public` or `internal`) of the extension methods is made to match the accessibility of your type declaration.
+
+#### `IEnumerable<T>`
+These allow for easy and powerful integration into `System.Linq`-like queries on `IEnumerable<T>` sequences, that let you manipulate a stream of variants based on the contained type.
+```csharp
+[Variant]
+public readonly partial struct MyVariant
+{
+    partial void VariantOf(int i, double d, string s);
+}
+
+var xs = new MyVariant[] { 1, 2.0, "3", 4, 5.0, "6" };
+
+// Unary Match only transforms the matching type and drops all others
+xs.Match((int i) => i); // result: IEnumerable<int> [1, 4]
+
+// Binary Match lets you provide a fallback value or delegate to replace non-matching values with
+xs.Match((int i) => i, 0); // result: IEnumerable<int> [1, 0, 0, 4, 0, 0]
+xs.Match((int i) => i, () => -1); // result: IEnumerable<int> [1, -1, -1, 4, -1, -1]
+
+// Visit transform each possible value type individually
+xs.Visit(
+    i => $"int {i}",
+    d => $"double {d}"
+    s=> $"string {s}");
+// result: IEnumerable<string> ["int 1", "double 2", "string 3", "int 4", "double 5", "string 6"]
+```
+
+## Customization
 TODO
 
 ## Compatibility

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -829,3 +829,252 @@ namespace Foo
             => _variant.Visit(i, f, s, _);
     }
 }
+
+namespace Foo
+{
+    public static partial class _Variant_class_nullable_disable_Ex
+    {
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<int, TResult> i)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out int value))
+                {
+                    yield return i(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<float, TResult> f)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out float value))
+                {
+                    yield return f(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<string, TResult> s)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out string value))
+                {
+                    yield return s(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<int, TResult> i,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<float, TResult> f,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(f, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<string, TResult> s,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(s, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<int, TResult> i,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<float, TResult> f,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(f, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(s, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_class_nullable_disable.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, f, s);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_disable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_disable> source,
+                global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, f, s, _);
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -1030,3 +1030,318 @@ namespace Foo
             => _variant.Visit(i, f, s, a, _);
     }
 }
+
+namespace Foo
+{
+    public static partial class _Variant_class_nullable_enable_Ex
+    {
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<int, TResult> i)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out int value))
+                {
+                    yield return i(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<float, TResult> f)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out float value))
+                {
+                    yield return f(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<string, TResult> s)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out string? value))
+                {
+                    yield return s(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.Array"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<global::System.Array?, TResult> a)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out global::System.Array? value))
+                {
+                    yield return a(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<int, TResult> i,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<float, TResult> f,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(f, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<string, TResult> s,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(s, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.Array"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<global::System.Array?, TResult> a,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(a, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<int, TResult> i,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="float"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="f">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<float, TResult> f,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(f, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(s, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.Array"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<global::System.Array?, TResult> a,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(a, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_class_nullable_enable.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, f, s, a);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_class_nullable_enable> source,
+                global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, f, s, a, _);
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -828,3 +828,252 @@ namespace Foo
             => _variant.Visit(l, d, o, _);
     }
 }
+
+namespace Foo
+{
+    public static partial class _Variant_struct_nullable_disable_Ex
+    {
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<long, TResult> l)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out long value))
+                {
+                    yield return l(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<double, TResult> d)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out double value))
+                {
+                    yield return d(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<object, TResult> o)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out object value))
+                {
+                    yield return o(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<long, TResult> l,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(l, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<double, TResult> d,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(d, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<object, TResult> o,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(o, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<long, TResult> l,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(l, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<double, TResult> d,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(d, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<object, TResult> o,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(o, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">The delegate to invoke if the element's value is of type <see cref="long"/>.</param>
+        /// <param name="d">The delegate to invoke if the element's value is of type <see cref="double"/>.</param>
+        /// <param name="o">The delegate to invoke if the element's value is of type <see cref="object"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_struct_nullable_disable.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(l, d, o);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_disable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">The delegate to invoke if the element's value is of type <see cref="long"/>.</param>
+        /// <param name="d">The delegate to invoke if the element's value is of type <see cref="double"/>.</param>
+        /// <param name="o">The delegate to invoke if the element's value is of type <see cref="object"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_disable> source,
+                global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(l, d, o, _);
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -828,3 +828,252 @@ namespace Foo
             => _variant.Visit(l, d, o, _);
     }
 }
+
+namespace Foo
+{
+    public static partial class _Variant_struct_nullable_enable_Ex
+    {
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<long, TResult> l)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out long value))
+                {
+                    yield return l(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<double, TResult> d)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out double value))
+                {
+                    yield return d(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<object, TResult> o)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out object? value))
+                {
+                    yield return o(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<long, TResult> l,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(l, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<double, TResult> d,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(d, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<object, TResult> o,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(o, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="long"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<long, TResult> l,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(l, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="double"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="d">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<double, TResult> d,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(d, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="object"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="o">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<object, TResult> o,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(o, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">The delegate to invoke if the element's value is of type <see cref="long"/>.</param>
+        /// <param name="d">The delegate to invoke if the element's value is of type <see cref="double"/>.</param>
+        /// <param name="o">The delegate to invoke if the element's value is of type <see cref="object"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_struct_nullable_enable.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(l, d, o);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_struct_nullable_enable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="l">The delegate to invoke if the element's value is of type <see cref="long"/>.</param>
+        /// <param name="d">The delegate to invoke if the element's value is of type <see cref="double"/>.</param>
+        /// <param name="o">The delegate to invoke if the element's value is of type <see cref="object"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_struct_nullable_enable> source,
+                global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(l, d, o, _);
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -63,5 +63,8 @@ namespace dotVariant.Generator
 
         public static IMethodSymbol? FindNullaryToString(ITypeSymbol type)
             => FindMethod(type, m => m.MethodKind == MethodKind.Ordinary && m.Name == "ToString()" && m.Parameters.IsEmpty);
+
+        public static Accessibility EffectiveAccessibility(ITypeSymbol type)
+            => type.DeclaredAccessibility;
     }
 }

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -777,3 +777,141 @@ namespace {{ Variant.Namespace }}
 {{~ if Variant.Namespace ~}}
 }
 {{~ end ~}}
+
+{{~ if Variant.ExtensionsAccessibility ~}}
+{{~ if Options.ExtensionClassNamespace ~}}
+namespace {{ Options.ExtensionClassNamespace }}
+{
+{{~ end ~}}
+    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
+    {
+        {{~ ## Match(IEnumerable<V>, Func<A, R>) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }})
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out {{ outref_type $p }} value))
+                {
+                    yield return {{ $p.Hint }}(value);
+                }
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Match(IEnumerable<V>, Func<A, R>, R) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }},
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match({{ $p.Hint }}, _);
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Match(IEnumerable<V>, Func<A, R>, Func<R>) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }},
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match({{ $p.Hint }}, _);
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ...) ## ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        {{~ for $p in Params ~}}
+        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
+        {{~ end ~}}
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty {{ Variant.Name }}.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_params }})
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit({{ Params | array.each @param_hint | array.join ", "  }});
+            }
+        }
+
+        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ..., empty) ## ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        {{~ for $p in Params ~}}
+        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
+        {{~ end ~}}
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_params }},
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit({{ Params | array.each @param_hint | array.join ", "  }}, _);
+            }
+        }
+    }
+{{~ if Options.ExtensionClassNamespace ~}}
+}
+{{~ end ~}}
+{{~ end ~}}

--- a/src/dotVariant.Test/Variant+IEnumerable.cs
+++ b/src/dotVariant.Test/Variant+IEnumerable.cs
@@ -1,0 +1,192 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using dotVariant.Test.Variants;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace dotVariant.Test
+{
+    public static partial class Variant_Test
+    {
+        public static class IEnumerable_Ex
+        {
+            [Test]
+            public static void Match_transforms_matching_elements_and_drops_rest_1()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((int x) => x * 3),
+                    Is.EqualTo(new[] { 3, 12 }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_drops_rest_2()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((float x) => x * 3),
+                    Is.EqualTo(new[] { 2f * 3, 5f * 3 }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_drops_rest_3()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((string x) => x + x),
+                    Is.EqualTo(new[] { "33", "66" }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_value_1()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((int x) => x * 3, -1),
+                    Is.EqualTo(new[] { 3, -1, -1, 12, -1, -1 }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_value_2()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((float x) => x * 3, -1f),
+                    Is.EqualTo(new[] { -1f, 2f * 3, -1f, -1f, 5f * 3, -1f }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_value_3()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((string x) => x + x, "-"),
+                    Is.EqualTo(new[] { "-", "-", "33", "-", "-", "66" }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_selector_1()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((int x) => x * 3, () => -1),
+                    Is.EqualTo(new[] { 3, -1, -1, 12, -1, -1 }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_selector_2()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((float x) => x * 3, () => -1f),
+                    Is.EqualTo(new[] { -1f, 2f * 3, -1f, -1f, 5f * 3, -1f }));
+            }
+
+            [Test]
+            public static void Match_transforms_matching_elements_and_replaces_rest_with_fallback_selector_3()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Match((string x) => x + x, () => "-"),
+                    Is.EqualTo(new[] { "-", "-", "33", "-", "-", "66" }));
+            }
+
+            [Test]
+            public static void Visit_transforms_each_element()
+            {
+                var input = new Class_int_float_string[]
+                {
+                    1, 2f, "3", 4, 5f, "6",
+                };
+
+                Assert.That(
+                    input.Visit(
+                        (int x) => $"int: {x}",
+                        (float x) => $"float: {x}",
+                        (string x) => $"string: {x}"),
+                    Is.EqualTo(new[]
+                    {
+                        "int: 1", "float: 2", "string: 3", "int: 4", "float: 5", "string: 6",
+                    }));
+            }
+
+            [Test]
+            public static void Visit_throws_on_empty_element()
+            {
+                var input = new Struct_int_float_object[]
+                {
+                    1, 2f, default,
+                };
+
+                var processed = new List<string>();
+                Assert.That(
+                    () =>
+                        input.Visit(
+                            (int x) => $"int",
+                            (float x) => $"float",
+                            (Helper x) => $"Helper")
+                        .ForEach(processed.Add),
+                    Throws.InvalidOperationException);
+                Assert.That(processed, Is.EqualTo(new[] { "int", "float" }));
+            }
+
+            [Test]
+            public static void Visit_transforms_each_element_and_calls_empty_fallback()
+            {
+                var input = new Struct_int_float_object[]
+                {
+                    1, 2f, default,
+                };
+
+                Assert.That(
+                    input.Visit(
+                        (int x) => $"int",
+                        (float x) => $"float",
+                        (Helper x) => $"Helper",
+                        () => "empty"),
+                    Is.EqualTo(new[] { "int", "float", "empty" }));
+            }
+        }
+    }
+}

--- a/src/dotVariant.Test/dotVariant.Test.projitems
+++ b/src/dotVariant.Test/dotVariant.Test.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Variant+Equality.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+ToString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+IsEmpty.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Variant+IEnumerable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+Visit.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+Match-Func.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+Match-Action.cs" />

--- a/src/dotVariant.Test/dotVariant.Test.props
+++ b/src/dotVariant.Test/dotVariant.Test.props
@@ -13,6 +13,11 @@
     <PackageReference Include="System.Interactive" Version="5.0.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <dotVariant-ExtensionClassNamespace>dotVariant.Test</dotVariant-ExtensionClassNamespace>
+  </PropertyGroup>
+
+  <!-- local development setup -->
   <ItemGroup Condition="!$(PackageSelfTest)">
     <ProjectReference Include="..\dotVariant.Runtime\dotVariant.Runtime.csproj" />
     <ProjectReference Include="..\dotVariant.Generator\dotVariant.Generator.csproj">
@@ -22,9 +27,12 @@
       <ExcludeAssets>all</ExcludeAssets>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\dotVariant\build\dotVariant.props" Condition="!$(PackageSelfTest)" />
 
+  <!-- package self-test setup -->
   <ItemGroup Condition="$(PackageSelfTest)">
     <PackageReference Include="dotVariant" Version="$(Version)" />
   </ItemGroup>
+
 
 </Project>

--- a/src/dotVariant/build/dotVariant.props
+++ b/src/dotVariant/build/dotVariant.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="dotVariant-ExtensionClassNamespace" />
+  </ItemGroup>
+</Project>

--- a/src/dotVariant/dotVariant.csproj
+++ b/src/dotVariant/dotVariant.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <None Include="$(GeneratorOutputPath)/dotVariant.dll" Pack="true" PackagePath="lib/$(TargetFramework)" Link="lib/$(TargetFramework)/%(Filename)%(Extension)" />
     <None Include="../dotVariant.Generator/licenses/**" Pack="true" PackagePath="licenses" Link="licenses/%(RecursiveDir)%(Filename)%(Extension)"/>
+    <None Include="build/*" Pack="true" PackagePath="build" />
   </ItemGroup>
 
   <Target Name="dotVariant-GatherGeneratorDependencies" AfterTargets="Build">


### PR DESCRIPTION
If possible create extension methods for `IEnumerable<T>` with custom operators.

```csharp
[Variant]
public readonly partial struct MyVariant
{
    partial void VariantOf(int i, double d, string s);
}
var xs = new MyVariant[] { 1, 2.0, "3", 4, 5.0, "6" };
// Unary Match only transforms the matching type and drops all others
xs.Match((int i) => i); // result: IEnumerable<int> [1, 4]
// Binary Match lets you provide a fallback value or delegate to replace non-matching values with
xs.Match((int i) => i, 0); // result: IEnumerable<int> [1, 0, 0, 4, 0, 0]
xs.Match((int i) => i, () => -1); // result: IEnumerable<int> [1, -1, -1, 4, -1, -1]
// Visit transform each possible value type individually
xs.Visit(
    i => $"int {i}",
    d => $"double {d}"
    s=> $"string {s}");
// result: IEnumerable<string> ["int 1", "double 2", "string 3", "int 4", "double 5", "string 6"]
```