### PR TITLE
Add support for IDisposable value types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A type-safe and space-efficient sum type for C# (comparable to unions in C or C+
   - [Nullability](#nullability)
   - [Emptiness](#emptiness)
 - [Generated Code Features](#generated-code-features)
+  - [`IDisposable` Support](#idisposable-support)
   - [Third-party Integrations](#third-party-integrations)
 - [Customization](#customization)
   - [Extension Class Namespace](#extension-class-namespace)
@@ -185,6 +186,11 @@ variant.Match(
 
 ## Generated Code Features
 The generated implemenation provides some additional features depending on the types you provide it, or third-party libraries available to you.
+
+### `IDisposable` Support
+If _at least one_ of the types included in the `VariantOf()` parameters implements `System.IDisposable` then the generated variant will also implement this interface and provide a public `Dispose()` member which delegates to the stored value's `Dispose()` if applicable.
+
+If there already exists an implementation of `IDisposable.Dispose()` (either you defined one, or it is present in a base class) then the public `Dispose()` method is _not_ generated and it is your responsibility to take care of calling the private `_variant.Dispose()`.
 
 ### Third-party Integrations
 If your type is declared in such a way that providing extensions methods is possible you will get additional integration with .NET facilities, or popular external libraries, listed in this section. The visibility (`public` or `internal`) of the extension methods is made to match the accessibility of your type declaration.

--- a/src/dotVariant.Generator.Test/VariantSourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/VariantSourceGenerator.Test.cs
@@ -58,6 +58,7 @@ namespace dotVariant.Generator.Test
                 {
                     ("Variant-class-nullable-disable", "Foo.Variant_class_nullable_disable"),
                     ("Variant-class-nullable-enable", "Foo.Variant_class_nullable_enable"),
+                    ("Variant-disposable", "Foo.Variant_disposable"),
                     ("Variant-struct-nullable-disable", "Foo.Variant_struct_nullable_disable"),
                     ("Variant-struct-nullable-enable", "Foo.Variant_struct_nullable_enable"),
                 }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -10,7 +10,8 @@ namespace Foo
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial class Variant_class_nullable_disable : global::System.IEquatable<Variant_class_nullable_disable>
+    partial class Variant_class_nullable_disable
+        : global::System.IEquatable<Variant_class_nullable_disable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly _VariantStorage _variant;
@@ -46,6 +47,7 @@ namespace Foo
                 _n = 3;
                 _x = new Union(s);
             }
+
 
             [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
             [global::System.Diagnostics.DebuggerNonUserCode]
@@ -364,6 +366,7 @@ namespace Foo
         /// <param name="s">The value to initlaize the variant with.</param>
         public static Variant_class_nullable_disable Create(string s)
             => new Variant_class_nullable_disable(s);
+
 
         /// <summary>
         /// <see langword="true"/> if Variant_class_nullable_disable was constructed without a value.

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -10,7 +10,8 @@ namespace Foo
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial class Variant_class_nullable_enable : global::System.IEquatable<Variant_class_nullable_enable>
+    partial class Variant_class_nullable_enable
+        : global::System.IEquatable<Variant_class_nullable_enable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly _VariantStorage _variant;
@@ -51,6 +52,7 @@ namespace Foo
                 _n = 4;
                 _x = new Union(a);
             }
+
 
             [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
             [global::System.Diagnostics.DebuggerNonUserCode]
@@ -434,6 +436,7 @@ namespace Foo
         /// <param name="a">The value to initlaize the variant with.</param>
         public static Variant_class_nullable_enable Create(global::System.Array? a)
             => new Variant_class_nullable_enable(a);
+
 
         /// <summary>
         /// <see langword="true"/> if Variant_class_nullable_enable was constructed without a value.

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.in.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.in.cs
@@ -1,0 +1,18 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable disable
+namespace Foo
+{
+    [dotVariant.Variant]
+    public partial class Variant_disposable
+    {
+        // "stream" is disposable and we don't have a user-defined Dispose()
+        // so we expect one to be generated.
+        // The generated Dispose() is supposed to ignore "i" and dispose "stream".
+        static partial void VariantOf(int i, System.IO.Stream stream);
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -1,0 +1,840 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable disable
+namespace Foo
+{
+    [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
+    [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    partial class Variant_disposable
+        : global::System.IEquatable<Variant_disposable>
+        , global::System.IDisposable
+    {
+        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
+        private readonly _VariantStorage _variant;
+
+        private sealed class _VariantTypeProxy
+        {
+            public object Value { get; }
+            public _VariantTypeProxy(Variant_disposable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct _VariantStorage
+            : global::System.IDisposable
+        {
+            private readonly int _n;
+            private readonly Union _x;
+
+            public _VariantStorage(int i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+            public _VariantStorage(global::System.IO.Stream stream)
+            {
+                _n = 2;
+                _x = new Union(stream);
+            }
+
+            public void Dispose()
+            {
+                switch (_n)
+                {
+                    case 0:
+                        break;
+                    case 1:
+                        break;
+                    case 2:
+                        _x._2.Value?.Dispose();
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+
+                }
+            }
+
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Union
+            {
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Union1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Union2 _2;
+
+                public Union(int value)
+                {
+                    _2 = default;
+                    _1 = new Union1(value);
+                }
+                public Union(global::System.IO.Stream value)
+                {
+                    _1 = default;
+                    _2 = new Union2(value);
+                }
+
+                [global::System.Diagnostics.DebuggerNonUserCode]
+                public readonly struct Union1
+                {
+                    public readonly int Value;
+                    public readonly object _dummy1;
+
+                    public Union1(int value)
+                    {
+                        _dummy1 = null;
+                        Value = value;
+                    }
+                }
+                [global::System.Diagnostics.DebuggerNonUserCode]
+                public readonly struct Union2
+                {
+                    public readonly global::System.IO.Stream Value;
+
+                    public Union2(global::System.IO.Stream value)
+                    {
+                        Value = value;
+                    }
+                }
+            }
+
+            public bool IsEmpty => _n == 0;
+
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int";
+                        case 2:
+                            return "System.IO.Stream";
+                        default:
+                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                    }
+                }
+            }
+
+            public string ValueString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "";
+                        case 1:
+                            return _x._1.Value.ToString();
+                        case 2:
+                            return _x._2.Value?.ToString() ?? "null";
+                        default:
+                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                    }
+                }
+            }
+
+            public object AsObject
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        default:
+                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                    }
+                }
+            }
+
+            public bool Equals(in _VariantStorage other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
+                switch (_n)
+                {
+                    case 0:
+                        return true;
+                    case 1:
+                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    case 2:
+                        return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                }
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return 0;
+                        case 1:
+                            return global::System.HashCode.Combine(_x._1.Value);
+                        case 2:
+                            return global::System.HashCode.Combine(_x._2.Value);
+                        default:
+                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                    }
+                }
+            }
+
+            public bool TryMatch(out int i)
+            {
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+            public bool TryMatch(out global::System.IO.Stream stream)
+            {
+                stream = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        stream(_x._2.Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                }
+            }
+
+            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        stream(_x._2.Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                }
+            }
+
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return stream(_x._2.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                }
+            }
+
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return stream(_x._2.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        public Variant_disposable(int i)
+            => _variant = new _VariantStorage(i);
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
+        /// </summary>
+        /// <param name="stream">The value to initlaize the variant with.</param>
+        public Variant_disposable(global::System.IO.Stream stream)
+            => _variant = new _VariantStorage(stream);
+
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        public static implicit operator Variant_disposable(int i)
+            => new Variant_disposable(i);
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
+        /// </summary>
+        /// <param name="stream">The value to initlaize the variant with.</param>
+        public static implicit operator Variant_disposable(global::System.IO.Stream stream)
+            => new Variant_disposable(stream);
+
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        public static Variant_disposable Create(int i)
+            => new Variant_disposable(i);
+        /// <summary>
+        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
+        /// </summary>
+        /// <param name="stream">The value to initlaize the variant with.</param>
+        public static Variant_disposable Create(global::System.IO.Stream stream)
+            => new Variant_disposable(stream);
+
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _variant.Dispose();
+        }
+
+        /// <summary>
+        /// <see langword="true"/> if Variant_disposable was constructed without a value.
+        /// </summary>
+        public bool IsEmpty
+            => _variant.IsEmpty;
+
+        public override bool Equals(object other)
+            => other is Variant_disposable v && Equals(v);
+
+        public bool Equals(Variant_disposable other)
+            => !(other is null) && _variant.Equals(other._variant);
+
+        public static bool operator ==(Variant_disposable lhs, Variant_disposable rhs)
+            => lhs?.Equals(rhs) ?? (rhs is null);
+
+        public static bool operator !=(Variant_disposable lhs, Variant_disposable rhs)
+            => !(lhs == rhs);
+
+        public override int GetHashCode()
+            => _variant.GetHashCode();
+
+        public override string ToString()
+            => _variant.ValueString;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        public void Match(out int i)
+        {
+            if (!_variant.TryMatch(out i))
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+            }
+        }
+        /// <summary>
+        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+        public void Match(out global::System.IO.Stream stream)
+        {
+            if (!_variant.TryMatch(out stream))
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+        public bool TryMatch(out int i)
+            => _variant.TryMatch(out i);
+        /// <summary>
+        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+        /// </summary>
+        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
+        public bool TryMatch(out global::System.IO.Stream stream)
+            => _variant.TryMatch(out stream);
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<int> i)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                i(_value);
+                return true;
+            }
+            return false;
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                stream(_value);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        public void Match(global::System.Action<int> i)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                i(_value);
+            }
+            else
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+            }
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+        public void Match(global::System.Action<global::System.IO.Stream> stream)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                stream(_value);
+            }
+            else
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        public void Match(global::System.Action<int> i, global::System.Action _)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                i(_value);
+            }
+            else
+            {
+                _();
+            }
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
+        public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                stream(_value);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                return i(_value);
+            }
+            else
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+            }
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="stream"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                return stream(_value);
+            }
+            else
+            {
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                return i(_value);
+            }
+            else
+            {
+                return _;
+            }
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="stream"/>, or <paramref name="default"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                return stream(_value);
+            }
+            else
+            {
+                return _;
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+        {
+            if (_variant.TryMatch(out int _value))
+            {
+                return i(_value);
+            }
+            else
+            {
+                return _();
+            }
+        }
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+        {
+            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            {
+                return stream(_value);
+            }
+            else
+            {
+                return _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable,
+        /// and throw an exception if Variant_disposable is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+            => _variant.Visit(i, stream);
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable,
+        /// and invoke a special delegate if Variant_disposable is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+            => _variant.Visit(i, stream, _);
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable and return the result,
+        /// and throw an exception if Variant_disposable is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+            => _variant.Visit(i, stream);
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable and return the result,
+        /// and invoke a special delegate if Variant_disposable is empty and return its result.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+            => _variant.Visit(i, stream, _);
+    }
+}
+
+namespace Foo
+{
+    public static partial class _Variant_disposable_Ex
+    {
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<int, TResult> i)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out int value))
+                {
+                    yield return i(value);
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.IO.Stream"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<global::System.IO.Stream, TResult> stream)
+        {
+            foreach (var variant in source)
+            {
+                if (variant.TryMatch(out global::System.IO.Stream value))
+                {
+                    yield return stream(value);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<int, TResult> i,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.IO.Stream"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<global::System.IO.Stream, TResult> stream,
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(stream, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<int, TResult> i,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(i, _);
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="global::System.IO.Stream"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<global::System.IO.Stream, TResult> stream,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Match(stream, _);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_disposable.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, stream);
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream,
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                yield return variant.Visit(i, stream, _);
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -10,7 +10,8 @@ namespace Foo
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial struct Variant_struct_nullable_disable : global::System.IEquatable<Variant_struct_nullable_disable>
+    partial struct Variant_struct_nullable_disable
+        : global::System.IEquatable<Variant_struct_nullable_disable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly _VariantStorage _variant;
@@ -46,6 +47,7 @@ namespace Foo
                 _n = 3;
                 _x = new Union(o);
             }
+
 
             [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
             [global::System.Diagnostics.DebuggerNonUserCode]
@@ -358,6 +360,7 @@ namespace Foo
         /// <param name="o">The value to initlaize the variant with.</param>
         public static Variant_struct_nullable_disable Create(object o)
             => new Variant_struct_nullable_disable(o);
+
 
         /// <summary>
         /// <see langword="true"/> if Variant_struct_nullable_disable was constructed without a value.

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -10,7 +10,8 @@ namespace Foo
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial struct Variant_struct_nullable_enable : global::System.IEquatable<Variant_struct_nullable_enable>
+    partial struct Variant_struct_nullable_enable
+        : global::System.IEquatable<Variant_struct_nullable_enable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly _VariantStorage _variant;
@@ -46,6 +47,7 @@ namespace Foo
                 _n = 3;
                 _x = new Union(o);
             }
+
 
             [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
             [global::System.Diagnostics.DebuggerNonUserCode]
@@ -358,6 +360,7 @@ namespace Foo
         /// <param name="o">The value to initlaize the variant with.</param>
         public static Variant_struct_nullable_enable Create(object o)
             => new Variant_struct_nullable_enable(o);
+
 
         /// <summary>
         /// <see langword="true"/> if Variant_struct_nullable_enable was constructed without a value.

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -15,8 +15,6 @@ namespace dotVariant.Generator
         TypeDeclarationSyntax Syntax,
         ImmutableArray<IParameterSymbol> Options,
         NullableContext NullableContext
-        // TODO: disposable types
-        // TODO: nullability
         // TODO: emptiness possible?
         // TODO: user-defined constructors
         // TODO: user-defined ToString()

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -66,5 +66,21 @@ namespace dotVariant.Generator
 
         public static Accessibility EffectiveAccessibility(ITypeSymbol type)
             => type.DeclaredAccessibility;
+
+        public static bool ImplementsDispose(ITypeSymbol type, CSharpCompilation compilation)
+        {
+            var dispose =
+                FindMethod(
+                    compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(IDisposable)}")!,
+                    m => m.Name == nameof(IDisposable.Dispose));
+            return type.FindImplementationForInterfaceMember(dispose!) is not null;
+        }
+
+        public static bool IsDisposable(ITypeSymbol type, CSharpCompilation compilation)
+        {
+            var disposable = compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(IDisposable)}")!;
+            return SymbolEqualityComparer.Default.Equals(type, disposable)
+                || type.AllInterfaces.Contains(disposable, SymbolEqualityComparer.Default);
+        }
     }
 }

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -60,9 +60,9 @@ end
 
 # Conditionally apply a null-caolescing member access with trailing null-expression after the ??
 # Works with both "Params" and "Variant"
-func coalesce(type, expression, sub_expression, null_expression)
+func coalesce(type, expression, sub_expression, null_expression = null)
     if type.Nullability == "nullable"
-        ret expression + "?" + sub_expression + " ?? " + null_expression
+        ret expression + "?" + sub_expression + (null_expression != null ? (" ?? " + null_expression) : "")
     else
         ret expression + sub_expression
     end
@@ -111,6 +111,7 @@ method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : "
 param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
 global_nullable = emit_nullability ? "?" : ""
 global_forgive = emit_nullability ? "!" : ""
+needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
 
 readonly func_params
 readonly action_params
@@ -128,7 +129,11 @@ namespace {{ Variant.Namespace }}
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial {{ Variant.Keyword }} {{ Variant.Name }} : global::System.IEquatable<{{ Variant.Name }}>
+    partial {{ Variant.Keyword }} {{ Variant.Name }}
+        : global::System.IEquatable<{{ Variant.Name }}>
+        {{~ if needs_dispose ~}}
+        , global::System.IDisposable
+        {{~ end ~}}
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly _VariantStorage _variant;
@@ -146,6 +151,9 @@ namespace {{ Variant.Namespace }}
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         private readonly struct _VariantStorage
+        {{~ if needs_dispose ~}}
+            : global::System.IDisposable
+        {{~ end ~}}
         {
             private readonly int _n;
             private readonly Union _x;
@@ -266,6 +274,27 @@ namespace {{ Variant.Namespace }}
             {
                 _n = {{ $p.Index }};
                 _x = new Union({{ $p.Hint }});
+            }
+            {{~ end ~}}
+
+            {{~ if needs_dispose ~}}
+            public void Dispose()
+            {
+                switch (_n)
+                {
+                    case 0:
+                        break;
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        {{~ if $p.IsDisposable ~}}
+                        {{ coalesce $p ("_x._" + $p.Index + ".Value") ".Dispose()" }};
+                        {{~ end ~}}
+                        break;
+                    {{~ end ~}}
+                    default:
+                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
+
+                }
             }
             {{~ end ~}}
 
@@ -516,7 +545,7 @@ namespace {{ Variant.Namespace }}
         {{~ end ~}}
         {{~ end ~}}
 
-        {{~ # STATIC CREATE FACTORIES ## ~}}
+        {{~ ## STATIC CREATE FACTORIES ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
         /// Create a {{ Variant.Name }} with a value of type <see cref="{{ $p.Name }}"/>.
@@ -524,6 +553,15 @@ namespace {{ Variant.Namespace }}
         /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
         public static {{ Variant.Name }} Create({{ value_type $p }} {{ $p.Hint }})
             => new {{ Variant.Name }}({{ $p.Hint }});
+        {{~ end ~}}
+
+        {{~ ## DISPOSE ## ~}}
+        {{~ if needs_dispose && !Variant.UserDefined.Dispose }}
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _variant.Dispose();
+        }
         {{~ end ~}}
 
         {{~ ## VARIANT IsEmpty ## ~}}

--- a/src/dotVariant.Test/Helpers.cs
+++ b/src/dotVariant.Test/Helpers.cs
@@ -39,4 +39,18 @@ namespace dotVariant.Test
 #endif
         public override int GetHashCode() => throw new NotImplementedException();
     }
+
+    internal sealed class Disposable : Helper, IDisposable
+    {
+        public Disposable(Action f)
+        {
+            _f = f;
+        }
+        private readonly Action _f;
+
+        public void Dispose()
+        {
+            _f();
+        }
+    }
 }

--- a/src/dotVariant.Test/Variant+Dispose.cs
+++ b/src/dotVariant.Test/Variant+Dispose.cs
@@ -1,0 +1,25 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using dotVariant.Test.Variants;
+using NUnit.Framework;
+
+namespace dotVariant.Test
+{
+    public static partial class Variant_Test
+    {
+        public static class Dispose
+        {
+            [Test]
+            public static void If_active_member_is_disposable_its_Dispose_is_called()
+            {
+                var a = new DisposableVariant(new Disposable(() => Assert.Pass()));
+                a.Dispose();
+                Assert.Fail("Dispose() not called");
+            }
+        }
+    }
+}

--- a/src/dotVariant.Test/Variants.cs
+++ b/src/dotVariant.Test/Variants.cs
@@ -4,6 +4,9 @@
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 //
 
+using NUnit.Framework;
+using System;
+
 namespace dotVariant.Test.Variants
 {
     [Variant]
@@ -49,5 +52,46 @@ namespace dotVariant.Test.Variants
     internal sealed partial class Class_int
     {
         static partial void VariantOf(int i);
+    }
+
+    [Variant]
+    internal sealed partial class DisposableVariant
+    {
+        static partial void VariantOf(int i, Disposable d);
+    }
+
+    [Variant]
+    internal sealed partial class DisposableVariantWithImpl : IDisposable
+    {
+        static partial void VariantOf(int i, Disposable d);
+
+        public void Dispose()
+        {
+            _variant.Dispose();
+        }
+    }
+
+    public static class TypeLoadTest
+    {
+        [Test]
+        public static void Load()
+        {
+            Assert.That(
+                () => new object[]
+                {
+                    // Make sure we don't get any TypeLoadException
+                    new Class_int_float_string("s"),
+                    new Class_int_float_object(new Helper()),
+                    new Struct_int_float_object(new Helper()),
+                    new Class_with_default_ctor(),
+#if NULLABLE_ENABLED
+                    new Class_int_float_nullable(default(Helper?)),
+#endif
+                    new Class_int(1),
+                    new DisposableVariant(new Disposable(() => { })),
+                    new DisposableVariantWithImpl(new Disposable(() => { })),
+                },
+                Throws.Nothing);
+        }
     }
 }

--- a/src/dotVariant.Test/dotVariant.Test.projitems
+++ b/src/dotVariant.Test/dotVariant.Test.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Variant+Dispose.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+Equality.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+ToString.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Variant+IsEmpty.cs" />

--- a/src/dotVariant.Test/dotVariant.Test.props
+++ b/src/dotVariant.Test/dotVariant.Test.props
@@ -11,6 +11,7 @@
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="System.Interactive" Version="5.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
If any type in the VariantOf() parameter list implements IDisposable
make the variant itself IDIsposable and dispose the active member, if
the currently active member implements IDisposable.