### PR TITLE
Separate RenderInfo from Renderer and make it testable

### DIFF
--- a/src/dotVariant.Generator.Test/RenderInfo.Test.cs
+++ b/src/dotVariant.Generator.Test/RenderInfo.Test.cs
@@ -1,0 +1,561 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis.CSharp;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using static dotVariant.Generator.Test.GeneratorTools;
+
+namespace dotVariant.Generator.Test
+{
+    [TestOf(typeof(RenderInfo))]
+    [Parallelizable(ParallelScope.All)]
+    internal static class RenderInfo_Test
+    {
+        [TestCaseSource(nameof(VariantTestCases))]
+        public static void Variant(string source, Action<RenderInfo> check)
+        {
+            var ris = GetRenderInfoFromCompilation(source);
+            Assert.That(ris, Is.Not.Empty);
+            check(ris[0]);
+        }
+
+        [TestCaseSource(nameof(ParamsTestCases))]
+        public static void Params(string source, Action<RenderInfo> check)
+        {
+            var ris = GetRenderInfoFromCompilation(source);
+            Assert.That(ris, Is.Not.Empty);
+            check(ris[0]);
+        }
+
+        private static ImmutableArray<RenderInfo> GetRenderInfoFromCompilation(string source)
+        {
+            var compilation = Compile(SupportSources.Add("input", source));
+            var generator = new SourceGenerator();
+            var driver = CSharpGeneratorDriver.Create(generator);
+            _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out var _, out var _);
+            return generator.RenderInfos;
+        }
+
+        public static IEnumerable<TestCaseData> VariantTestCases()
+            => new (string Name, string Source, Action<RenderInfo> Check)[]
+                {
+                    ///////////////////////////////////////////////////////////
+                    // VariantInfo properties
+                    //
+                    (
+                        "type name",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class XyzVariant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.Name, Is.EqualTo("XyzVariant"))
+                    ),
+                    (
+                        "namespace name",
+                        @"
+                        namespace Foo.Bar
+                        {
+                            [dotVariant.Variant]
+                            public partial class XyzVariant
+                            {
+                                static partial void VariantOf(int a, float b);
+                            }
+                        }",
+                        ri => Assert.That(ri.Variant.Namespace, Is.EqualTo("Foo.Bar"))
+                    ),
+                    (
+                        "global namespace",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.Namespace, Is.Null)
+                    ),
+                    (
+                        "diagnostic name",
+                        @"
+                        namespace Foo.Bar
+                        {
+                            [dotVariant.Variant]
+                            public partial class Variant
+                            {
+                                static partial void VariantOf(int a, float b);
+                            }
+                        }",
+                        ri => Assert.That(ri.Variant.DiagName, Is.EqualTo("Foo.Bar.Variant"))
+                    ),
+                    (
+                        "class type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Variant.IsClass, Is.True);
+                            Assert.That(ri.Variant.Keyword, Is.EqualTo("class"));
+                        })
+                    ),
+                    (
+                        "struct type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial struct Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Variant.IsClass, Is.False);
+                            Assert.That(ri.Variant.Keyword, Is.EqualTo("struct"));
+                        })
+                    ),
+                    (
+                        "classes are nullable",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.Nullability, Is.EqualTo("nullable"))
+                    ),
+                    (
+                        "struct are nonnull",
+                        @"
+                        [dotVariant.Variant]
+                        public partial struct Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.Nullability, Is.EqualTo("nonnull"))
+                    ),
+                    (
+                        "non-readonly struct type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial struct Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.IsReadonly, Is.False)
+                    ),
+                    (
+                        "readonly struct type",
+                        @"
+                        [dotVariant.Variant]
+                        public readonly partial struct Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.IsReadonly, Is.True)
+                    ),
+                    (
+                        "public extensions methods",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.ExtensionsAccessibility, Is.EqualTo("public"))
+                    ),
+                    (
+                        "internal extensions methods",
+                        @"
+                        [dotVariant.Variant]
+                        internal partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.ExtensionsAccessibility, Is.EqualTo("internal"))
+                    ),
+                    (
+                        "Dispose: false",
+                        @"
+                        [dotVariant.Variant]
+                        internal partial class Variant
+                        {
+                            static partial void VariantOf(int a, System.IO.Stream b);
+                        }",
+                        ri => Assert.That(ri.Variant.UserDefined.Dispose, Is.False)
+                    ),
+                    (
+                        "Dispose: user-defined",
+                        @"
+                        [dotVariant.Variant]
+                        internal partial class Variant
+                        {
+                            static partial void VariantOf(int a, System.IO.Stream b);
+                            public void Dispose() {}
+                        }",
+                        ri => Assert.That(ri.Variant.UserDefined.Dispose, Is.True)
+                    ),
+                    (
+                        "Dispose: implementated explicitly",
+                        @"
+                        [dotVariant.Variant]
+                        internal partial class Variant : System.IDisposable
+                        {
+                            static partial void VariantOf(int a, System.IO.Stream b);
+                            void System.IDisposable.Dispose() {}
+                        }",
+                        ri => Assert.That(ri.Variant.UserDefined.Dispose, Is.True)
+                    ),
+                    (
+                        "Dispose: implementated",
+                        @"
+                        [dotVariant.Variant]
+                        internal partial class Variant : System.IDisposable
+                        {
+                            static partial void VariantOf(int a, System.IO.Stream b);
+                            public void Dispose() {}
+                        }",
+                        ri => Assert.That(ri.Variant.UserDefined.Dispose, Is.True)
+                    ),
+                    (
+                        "Dispose: implementated in base",
+                        @"
+                        class Base : System.IDisposable
+                        {
+                            public void Dispose() {}
+                        }
+                        [dotVariant.Variant]
+                        internal partial class Variant : Base
+                        {
+                            static partial void VariantOf(int a, System.IO.Stream b);
+                        }",
+                        ri => Assert.That(ri.Variant.UserDefined.Dispose, Is.True)
+                    ),
+                }
+                .Select(test => new TestCaseData(test.Source, test.Check).SetName($"{nameof(Variant)}({test.Name})"));
+
+        public static IEnumerable<TestCaseData> ParamsTestCases()
+            => new (string Name, string Source, Action<RenderInfo> Check)[]
+                {
+                    (
+                        "parametrs: 1",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params.Length, Is.EqualTo(1))
+                    ),
+                    (
+                        "parameters: 2",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, double b);
+                        }",
+                        ri => Assert.That(ri.Params.Length, Is.EqualTo(2))
+                    ),
+                    (
+                        "parameters: 3",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, double b, string c);
+                        }",
+                        ri => Assert.That(ri.Params.Length, Is.EqualTo(3))
+                    ),
+                    (
+                        "1-based index",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, double b, string c);
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Params[0].Index, Is.EqualTo(1));
+                            Assert.That(ri.Params[1].Index, Is.EqualTo(2));
+                            Assert.That(ri.Params[2].Index, Is.EqualTo(3));
+                        })
+                    ),
+                    (
+                        "hint",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int foobar);
+                        }",
+                        ri => Assert.That(ri.Params[0].Hint, Is.EqualTo("foobar"))
+                    ),
+                    (
+                        "fully qualified type name",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(System.TimeSpan a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Name, Is.EqualTo("global::System.TimeSpan"))
+                    ),
+                    (
+                        "shortened specila type name",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Name, Is.EqualTo("int"))
+                    ),
+                    (
+                        "diagnostic type name",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(System.TimeStamp a);
+                        }",
+                        ri => Assert.That(ri.Params[0].DiagName, Is.EqualTo("System.TimeStamp"))
+                    ),
+                    (
+                        "diagnostic special type name",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params[0].DiagName, Is.EqualTo("int"))
+                    ),
+                    (
+                        "class type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(string a);
+                        }",
+                        ri => Assert.That(ri.Params[0].IsClass, Is.True)
+                    ),
+                    (
+                        "struct type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(System.TimeSpan a, int b, System.AttributeTargets c);
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Params[0].IsClass, Is.False);
+                            Assert.That(ri.Params[1].IsClass, Is.False);
+                            Assert.That(ri.Params[2].IsClass, Is.False);
+                        })
+                    ),
+                    (
+                        "emit implicit cast",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params[0].EmitImplicitCast, Is.True)
+                    ),
+                    (
+                        "emit no implicit cast for base types",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(object a);
+                        }",
+                        ri => Assert.That(ri.Params[0].EmitImplicitCast, Is.False)
+                    ),
+                    (
+                        "emit no implicit cast for interfaces",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(System.IDisposable a);
+                        }",
+                        ri => Assert.That(ri.Params[0].EmitImplicitCast, Is.False)
+                    ),
+                    (
+                        "disposable: false",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(object a);
+                        }",
+                        ri => Assert.That(ri.Params[0].IsDisposable, Is.False)
+                    ),
+                    (
+                        "disposable: true",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(System.IO.Stream a);
+                        }",
+                        ri => Assert.That(ri.Params[0].IsDisposable, Is.True)
+                    ),
+                    (
+                        "nonnull value type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Nullability, Is.EqualTo("nonnull"))
+                    ),
+                    (
+                        "nullable value type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int? a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Nullability, Is.EqualTo("nullable"))
+                    ),
+                    (
+                        "nullable class type in nullable-disable context",
+                        @"
+                        #nullable disable
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(string a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Nullability, Is.EqualTo("nullable"))
+                    ),
+                    (
+                        "nullable class type in nullable-enable context",
+                        @"
+                        #nullable enable
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(string? a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Nullability, Is.EqualTo("nullable"))
+                    ),
+                    (
+                        "nonnull class type in nullable-enable context",
+                        @"
+                        #nullable enable
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(string a);
+                        }",
+                        ri => Assert.That(ri.Params[0].Nullability, Is.EqualTo("nonnull"))
+                    ),
+                    (
+                        "object padding",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(TwoObjects a, OneObject b, NoObjects c, OneNestedObject d, int e, string f, System.TimeSpan g);
+
+                            struct TwoObjects
+                            {
+                                public string a;
+                                public string b;
+                            }
+                            struct OneObject
+                            {
+                                public string a;
+                                public int b;
+                            }
+                            struct NoObjects
+                            {
+                                public int a;
+                                public int b;
+                            }
+                            struct OneNestedObject
+                            {
+                                struct OneObject
+                                {
+                                    public string a;
+                                }
+                                public OneObejct a;
+                                public int b;
+                            }
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Params[0].ObjectPadding, Is.EqualTo(0));
+                            Assert.That(ri.Params[1].ObjectPadding, Is.EqualTo(1));
+                            Assert.That(ri.Params[2].ObjectPadding, Is.EqualTo(2));
+                            Assert.That(ri.Params[3].ObjectPadding, Is.EqualTo(1));
+                            Assert.That(ri.Params[4].ObjectPadding, Is.EqualTo(2));
+                            Assert.That(ri.Params[5].ObjectPadding, Is.EqualTo(1));
+                            Assert.That(ri.Params[6].ObjectPadding, Is.EqualTo(2));
+                        })
+                    ),
+                    (
+                        "ToString returns nonull string for most class types",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(string a);
+                        }",
+                        ri => Assert.That(ri.Params[0].ToStringNullability, Is.EqualTo("nonnull"))
+                    ),
+                    (
+                        "ToString returns nullable string for some class types",
+                        @"
+                        #nullable enable
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(object a); // ToString() returns string?
+                        }",
+                        ri => Assert.That(ri.Params[0].ToStringNullability, Is.EqualTo("nullable"))
+                    ),
+                    (
+                        "ToString returns nonnull for struct types",
+                        @"
+                        #nullable enable
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a);
+                        }",
+                        ri => Assert.That(ri.Params[0].ToStringNullability, Is.EqualTo("nonnull"))
+                    ),
+                    (
+                        "ToString returns nullable for nullable value types",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int? a);
+                        }",
+                        ri => Assert.That(ri.Params[0].ToStringNullability, Is.EqualTo("nullable"))
+                    ),
+                }
+                .Select(test => new TestCaseData(test.Source, test.Check).SetName($"{nameof(Params)}({test.Name})"));
+    }
+}

--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -18,26 +18,12 @@ namespace dotVariant.Generator.Test
 {
     [TestOf(typeof(SourceGenerator))]
     [Parallelizable(ParallelScope.All)]
-    internal static class VariantSourceGenerator_Test
+    internal static class SourceGenerator_Test
     {
-        private static Dictionary<string, string>? _extraSources;
-
-        [OneTimeSetUp]
-        public static void LoadAttribute()
-        {
-            _extraSources = new()
-            {
-                { "VariantAttribute.cs", LoadSample("VariantAttribute.cs") },
-            };
-        }
-
         [TestCaseSource(nameof(TranslationCases))]
         public static void Translation(string typeName, string input, string expected)
         {
-            var sources = new Dictionary<string, string>(_extraSources!)
-            {
-                ["input"] = input
-            };
+            var sources = SupportSources.Add("input", input);
             var outputs = GetGeneratedOutput<SourceGenerator>(sources);
             var file =
                 Path.Combine(
@@ -96,10 +82,7 @@ namespace dotVariant.Generator.Test
         [TestCaseSource(nameof(DiagnosticsCases))]
         public static void Diagnostics(string input)
         {
-            var sources = new Dictionary<string, string>(_extraSources!)
-            {
-                ["input"] = input
-            };
+            var sources = SupportSources.Add("input", input);
             var expectations = ExtractExpectations(input);
             var diags =
                 GetGeneratorDiagnostics<SourceGenerator>(sources)

--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -10,19 +10,11 @@ using System.Collections.Immutable;
 
 namespace dotVariant.Generator
 {
-    internal sealed record Descriptor(
+    public sealed record Descriptor(
         ITypeSymbol Type,
         TypeDeclarationSyntax Syntax,
         ImmutableArray<IParameterSymbol> Options,
-        NullableContext NullableContext
-        // TODO: emptiness possible?
-        // TODO: user-defined constructors
-        // TODO: user-defined ToString()
-        // TODO: user-defined Equals()
-        // TODO: user-defined GetHashCode()
-        // TODO: user-defined Dispose()
-        // TODO: nested class
-        )
+        NullableContext NullableContext)
     {
         public static Descriptor FromDeclaration(
             ITypeSymbol type,

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -76,11 +76,29 @@ namespace dotVariant.Generator
             return type.FindImplementationForInterfaceMember(dispose!) is not null;
         }
 
+        public static bool HasAnyDisposeMethod(ITypeSymbol type)
+            => type
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Any(m => m.Name == nameof(IDisposable.Dispose));
+
         public static bool IsDisposable(ITypeSymbol type, CSharpCompilation compilation)
         {
             var disposable = compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(IDisposable)}")!;
             return SymbolEqualityComparer.Default.Equals(type, disposable)
                 || type.AllInterfaces.Contains(disposable, SymbolEqualityComparer.Default);
         }
+
+        public static int NumReferenceFields(IParameterSymbol param)
+            => NumReferenceFields(param.Type);
+
+        public static int NumReferenceFields(ITypeSymbol type)
+            => type.IsReferenceType
+                ? 1
+                : type
+                    .GetMembers()
+                    .OfType<IFieldSymbol>() // Inludes backing fields of auto-properties
+                    .Where(m => !m.IsStatic)
+                    .Sum(m => NumReferenceFields(m.Type));
     }
 }

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -1,0 +1,233 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using static dotVariant.Generator.Inspect;
+
+namespace dotVariant.Generator
+{
+    public sealed record RenderInfo(
+        RenderInfo.LanguageInfo Language,
+        RenderInfo.OptionsInfo Options,
+        ImmutableArray<RenderInfo.ParamInfo> Params,
+        RenderInfo.RuntimeInfo Runtime,
+        RenderInfo.VariantInfo Variant)
+    // TODO: emptiness possible?
+    // TODO: user-defined constructors
+    // TODO: user-defined ToString()
+    // TODO: user-defined Equals()
+    // TODO: user-defined GetHashCode()
+    // TODO: nested class
+    {
+        public sealed record LanguageInfo(
+            /// <summary>
+            /// Either <c>"enable"</c> or <c>"disable"</c>.
+            /// </summary>
+            string Nullable,
+            /// <summary>
+            /// Integer of the form ABB where A=major and BB=minor version of the language (i.e. 703 -> 7.3)
+            /// </summary>
+            int Version);
+
+        public sealed record OptionsInfo(
+            /// <summary>
+            /// The namespace in which to generate extension method implementations. If <see langword="null"/> use the global namespace.
+            /// </summary>
+            string? ExtensionClassNamespace);
+
+        public sealed record RuntimeInfo(
+            /// <summary>
+            /// <see langword="true"/> if <see cref="System.HashCode"/> is found.
+            /// </summary>
+            bool HasHashCode);
+
+        public sealed record VariantInfo(
+            /// <summary>
+            /// The fully qualified name of the type (without global:: alias, for diagnostic strings/messages)
+            /// </summary>
+            string DiagName,
+            /// <summary>
+            /// The accessibility to use for the class containing extension methods. <see langword="null"/> if extensions are impossible to define.
+            /// </summary>
+            string? ExtensionsAccessibility,
+            /// <summary>
+            /// The fully qualified name of the type.
+            /// </summary>
+            string FullName,
+            /// <summary>
+            /// <see langword="true"/> if this is an object type.
+            /// </summary>
+            bool IsClass,
+            /// <summary>
+            /// <see langword="true"/> if this type was declared with the <see langword="readonly"/> modifier.
+            /// </summary>
+            bool IsReadonly,
+            /// <summary>
+            /// The C# keyword used to define this type.
+            /// </summary>
+            string Keyword,
+            /// <summary>
+            /// Namespace of the variant type, or <see langword="null"/> if in the global namespace.
+            /// </summary>
+            string? Namespace,
+            /// <summary>
+            /// Name of the variant type within the context of its namespace.
+            /// </summary>
+            string Name,
+            /// <summary>
+            /// <c>"nonnull"</c> or <c>"nullable"</c>. For a class this determines if certain public methods need nullability annotations.
+            /// Always <c>"nonnull"</c> for a value type.
+            /// </summary>
+            string Nullability,
+            /// <summary>
+            /// Contains info about relevant members the user has defined.
+            /// </summary>
+            VariantInfo.UserDefinitions UserDefined)
+        {
+            public sealed record UserDefinitions(
+                /// <summary>
+                /// <see langword="true"/> if a user-defined <see cref="IDisposable.Dispose()"/> exists.
+                /// </summary>
+                bool Dispose);
+        }
+
+
+        public sealed record ParamInfo(
+            /// <summary>
+            /// A shorter type name (without global:: qualifier, for diagnostic strings/messages, may contain nullability annotation).
+            /// </summary>
+            string DiagName,
+            /// <summary>
+            /// <see langword="true"/> if the implicit cast from option to variant should be emitted for this type.
+            /// </summary>
+            bool EmitImplicitCast,
+            /// <summary>
+            /// The user-provided parameter name in <c>VariantOf</c>.
+            /// </summary>
+            string Hint,
+            /// <summary>
+            /// The 1-based index of the type within the variant.
+            /// </summary>
+            int Index,
+            /// <summary>
+            /// <see langword="true"/> if this is an object type (or generic with class constraint).
+            /// </summary>
+            bool IsClass,
+            /// <summary>
+            /// <see langword="true"/> if this type implements <see cref="IDisposable"/>.
+            /// </summary>
+            bool IsDisposable,
+            /// <summary>
+            /// The fully qualified name of the type. Never contains a nullability annotation.
+            /// </summary>
+            string Name,
+            /// <summary>
+            /// <c>"nonnull"</c> or <c>"nullable"</c>. For classes this determines whether the parameter was originally as nullable or null oblivious verses not nullable. For value types this determines whether it's a <see cref="Nullable{T}"/>.
+            /// </summary>
+            string Nullability,
+            /// <summary>
+            /// The number of <see langword="object"/> padding fields required for this type.
+            /// </summary>
+            int ObjectPadding,
+            /// <summary>
+            /// <c>"nonnull"</c> or <c>"nullable"</c> annotation of the parameters's <see cref="object.ToString()"/> return type.
+            /// </summary>
+            string ToStringNullability);
+
+        public static RenderInfo FromDescriptor(
+            Descriptor desc,
+            CSharpCompilation compilation,
+            AnalyzerConfigOptionsProvider options,
+            CancellationToken token)
+        {
+            var maxObjects = desc.Options.Max(NumReferenceFields);
+            var type = desc.Type;
+
+            var paramDescriptors =
+                desc
+                .Options
+                .Select((p, i) => new ParamInfo(
+                    Name: p.Type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    DiagName: p.Type.ToDisplayString(),
+                    Hint: p.Name,
+                    ObjectPadding: maxObjects - NumReferenceFields(p),
+                    Index: i + 1,
+                    IsClass: p.Type.IsReferenceType,
+                    IsDisposable: IsDisposable(p.Type, compilation),
+                    Nullability: p.Type.NullableAnnotation == NullableAnnotation.NotAnnotated ? "nonnull" : "nullable",
+                    EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type)),
+                    ToStringNullability: IsToStringNullable(p.Type) ? "nullable" : "nonnull"));
+
+            var typeNamespace = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
+
+            return new(
+                Language: new(
+                    Nullable: (desc.NullableContext & NullableContext.Enabled) != NullableContext.Disabled ? "enable" : "disable",
+                    Version: ConvertLanguageVersion(compilation.LanguageVersion)),
+                Options: new(
+                    ExtensionClassNamespace: ExtensionsNamespace(options, typeNamespace)),
+                Params: paramDescriptors.ToImmutableArray(),
+                Runtime: new(
+                    HasHashCode: compilation.GetTypeByMetadataName("System.HashCode") is not null),
+                Variant: new(
+                    DiagName: type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                    ExtensionsAccessibility: ExtensionsAccessibility(type),
+                    FullName: type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    IsClass: type.IsReferenceType,
+                    IsReadonly: IsReadonly(type, token),
+                    Keyword: desc.Syntax.Keyword.Text,
+                    Namespace: typeNamespace,
+                    Name: type.Name,
+                    Nullability: type.IsReferenceType ? "nullable" : "nonnull",
+                    UserDefined: new(
+                        // If the user defined any method named Dispose() bail out. Too risky!
+                        Dispose: ImplementsDispose(type, compilation) || HasAnyDisposeMethod(type))));
+        }
+
+        private static string? ExtensionsAccessibility(ITypeSymbol type)
+            => EffectiveAccessibility(type) switch
+            {
+                Accessibility.Internal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
+                Accessibility.NotApplicable => null,
+                Accessibility.Public => SyntaxFactory.Token(SyntaxKind.PublicKeyword).Text,
+                Accessibility.Private => null,
+                Accessibility.ProtectedAndInternal => null,
+                Accessibility.Protected => null,
+                Accessibility.ProtectedOrInternal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
+                _ => null,
+            };
+
+        private static int ConvertLanguageVersion(LanguageVersion v)
+        {
+            // Versions up to C# 7 have values 1..7
+            // 7.1 and higher have values 701..
+            // Pass the script a unified numbering scheme
+            return (int)v < 100 ? (int)v * 100 : (int)v;
+        }
+
+        private static bool IsToStringNullable(ITypeSymbol type)
+            => FindMethod(type, m => m.Name == "ToString" && m.Parameters.IsEmpty)?
+                .ReturnNullableAnnotation != NullableAnnotation.NotAnnotated;
+
+        private static string? ExtensionsNamespace(AnalyzerConfigOptionsProvider options, string? typeNamespace)
+        {
+            if (options.GlobalOptions.TryGetValue("build_property.dotVariant-ExtensionClassNamespace", out var property))
+            {
+                property = property.Trim('.');
+                return string.IsNullOrWhiteSpace(property) ? null : property;
+            }
+            else
+            {
+                return typeNamespace;
+            }
+        }
+    }
+}

--- a/src/dotVariant.Generator/Renderer.cs
+++ b/src/dotVariant.Generator/Renderer.cs
@@ -4,14 +4,10 @@
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 //
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Scriban;
 using Scriban.Runtime;
 using System;
-using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace dotVariant.Generator
@@ -26,10 +22,10 @@ namespace dotVariant.Generator
             return Template.Parse(new StreamReader(stream).ReadToEnd());
         });
 
-        public static string Render(GeneratorExecutionContext context, Descriptor type)
-            => Render(context, type, _template.Value);
+        public static string Render(RenderInfo info)
+            => Render(info, _template.Value);
 
-        public static string Render(GeneratorExecutionContext context, Descriptor type, Template template)
+        private static string Render(RenderInfo info, Template template)
         {
             var templateContext = new TemplateContext
             {
@@ -37,230 +33,9 @@ namespace dotVariant.Generator
                 StrictVariables = true,
             };
             var globals = new ScriptObject();
-            globals.Import(CreateRenderInfo(context, type), renamer: m => m.Name);
+            globals.Import(info, renamer: m => m.Name);
             templateContext.PushGlobal(globals);
             return template.Render(templateContext);
         }
-
-        private static RenderInfo CreateRenderInfo(GeneratorExecutionContext context, Descriptor desc)
-        {
-            var compilation = (CSharpCompilation)context.Compilation;
-            var maxObjects = desc.Options.Max(NumReferenceFields);
-            var type = desc.Type;
-
-            var paramDescriptors =
-                desc
-                .Options
-                .Select((p, i) => new ParamInfo(
-                    Name: p.Type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    DiagName: p.Type.ToDisplayString(),
-                    Hint: p.Name,
-                    ObjectPadding: maxObjects - NumReferenceFields(p),
-                    Index: i + 1,
-                    IsClass: p.Type.IsReferenceType,
-                    IsDisposable: Inspect.IsDisposable(p.Type, compilation),
-                    Nullability: p.Type.NullableAnnotation == NullableAnnotation.NotAnnotated ? "nonnull" : "nullable",
-                    EmitImplicitCast: !Inspect.IsAncestorOf(p.Type, desc.Type),
-                    ToStringNullability: ToStringNullability(p.Type)));
-
-            var ns = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
-
-            if (context.AnalyzerConfigOptions.GlobalOptions.TryGetValue(
-                "build_property.dotVariant-ExtensionClassNamespace", out var extensionClassNamespace))
-            {
-                extensionClassNamespace = extensionClassNamespace.Trim('.');
-                if (string.IsNullOrWhiteSpace(extensionClassNamespace))
-                {
-                    extensionClassNamespace = null;
-                }
-            }
-            else
-            {
-                extensionClassNamespace = ns;
-            }
-
-            return new(
-                Language: new(
-                    Nullable: (desc.NullableContext & NullableContext.Enabled) != NullableContext.Disabled ? "enable" : "disable",
-                    Version: ConvertLanguageVersion(compilation.LanguageVersion)),
-                Options: new(
-                    ExtensionClassNamespace: extensionClassNamespace),
-                Params: paramDescriptors.ToImmutableArray(),
-                Runtime: new(
-                    HasHashCode: compilation.GetTypeByMetadataName("System.HashCode") is not null),
-                Variant: new(
-                    DiagName: type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
-                    ExtensionsAccessibility: ExtensionsAccessibility(type),
-                    FullName: type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    IsClass: type.IsReferenceType,
-                    IsReadonly: Inspect.IsReadonly(type, context.CancellationToken),
-                    Keyword: desc.Syntax.Keyword.Text,
-                    Namespace: ns,
-                    Name: type.Name,
-                    Nullability: type.IsReferenceType ? "nullable" : "nonnull",
-                    UserDefined: new(
-                        Dispose: Inspect.ImplementsDispose(type, compilation))));
-        }
-
-        private static string? ExtensionsAccessibility(ITypeSymbol type)
-            => Inspect.EffectiveAccessibility(type) switch
-            {
-                Accessibility.Internal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
-                Accessibility.NotApplicable => null,
-                Accessibility.Public => SyntaxFactory.Token(SyntaxKind.PublicKeyword).Text,
-                Accessibility.Private => null,
-                Accessibility.ProtectedAndInternal => null,
-                Accessibility.Protected => null,
-                Accessibility.ProtectedOrInternal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
-                _ => null,
-            };
-
-        private static string ToStringNullability(ITypeSymbol type)
-        {
-            var method = Inspect.FindMethod(type, m => m.Name == "ToString" && m.Parameters.IsEmpty);
-            return method?.ReturnNullableAnnotation == NullableAnnotation.NotAnnotated ? "nonnull" : "nullable";
-        }
-
-        private static int ConvertLanguageVersion(LanguageVersion v)
-        {
-            // Versions up to C# 7 have values 1..7
-            // 7.1 and higher have values 701..
-            // Pass the script a unified numbering scheme
-            return (int)v < 100 ? (int)v * 100 : (int)v;
-        }
-
-        private static int NumReferenceFields(IParameterSymbol param)
-            => NumReferenceFields(param.Type);
-
-        private static int NumReferenceFields(ITypeSymbol type)
-            => type.IsReferenceType
-                ? 1
-                : type
-                    .GetMembers()
-                    .OfType<IFieldSymbol>() // Inludes backing fields of auto-properties
-                    .Where(m => !m.IsStatic)
-                    .Sum(m => NumReferenceFields(m.Type));
-
-        public sealed record RenderInfo(
-            LanguageInfo Language,
-            OptionsInfo Options,
-            ImmutableArray<ParamInfo> Params,
-            RuntimeInfo Runtime,
-            VariantInfo Variant);
-
-        public sealed record LanguageInfo(
-            /// <summary>
-            /// Either <c>"enable"</c> or <c>"disable"</c>.
-            /// </summary>
-            string Nullable,
-            /// <summary>
-            /// Integer of the form ABB where A=major and BB=minor version of the language (i.e. 703 -> 7.3)
-            /// </summary>
-            int Version);
-
-        public sealed record OptionsInfo(
-            /// <summary>
-            /// The namespace in which to generate extension method implementations. If <see langword="null"/> use the global namespace.
-            /// </summary>
-            string? ExtensionClassNamespace);
-
-        public sealed record RuntimeInfo(
-            /// <summary>
-            /// <see langword="true"/> if <see cref="System.HashCode"/> is found.
-            /// </summary>
-            bool HasHashCode);
-
-        public sealed record VariantInfo(
-            /// <summary>
-            /// The fully qualified name of the type (without global:: alias, for diagnostic strings/messages)
-            /// </summary>
-            string DiagName,
-            /// <summary>
-            /// The accessibility to use for the class containing extension methods. <see langword="null"/> if extensions are impossible to define.
-            /// </summary>
-            string? ExtensionsAccessibility,
-            /// <summary>
-            /// The fully qualified name of the type.
-            /// </summary>
-            string FullName,
-            /// <summary>
-            /// <see langword="true"/> if this is an object type.
-            /// </summary>
-            bool IsClass,
-            /// <summary>
-            /// <see langword="true"/> if this type was declared with the <see langword="readonly"/> modifier.
-            /// </summary>
-            bool IsReadonly,
-            /// <summary>
-            /// The C# keyword used to define this type.
-            /// </summary>
-            string Keyword,
-            /// <summary>
-            /// Namespace of the variant type, or <see langword="null"/> if in the global namespace.
-            /// </summary>
-            string? Namespace,
-            /// <summary>
-            /// Name of the variant type within the context of its namespace.
-            /// </summary>
-            string Name,
-            /// <summary>
-            /// <c>"nonnull"</c> or <c>"nullable"</c>. For a class this determines if certain public methods need nullability annotations.
-            /// Always <c>"nonnull"</c> for a value type.
-            /// </summary>
-            string Nullability,
-            /// <summary>
-            /// Contains info about relevant members the user has defined.
-            /// </summary>
-            VariantInfo.UserDefinitions UserDefined)
-        {
-            public sealed record UserDefinitions(
-                /// <summary>
-                /// <see langword="true"/> if a user-defined <see cref="IDisposable.Dispose()"/> exists.
-                /// </summary>
-                bool Dispose);
-        }
-
-
-        public sealed record ParamInfo(
-            /// <summary>
-            /// A shorter type name (without global:: qualifier, for diagnostic strings/messages, may contain nullability annotation).
-            /// </summary>
-            string DiagName,
-            /// <summary>
-            /// <see langword="true"/> if the implicit cast from option to variant should be emitted for this type.
-            /// </summary>
-            bool EmitImplicitCast,
-            /// <summary>
-            /// The user-provided parameter name in <c>VariantOf</c>.
-            /// </summary>
-            string Hint,
-            /// <summary>
-            /// The 1-based index of the type within the variant.
-            /// </summary>
-            int Index,
-            /// <summary>
-            /// <see langword="true"/> if this is an object type (or generic with class constraint).
-            /// </summary>
-            bool IsClass,
-            /// <summary>
-            /// <see langword="true"/> if this type implements <see cref="IDisposable"/>.
-            /// </summary>
-            bool IsDisposable,
-            /// <summary>
-            /// The fully qualified name of the type. Never contains a nullability annotation.
-            /// </summary>
-            string Name,
-            /// <summary>
-            /// <c>"nonnull"</c> or <c>"nullable"</c>. For classes this determines whether the parameter was originally as nullable or null oblivious verses not nullable. For value types this determines whether it's a <see cref="Nullable{T}"/>.
-            /// </summary>
-            string Nullability,
-            /// <summary>
-            /// The number of <see langword="object"/> padding fields required for this type.
-            /// </summary>
-            int ObjectPadding,
-            /// <summary>
-            /// <c>"nonnull"</c> or <c>"nullable"</c> annotation of the parameters's <see cref="object.ToString()"/> return type.
-            /// </summary>
-            string ToStringNullability);
     }
 }


### PR DESCRIPTION
This is the closest we get to unit testing the generator since all the
generated output hinges on the values of the RenderInfo members.