### PR TITLE
Refactor the generated code

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -14,320 +14,26 @@ namespace Foo
         : global::System.IEquatable<Variant_class_nullable_disable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object Value { get; }
-            public _VariantTypeProxy(Variant_class_nullable_disable v)
-            {
-                Value = v._variant.AsObject;
-                VariantOf(default, default, default);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-        {
-            private readonly int _n;
-            private readonly Union _x;
-
-            public _VariantStorage(int i)
-            {
-                _n = 1;
-                _x = new Union(i);
-            }
-            public _VariantStorage(float f)
-            {
-                _n = 2;
-                _x = new Union(f);
-            }
-            public _VariantStorage(string s)
-            {
-                _n = 3;
-                _x = new Union(s);
-            }
-
-
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union1 _1;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union2 _2;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union3 _3;
-
-                public Union(int value)
-                {
-                    _2 = default;
-                    _3 = default;
-                    _1 = new Union1(value);
-                }
-                public Union(float value)
-                {
-                    _1 = default;
-                    _3 = default;
-                    _2 = new Union2(value);
-                }
-                public Union(string value)
-                {
-                    _1 = default;
-                    _2 = default;
-                    _3 = new Union3(value);
-                }
-
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union1
-                {
-                    public readonly int Value;
-                    public readonly object _dummy1;
-
-                    public Union1(int value)
-                    {
-                        _dummy1 = null;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union2
-                {
-                    public readonly float Value;
-                    public readonly object _dummy1;
-
-                    public Union2(float value)
-                    {
-                        _dummy1 = null;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union3
-                {
-                    public readonly string Value;
-
-                    public Union3(string value)
-                    {
-                        Value = value;
-                    }
-                }
-            }
-
-            public bool IsEmpty => _n == 0;
-
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        case 1:
-                            return "int";
-                        case 2:
-                            return "float";
-                        case 3:
-                            return "string";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        case 1:
-                            return _x._1.Value.ToString();
-                        case 2:
-                            return _x._2.Value.ToString();
-                        case 3:
-                            return _x._3.Value?.ToString() ?? "null";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public object AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        case 1:
-                            return _x._1.Value;
-                        case 2:
-                            return _x._2.Value;
-                        case 3:
-                            return _x._3.Value;
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    case 1:
-                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                    case 2:
-                        return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
-                    case 3:
-                        return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        case 1:
-                            return global::System.HashCode.Combine(_x._1.Value);
-                        case 2:
-                            return global::System.HashCode.Combine(_x._2.Value);
-                        case 3:
-                            return global::System.HashCode.Combine(_x._3.Value);
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool TryMatch(out int i)
-            {
-                i = _n == 1 ? _x._1.Value : default;
-                return _n == 1;
-            }
-            public bool TryMatch(out float f)
-            {
-                f = _n == 2 ? _x._2.Value : default;
-                return _n == 2;
-            }
-            public bool TryMatch(out string s)
-            {
-                s = _n == 3 ? _x._3.Value : default;
-                return _n == 3;
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        f(_x._2.Value);
-                        break;
-                    case 3:
-                        s(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        f(_x._2.Value);
-                        break;
-                    case 3:
-                        s(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return f(_x._2.Value);
-                    case 3:
-                        return s(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return f(_x._2.Value);
-                    case 3:
-                        return s(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is in a corrupted state.");
-                }
-            }
-        }
+        private readonly global::dotVariant._G.Foo.Variant_class_nullable_disable _variant;
 
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
         public Variant_class_nullable_disable(int i)
-            => _variant = new _VariantStorage(i);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(i);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
         public Variant_class_nullable_disable(float f)
-            => _variant = new _VariantStorage(f);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(f);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
         public Variant_class_nullable_disable(string s)
-            => _variant = new _VariantStorage(s);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(s);
 
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="int"/>.
@@ -400,7 +106,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (!_variant.TryMatch(out i))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'int', actual '{_variant.TypeString}').");
             }
@@ -413,7 +123,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
         public void Match(out float f)
         {
-            if (!_variant.TryMatch(out f))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            {
+                f = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'float', actual '{_variant.TypeString}').");
             }
@@ -426,7 +140,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
         public void Match(out string s)
         {
-            if (!_variant.TryMatch(out s))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            {
+                s = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'string', actual '{_variant.TypeString}').");
             }
@@ -438,21 +156,54 @@ namespace Foo
         /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
-            => _variant.TryMatch(out i);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value;
+                return true;
+            }
+            else
+            {
+                i = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch(out float f)
-            => _variant.TryMatch(out f);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            {
+                f = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value;
+                return true;
+            }
+            else
+            {
+                f = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch(out string s)
-            => _variant.TryMatch(out s);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            {
+                s = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value;
+                return true;
+            }
+            else
+            {
+                s = default;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>.
@@ -462,12 +213,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
@@ -477,12 +231,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<float> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
@@ -492,12 +249,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<string> s)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                s(_value);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -509,9 +269,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -527,9 +287,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public void Match(global::System.Action<float> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -545,9 +305,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public void Match(global::System.Action<string> s)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                s(_value);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -564,9 +324,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -582,9 +342,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<float> f, global::System.Action _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -600,9 +360,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                s(_value);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -620,9 +380,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -639,9 +399,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -658,9 +418,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                return s(_value);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -678,9 +438,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -697,9 +457,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -716,9 +476,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                return s(_value);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -735,9 +495,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -753,9 +513,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -771,9 +531,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out string _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
             {
-                return s(_value);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -791,7 +551,24 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
-            => _variant.Visit(i, f, s);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    break;
+                case 2:
+                    f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    break;
+                case 3:
+                    s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable,
@@ -803,7 +580,25 @@ namespace Foo
         /// <param name="_">The delegate to invoke if Variant_class_nullable_disable is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
-            => _variant.Visit(i, f, s, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    break;
+                case 2:
+                    f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    break;
+                case 3:
+                    s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_disable and return the result,
@@ -816,7 +611,21 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
-            => _variant.Visit(i, f, s);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                case 2:
+                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                case 3:
+                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable and return the result,
@@ -829,9 +638,337 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-            => _variant.Visit(i, f, s, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                case 2:
+                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                case 3:
+                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object Value { get; }
+            public _VariantTypeProxy(Variant_class_nullable_disable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default, default);
+            }
+        }
+
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_N(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_1(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_2(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_2)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_3(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_3)v._variant;
     }
 }
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_disable
+    {
+        private readonly Variant_class_nullable_disable_Union _x;
+        private readonly uint _n;
+
+        public Variant_class_nullable_disable(int i)
+        {
+            _n = 1;
+            _x = new Variant_class_nullable_disable_Union(i);
+        }
+        public Variant_class_nullable_disable(float f)
+        {
+            _n = 2;
+            _x = new Variant_class_nullable_disable_Union(f);
+        }
+        public Variant_class_nullable_disable(string s)
+        {
+            _n = 3;
+            _x = new Variant_class_nullable_disable_Union(s);
+        }
+
+
+        public static explicit operator Variant_class_nullable_disable_N(Variant_class_nullable_disable v) => new Variant_class_nullable_disable_N(v._n);
+        public static explicit operator Variant_class_nullable_disable_1(Variant_class_nullable_disable v) => v._x._1;
+        public static explicit operator Variant_class_nullable_disable_2(Variant_class_nullable_disable v) => v._x._2;
+        public static explicit operator Variant_class_nullable_disable_3(Variant_class_nullable_disable v) => v._x._3;
+
+        public bool IsEmpty => _n == 0;
+
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "int";
+                    case 2:
+                        return "float";
+                    case 3:
+                        return "string";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    case 1:
+                        return _x._1.Value.ToString();
+                    case 2:
+                        return _x._2.Value.ToString();
+                    case 3:
+                        return _x._3.Value?.ToString() ?? "null";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public object AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1.Value;
+                    case 2:
+                        return _x._2.Value;
+                    case 3:
+                        return _x._3.Value;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_class_nullable_disable other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
+                case 3:
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    case 1:
+                        return global::System.HashCode.Combine(_x._1.Value);
+                    case 2:
+                        return global::System.HashCode.Combine(_x._2.Value);
+                    case 3:
+                        return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool TryMatch(out int i)
+        {
+            i = _n == 1 ? _x._1.Value : default;
+            return _n == 1;
+        }
+        public bool TryMatch(out float f)
+        {
+            f = _n == 2 ? _x._2.Value : default;
+            return _n == 2;
+        }
+        public bool TryMatch(out string s)
+        {
+            s = _n == 3 ? _x._3.Value : default;
+            return _n == 3;
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    f(_x._2.Value);
+                    break;
+                case 3:
+                    s(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    f(_x._2.Value);
+                    break;
+                case 3:
+                    s(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return f(_x._2.Value);
+                case 3:
+                    return s(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return f(_x._2.Value);
+                case 3:
+                    return s(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+    }
+
+    internal readonly ref struct Variant_class_nullable_disable_N
+    {
+        public readonly uint N;
+        public Variant_class_nullable_disable_N(uint n) => N = n;
+    }
+
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_disable_Union
+    {
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_disable_1 _1;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_disable_2 _2;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_disable_3 _3;
+
+        public Variant_class_nullable_disable_Union(int value)
+        {
+            _2 = default;
+            _3 = default;
+            _1 = new Variant_class_nullable_disable_1(value);
+        }
+        public Variant_class_nullable_disable_Union(float value)
+        {
+            _1 = default;
+            _3 = default;
+            _2 = new Variant_class_nullable_disable_2(value);
+        }
+        public Variant_class_nullable_disable_Union(string value)
+        {
+            _1 = default;
+            _2 = default;
+            _3 = new Variant_class_nullable_disable_3(value);
+        }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_disable_1
+    {
+        public readonly int Value;
+        public readonly object _dummy1;
+
+        public Variant_class_nullable_disable_1(int value)
+        {
+            _dummy1 = null;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_disable_2
+    {
+        public readonly float Value;
+        public readonly object _dummy1;
+
+        public Variant_class_nullable_disable_2(float value)
+        {
+            _dummy1 = null;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_disable_3
+    {
+        public readonly string Value;
+
+        public Variant_class_nullable_disable_3(string value)
+        {
+            Value = value;
+        }
+    }
+}
+
 
 namespace Foo
 {
@@ -853,9 +990,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out int value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
                 {
-                    yield return i(value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
                 }
             }
         }
@@ -875,9 +1012,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out float value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
                 {
-                    yield return f(value);
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
                 }
             }
         }
@@ -897,9 +1034,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out string value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
                 {
-                    yield return s(value);
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
                 }
             }
         }
@@ -922,7 +1059,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -943,7 +1087,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(f, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
+                {
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -964,7 +1115,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(s, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
+                {
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
 
@@ -986,7 +1144,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1007,7 +1172,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(f, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
+                {
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1028,7 +1200,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(s, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
+                {
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
 
@@ -1052,7 +1231,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, f, s);
+                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
 
@@ -1076,7 +1270,23 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, f, s, _);
+                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
     }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -14,378 +14,32 @@ namespace Foo
         : global::System.IEquatable<Variant_class_nullable_enable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object? Value { get; }
-            public _VariantTypeProxy(Variant_class_nullable_enable v)
-            {
-                Value = v._variant.AsObject;
-                VariantOf(default, default, default!, default);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-        {
-            private readonly int _n;
-            private readonly Union _x;
-
-            public _VariantStorage(int i)
-            {
-                _n = 1;
-                _x = new Union(i);
-            }
-            public _VariantStorage(float f)
-            {
-                _n = 2;
-                _x = new Union(f);
-            }
-            public _VariantStorage(string s)
-            {
-                _n = 3;
-                _x = new Union(s);
-            }
-            public _VariantStorage(global::System.Array? a)
-            {
-                _n = 4;
-                _x = new Union(a);
-            }
-
-
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union1 _1;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union2 _2;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union3 _3;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union4 _4;
-
-                public Union(int value)
-                {
-                    _2 = default;
-                    _3 = default;
-                    _4 = default;
-                    _1 = new Union1(value);
-                }
-                public Union(float value)
-                {
-                    _1 = default;
-                    _3 = default;
-                    _4 = default;
-                    _2 = new Union2(value);
-                }
-                public Union(string value)
-                {
-                    _1 = default;
-                    _2 = default;
-                    _4 = default;
-                    _3 = new Union3(value);
-                }
-                public Union(global::System.Array? value)
-                {
-                    _1 = default;
-                    _2 = default;
-                    _3 = default;
-                    _4 = new Union4(value);
-                }
-
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union1
-                {
-                    public readonly int Value;
-                    public readonly object _dummy1;
-
-                    public Union1(int value)
-                    {
-                        _dummy1 = null!;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union2
-                {
-                    public readonly float Value;
-                    public readonly object _dummy1;
-
-                    public Union2(float value)
-                    {
-                        _dummy1 = null!;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union3
-                {
-                    public readonly string Value;
-
-                    public Union3(string value)
-                    {
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union4
-                {
-                    public readonly global::System.Array? Value;
-
-                    public Union4(global::System.Array? value)
-                    {
-                        Value = value;
-                    }
-                }
-            }
-
-            public bool IsEmpty => _n == 0;
-
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        case 1:
-                            return "int";
-                        case 2:
-                            return "float";
-                        case 3:
-                            return "string";
-                        case 4:
-                            return "System.Array?";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        case 1:
-                            return _x._1.Value.ToString();
-                        case 2:
-                            return _x._2.Value.ToString();
-                        case 3:
-                            return _x._3.Value.ToString();
-                        case 4:
-                            return _x._4.Value?.ToString() ?? "null";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public object? AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        case 1:
-                            return _x._1.Value;
-                        case 2:
-                            return _x._2.Value;
-                        case 3:
-                            return _x._3.Value;
-                        case 4:
-                            return _x._4.Value;
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    case 1:
-                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                    case 2:
-                        return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
-                    case 3:
-                        return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
-                    case 4:
-                        return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        case 1:
-                            return global::System.HashCode.Combine(_x._1.Value);
-                        case 2:
-                            return global::System.HashCode.Combine(_x._2.Value);
-                        case 3:
-                            return global::System.HashCode.Combine(_x._3.Value);
-                        case 4:
-                            return global::System.HashCode.Combine(_x._4.Value);
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool TryMatch(out int i)
-            {
-                i = _n == 1 ? _x._1.Value : default;
-                return _n == 1;
-            }
-            public bool TryMatch(out float f)
-            {
-                f = _n == 2 ? _x._2.Value : default;
-                return _n == 2;
-            }
-            public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
-            {
-                s = _n == 3 ? _x._3.Value : default;
-                return _n == 3;
-            }
-            public bool TryMatch(out global::System.Array? a)
-            {
-                a = _n == 4 ? _x._4.Value : default;
-                return _n == 4;
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        f(_x._2.Value);
-                        break;
-                    case 3:
-                        s(_x._3.Value);
-                        break;
-                    case 4:
-                        a(_x._4.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        f(_x._2.Value);
-                        break;
-                    case 3:
-                        s(_x._3.Value);
-                        break;
-                    case 4:
-                        a(_x._4.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return f(_x._2.Value);
-                    case 3:
-                        return s(_x._3.Value);
-                    case 4:
-                        return a(_x._4.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return f(_x._2.Value);
-                    case 3:
-                        return s(_x._3.Value);
-                    case 4:
-                        return a(_x._4.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is in a corrupted state.");
-                }
-            }
-        }
+        private readonly global::dotVariant._G.Foo.Variant_class_nullable_enable _variant;
 
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
         public Variant_class_nullable_enable(int i)
-            => _variant = new _VariantStorage(i);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(i);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
         public Variant_class_nullable_enable(float f)
-            => _variant = new _VariantStorage(f);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(f);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
         public Variant_class_nullable_enable(string s)
-            => _variant = new _VariantStorage(s);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(s);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
         public Variant_class_nullable_enable(global::System.Array? a)
-            => _variant = new _VariantStorage(a);
+            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(a);
 
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="int"/>.
@@ -470,7 +124,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (!_variant.TryMatch(out i))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'int', actual '{_variant.TypeString}').");
             }
@@ -483,7 +141,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
         public void Match(out float f)
         {
-            if (!_variant.TryMatch(out f))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            {
+                f = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'float', actual '{_variant.TypeString}').");
             }
@@ -496,7 +158,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
         public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out string? s)
         {
-            if (!_variant.TryMatch(out s!))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            {
+                s = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'string', actual '{_variant.TypeString}').");
             }
@@ -509,7 +175,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
         public void Match(out global::System.Array? a)
         {
-            if (!_variant.TryMatch(out a))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            {
+                a = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'System.Array?', actual '{_variant.TypeString}').");
             }
@@ -521,28 +191,72 @@ namespace Foo
         /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
-            => _variant.TryMatch(out i);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value;
+                return true;
+            }
+            else
+            {
+                i = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch(out float f)
-            => _variant.TryMatch(out f);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            {
+                f = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value;
+                return true;
+            }
+            else
+            {
+                f = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
-            => _variant.TryMatch(out s);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            {
+                s = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value;
+                return true;
+            }
+            else
+            {
+                s = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
         /// </summary>
         /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
         public bool TryMatch(out global::System.Array? a)
-            => _variant.TryMatch(out a);
+        {
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            {
+                a = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value;
+                return true;
+            }
+            else
+            {
+                a = default;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>.
@@ -552,12 +266,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
@@ -567,12 +284,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<float> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
@@ -582,12 +302,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<string> s)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                s(_value!);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
@@ -597,12 +320,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<global::System.Array?> a)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                a(_value);
+                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -614,9 +340,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -632,9 +358,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public void Match(global::System.Action<float> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -650,9 +376,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public void Match(global::System.Action<string> s)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                s(_value!);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -668,9 +394,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.Array?> a)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                a(_value);
+                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
             }
             else
             {
@@ -687,9 +413,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -705,9 +431,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<float> f, global::System.Action _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                f(_value);
+                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -723,9 +449,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                s(_value!);
+                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -741,9 +467,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                a(_value);
+                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
             }
             else
             {
@@ -761,9 +487,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -780,9 +506,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -799,9 +525,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                return s(_value!);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -818,9 +544,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                return a(_value);
+                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
             }
             else
             {
@@ -838,9 +564,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -857,9 +583,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -876,9 +602,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                return s(_value!);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -895,9 +621,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                return a(_value);
+                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
             }
             else
             {
@@ -914,9 +640,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -932,9 +658,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out float _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
             {
-                return f(_value);
+                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -950,9 +676,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out string? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
             {
-                return s(_value!);
+                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -968,9 +694,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out global::System.Array? _value))
+            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
             {
-                return a(_value);
+                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
             }
             else
             {
@@ -989,7 +715,27 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
-            => _variant.Visit(i, f, s, a);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    break;
+                case 2:
+                    f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    break;
+                case 3:
+                    s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    break;
+                case 4:
+                    a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable,
@@ -1002,7 +748,28 @@ namespace Foo
         /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
-            => _variant.Visit(i, f, s, a, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    break;
+                case 2:
+                    f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    break;
+                case 3:
+                    s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    break;
+                case 4:
+                    a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_enable and return the result,
@@ -1016,7 +783,23 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
-            => _variant.Visit(i, f, s, a);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                case 2:
+                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                case 3:
+                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                case 4:
+                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable and return the result,
@@ -1030,9 +813,393 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
-            => _variant.Visit(i, f, s, a, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                case 2:
+                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                case 3:
+                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                case 4:
+                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object? Value { get; }
+            public _VariantTypeProxy(Variant_class_nullable_enable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default, default!, default);
+            }
+        }
+
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_N(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_1(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_2(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_2)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_3(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_3)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_4(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_4)v._variant;
     }
 }
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable
+    {
+        private readonly Variant_class_nullable_enable_Union _x;
+        private readonly uint _n;
+
+        public Variant_class_nullable_enable(int i)
+        {
+            _n = 1;
+            _x = new Variant_class_nullable_enable_Union(i);
+        }
+        public Variant_class_nullable_enable(float f)
+        {
+            _n = 2;
+            _x = new Variant_class_nullable_enable_Union(f);
+        }
+        public Variant_class_nullable_enable(string s)
+        {
+            _n = 3;
+            _x = new Variant_class_nullable_enable_Union(s);
+        }
+        public Variant_class_nullable_enable(global::System.Array? a)
+        {
+            _n = 4;
+            _x = new Variant_class_nullable_enable_Union(a);
+        }
+
+
+        public static explicit operator Variant_class_nullable_enable_N(Variant_class_nullable_enable v) => new Variant_class_nullable_enable_N(v._n);
+        public static explicit operator Variant_class_nullable_enable_1(Variant_class_nullable_enable v) => v._x._1;
+        public static explicit operator Variant_class_nullable_enable_2(Variant_class_nullable_enable v) => v._x._2;
+        public static explicit operator Variant_class_nullable_enable_3(Variant_class_nullable_enable v) => v._x._3;
+        public static explicit operator Variant_class_nullable_enable_4(Variant_class_nullable_enable v) => v._x._4;
+
+        public bool IsEmpty => _n == 0;
+
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "int";
+                    case 2:
+                        return "float";
+                    case 3:
+                        return "string";
+                    case 4:
+                        return "System.Array?";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    case 1:
+                        return _x._1.Value.ToString();
+                    case 2:
+                        return _x._2.Value.ToString();
+                    case 3:
+                        return _x._3.Value.ToString();
+                    case 4:
+                        return _x._4.Value?.ToString() ?? "null";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public object? AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1.Value;
+                    case 2:
+                        return _x._2.Value;
+                    case 3:
+                        return _x._3.Value;
+                    case 4:
+                        return _x._4.Value;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_class_nullable_enable other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
+                case 3:
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
+                case 4:
+                    return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    case 1:
+                        return global::System.HashCode.Combine(_x._1.Value);
+                    case 2:
+                        return global::System.HashCode.Combine(_x._2.Value);
+                    case 3:
+                        return global::System.HashCode.Combine(_x._3.Value);
+                    case 4:
+                        return global::System.HashCode.Combine(_x._4.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool TryMatch(out int i)
+        {
+            i = _n == 1 ? _x._1.Value : default;
+            return _n == 1;
+        }
+        public bool TryMatch(out float f)
+        {
+            f = _n == 2 ? _x._2.Value : default;
+            return _n == 2;
+        }
+        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
+        {
+            s = _n == 3 ? _x._3.Value : default;
+            return _n == 3;
+        }
+        public bool TryMatch(out global::System.Array? a)
+        {
+            a = _n == 4 ? _x._4.Value : default;
+            return _n == 4;
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    f(_x._2.Value);
+                    break;
+                case 3:
+                    s(_x._3.Value);
+                    break;
+                case 4:
+                    a(_x._4.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    f(_x._2.Value);
+                    break;
+                case 3:
+                    s(_x._3.Value);
+                    break;
+                case 4:
+                    a(_x._4.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return f(_x._2.Value);
+                case 3:
+                    return s(_x._3.Value);
+                case 4:
+                    return a(_x._4.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return f(_x._2.Value);
+                case 3:
+                    return s(_x._3.Value);
+                case 4:
+                    return a(_x._4.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+    }
+
+    internal readonly ref struct Variant_class_nullable_enable_N
+    {
+        public readonly uint N;
+        public Variant_class_nullable_enable_N(uint n) => N = n;
+    }
+
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable_Union
+    {
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_enable_1 _1;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_enable_2 _2;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_enable_3 _3;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_class_nullable_enable_4 _4;
+
+        public Variant_class_nullable_enable_Union(int value)
+        {
+            _2 = default;
+            _3 = default;
+            _4 = default;
+            _1 = new Variant_class_nullable_enable_1(value);
+        }
+        public Variant_class_nullable_enable_Union(float value)
+        {
+            _1 = default;
+            _3 = default;
+            _4 = default;
+            _2 = new Variant_class_nullable_enable_2(value);
+        }
+        public Variant_class_nullable_enable_Union(string value)
+        {
+            _1 = default;
+            _2 = default;
+            _4 = default;
+            _3 = new Variant_class_nullable_enable_3(value);
+        }
+        public Variant_class_nullable_enable_Union(global::System.Array? value)
+        {
+            _1 = default;
+            _2 = default;
+            _3 = default;
+            _4 = new Variant_class_nullable_enable_4(value);
+        }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable_1
+    {
+        public readonly int Value;
+        public readonly object _dummy1;
+
+        public Variant_class_nullable_enable_1(int value)
+        {
+            _dummy1 = null!;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable_2
+    {
+        public readonly float Value;
+        public readonly object _dummy1;
+
+        public Variant_class_nullable_enable_2(float value)
+        {
+            _dummy1 = null!;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable_3
+    {
+        public readonly string Value;
+
+        public Variant_class_nullable_enable_3(string value)
+        {
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_class_nullable_enable_4
+    {
+        public readonly global::System.Array? Value;
+
+        public Variant_class_nullable_enable_4(global::System.Array? value)
+        {
+            Value = value;
+        }
+    }
+}
+
 
 namespace Foo
 {
@@ -1054,9 +1221,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out int value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
                 {
-                    yield return i(value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
                 }
             }
         }
@@ -1076,9 +1243,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out float value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
                 {
-                    yield return f(value);
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
                 }
             }
         }
@@ -1098,9 +1265,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out string? value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
                 {
-                    yield return s(value);
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
                 }
             }
         }
@@ -1120,9 +1287,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out global::System.Array? value))
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
                 {
-                    yield return a(value);
+                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
                 }
             }
         }
@@ -1145,7 +1312,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -1166,7 +1340,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(f, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
+                {
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -1187,7 +1368,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(s, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
+                {
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -1208,7 +1396,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(a, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
+                {
+                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
 
@@ -1230,7 +1425,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1251,7 +1453,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(f, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
+                {
+                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1272,7 +1481,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(s, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
+                {
+                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1293,7 +1509,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(a, _);
+                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
+                {
+                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
 
@@ -1318,7 +1541,25 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, f, s, a);
+                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                        break;
+                    case 4:
+                        yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
 
@@ -1343,7 +1584,26 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, f, s, a, _);
+                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                        break;
+                    case 4:
+                        yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
     }

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -15,279 +15,20 @@ namespace Foo
         , global::System.IDisposable
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object Value { get; }
-            public _VariantTypeProxy(Variant_disposable v)
-            {
-                Value = v._variant.AsObject;
-                VariantOf(default, default);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-            : global::System.IDisposable
-        {
-            private readonly int _n;
-            private readonly Union _x;
-
-            public _VariantStorage(int i)
-            {
-                _n = 1;
-                _x = new Union(i);
-            }
-            public _VariantStorage(global::System.IO.Stream stream)
-            {
-                _n = 2;
-                _x = new Union(stream);
-            }
-
-            public void Dispose()
-            {
-                switch (_n)
-                {
-                    case 0:
-                        break;
-                    case 1:
-                        break;
-                    case 2:
-                        _x._2.Value?.Dispose();
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-
-                }
-            }
-
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union1 _1;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union2 _2;
-
-                public Union(int value)
-                {
-                    _2 = default;
-                    _1 = new Union1(value);
-                }
-                public Union(global::System.IO.Stream value)
-                {
-                    _1 = default;
-                    _2 = new Union2(value);
-                }
-
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union1
-                {
-                    public readonly int Value;
-                    public readonly object _dummy1;
-
-                    public Union1(int value)
-                    {
-                        _dummy1 = null;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union2
-                {
-                    public readonly global::System.IO.Stream Value;
-
-                    public Union2(global::System.IO.Stream value)
-                    {
-                        Value = value;
-                    }
-                }
-            }
-
-            public bool IsEmpty => _n == 0;
-
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        case 1:
-                            return "int";
-                        case 2:
-                            return "System.IO.Stream";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        case 1:
-                            return _x._1.Value.ToString();
-                        case 2:
-                            return _x._2.Value?.ToString() ?? "null";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public object AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        case 1:
-                            return _x._1.Value;
-                        case 2:
-                            return _x._2.Value;
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    case 1:
-                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                    case 2:
-                        return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                }
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        case 1:
-                            return global::System.HashCode.Combine(_x._1.Value);
-                        case 2:
-                            return global::System.HashCode.Combine(_x._2.Value);
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool TryMatch(out int i)
-            {
-                i = _n == 1 ? _x._1.Value : default;
-                return _n == 1;
-            }
-            public bool TryMatch(out global::System.IO.Stream stream)
-            {
-                stream = _n == 2 ? _x._2.Value : default;
-                return _n == 2;
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        stream(_x._2.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                }
-            }
-
-            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
-                    case 1:
-                        i(_x._1.Value);
-                        break;
-                    case 2:
-                        stream(_x._2.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return stream(_x._2.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
-                    case 1:
-                        return i(_x._1.Value);
-                    case 2:
-                        return stream(_x._2.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable is in a corrupted state.");
-                }
-            }
-        }
+        private readonly global::dotVariant._G.Foo.Variant_disposable _variant;
 
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
         public Variant_disposable(int i)
-            => _variant = new _VariantStorage(i);
+            => _variant = new global::dotVariant._G.Foo.Variant_disposable(i);
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
         /// </summary>
         /// <param name="stream">The value to initlaize the variant with.</param>
         public Variant_disposable(global::System.IO.Stream stream)
-            => _variant = new _VariantStorage(stream);
+            => _variant = new global::dotVariant._G.Foo.Variant_disposable(stream);
 
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="int"/>.
@@ -354,7 +95,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (!_variant.TryMatch(out i))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
             }
@@ -367,7 +112,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
         public void Match(out global::System.IO.Stream stream)
         {
-            if (!_variant.TryMatch(out stream))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            {
+                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
             }
@@ -379,14 +128,36 @@ namespace Foo
         /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
-            => _variant.TryMatch(out i);
+        {
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            {
+                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+                return true;
+            }
+            else
+            {
+                i = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
         /// </summary>
         /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
         public bool TryMatch(out global::System.IO.Stream stream)
-            => _variant.TryMatch(out stream);
+        {
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            {
+                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+                return true;
+            }
+            else
+            {
+                stream = default;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>.
@@ -396,12 +167,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
@@ -411,12 +185,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                stream(_value);
+                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -428,9 +205,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
             }
             else
             {
@@ -446,9 +223,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.IO.Stream> stream)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                stream(_value);
+                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
             }
             else
             {
@@ -465,9 +242,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                i(_value);
+                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
             }
             else
             {
@@ -483,9 +260,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                stream(_value);
+                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
             }
             else
             {
@@ -503,9 +280,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
             }
             else
             {
@@ -522,9 +299,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                return stream(_value);
+                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
             }
             else
             {
@@ -542,9 +319,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
             }
             else
             {
@@ -561,9 +338,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                return stream(_value);
+                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
             }
             else
             {
@@ -580,9 +357,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out int _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
             {
-                return i(_value);
+                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
             }
             else
             {
@@ -598,9 +375,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out global::System.IO.Stream _value))
+            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
             {
-                return stream(_value);
+                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
             }
             else
             {
@@ -617,7 +394,21 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
-            => _variant.Visit(i, stream);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    break;
+                case 2:
+                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable,
@@ -628,7 +419,22 @@ namespace Foo
         /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
-            => _variant.Visit(i, stream, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    break;
+                case 2:
+                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable and return the result,
@@ -640,7 +446,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
-            => _variant.Visit(i, stream);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                case 2:
+                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable and return the result,
@@ -652,9 +470,297 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
-            => _variant.Visit(i, stream, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                case 2:
+                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object Value { get; }
+            public _VariantTypeProxy(Variant_disposable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default);
+            }
+        }
+
+        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_N(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_1(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_2(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_2)v._variant;
     }
 }
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_disposable
+        : global::System.IDisposable
+    {
+        private readonly Variant_disposable_Union _x;
+        private readonly uint _n;
+
+        public Variant_disposable(int i)
+        {
+            _n = 1;
+            _x = new Variant_disposable_Union(i);
+        }
+        public Variant_disposable(global::System.IO.Stream stream)
+        {
+            _n = 2;
+            _x = new Variant_disposable_Union(stream);
+        }
+
+        public void Dispose()
+        {
+            switch (_n)
+            {
+                case 0:
+                    break;
+                case 1:
+                    break;
+                case 2:
+                    _x._2.Value?.Dispose();
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public static explicit operator Variant_disposable_N(Variant_disposable v) => new Variant_disposable_N(v._n);
+        public static explicit operator Variant_disposable_1(Variant_disposable v) => v._x._1;
+        public static explicit operator Variant_disposable_2(Variant_disposable v) => v._x._2;
+
+        public bool IsEmpty => _n == 0;
+
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "int";
+                    case 2:
+                        return "System.IO.Stream";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    case 1:
+                        return _x._1.Value.ToString();
+                    case 2:
+                        return _x._2.Value?.ToString() ?? "null";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public object AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1.Value;
+                    case 2:
+                        return _x._2.Value;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_disposable other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    case 1:
+                        return global::System.HashCode.Combine(_x._1.Value);
+                    case 2:
+                        return global::System.HashCode.Combine(_x._2.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool TryMatch(out int i)
+        {
+            i = _n == 1 ? _x._1.Value : default;
+            return _n == 1;
+        }
+        public bool TryMatch(out global::System.IO.Stream stream)
+        {
+            stream = _n == 2 ? _x._2.Value : default;
+            return _n == 2;
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    stream(_x._2.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                case 1:
+                    i(_x._1.Value);
+                    break;
+                case 2:
+                    stream(_x._2.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return stream(_x._2.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                case 1:
+                    return i(_x._1.Value);
+                case 2:
+                    return stream(_x._2.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+    }
+
+    internal readonly ref struct Variant_disposable_N
+    {
+        public readonly uint N;
+        public Variant_disposable_N(uint n) => N = n;
+    }
+
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_disposable_Union
+    {
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_disposable_1 _1;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_disposable_2 _2;
+
+        public Variant_disposable_Union(int value)
+        {
+            _2 = default;
+            _1 = new Variant_disposable_1(value);
+        }
+        public Variant_disposable_Union(global::System.IO.Stream value)
+        {
+            _1 = default;
+            _2 = new Variant_disposable_2(value);
+        }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_disposable_1
+    {
+        public readonly int Value;
+        public readonly object _dummy1;
+
+        public Variant_disposable_1(int value)
+        {
+            _dummy1 = null;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_disposable_2
+    {
+        public readonly global::System.IO.Stream Value;
+
+        public Variant_disposable_2(global::System.IO.Stream value)
+        {
+            Value = value;
+        }
+    }
+}
+
 
 namespace Foo
 {
@@ -676,9 +782,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out int value))
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
                 {
-                    yield return i(value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
                 }
             }
         }
@@ -698,9 +804,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out global::System.IO.Stream value))
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
                 {
-                    yield return stream(value);
+                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
                 }
             }
         }
@@ -723,7 +829,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -744,7 +857,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(stream, _);
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                {
+                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
 
@@ -766,7 +886,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(i, _);
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                {
+                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -787,7 +914,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(stream, _);
+                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                {
+                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
 
@@ -810,7 +944,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, stream);
+                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
 
@@ -833,7 +979,20 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(i, stream, _);
+                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
     }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -14,320 +14,26 @@ namespace Foo
         : global::System.IEquatable<Variant_struct_nullable_disable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object Value { get; }
-            public _VariantTypeProxy(Variant_struct_nullable_disable v)
-            {
-                Value = v._variant.AsObject;
-                VariantOf(default, default, default);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-        {
-            private readonly int _n;
-            private readonly Union _x;
-
-            public _VariantStorage(long l)
-            {
-                _n = 1;
-                _x = new Union(l);
-            }
-            public _VariantStorage(double d)
-            {
-                _n = 2;
-                _x = new Union(d);
-            }
-            public _VariantStorage(object o)
-            {
-                _n = 3;
-                _x = new Union(o);
-            }
-
-
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union1 _1;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union2 _2;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union3 _3;
-
-                public Union(long value)
-                {
-                    _2 = default;
-                    _3 = default;
-                    _1 = new Union1(value);
-                }
-                public Union(double value)
-                {
-                    _1 = default;
-                    _3 = default;
-                    _2 = new Union2(value);
-                }
-                public Union(object value)
-                {
-                    _1 = default;
-                    _2 = default;
-                    _3 = new Union3(value);
-                }
-
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union1
-                {
-                    public readonly long Value;
-                    public readonly object _dummy1;
-
-                    public Union1(long value)
-                    {
-                        _dummy1 = null;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union2
-                {
-                    public readonly double Value;
-                    public readonly object _dummy1;
-
-                    public Union2(double value)
-                    {
-                        _dummy1 = null;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union3
-                {
-                    public readonly object Value;
-
-                    public Union3(object value)
-                    {
-                        Value = value;
-                    }
-                }
-            }
-
-            public bool IsEmpty => _n == 0;
-
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        case 1:
-                            return "long";
-                        case 2:
-                            return "double";
-                        case 3:
-                            return "object";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        case 1:
-                            return _x._1.Value.ToString();
-                        case 2:
-                            return _x._2.Value.ToString();
-                        case 3:
-                            return _x._3.Value?.ToString() ?? "null";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public object AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        case 1:
-                            return _x._1.Value;
-                        case 2:
-                            return _x._2.Value;
-                        case 3:
-                            return _x._3.Value;
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    case 1:
-                        return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
-                    case 2:
-                        return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
-                    case 3:
-                        return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        case 1:
-                            return global::System.HashCode.Combine(_x._1.Value);
-                        case 2:
-                            return global::System.HashCode.Combine(_x._2.Value);
-                        case 3:
-                            return global::System.HashCode.Combine(_x._3.Value);
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool TryMatch(out long l)
-            {
-                l = _n == 1 ? _x._1.Value : default;
-                return _n == 1;
-            }
-            public bool TryMatch(out double d)
-            {
-                d = _n == 2 ? _x._2.Value : default;
-                return _n == 2;
-            }
-            public bool TryMatch(out object o)
-            {
-                o = _n == 3 ? _x._3.Value : default;
-                return _n == 3;
-            }
-
-            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    case 1:
-                        l(_x._1.Value);
-                        break;
-                    case 2:
-                        d(_x._2.Value);
-                        break;
-                    case 3:
-                        o(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
-                    case 1:
-                        l(_x._1.Value);
-                        break;
-                    case 2:
-                        d(_x._2.Value);
-                        break;
-                    case 3:
-                        o(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    case 1:
-                        return l(_x._1.Value);
-                    case 2:
-                        return d(_x._2.Value);
-                    case 3:
-                        return o(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
-                    case 1:
-                        return l(_x._1.Value);
-                    case 2:
-                        return d(_x._2.Value);
-                    case 3:
-                        return o(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is in a corrupted state.");
-                }
-            }
-        }
+        private readonly global::dotVariant._G.Foo.Variant_struct_nullable_disable _variant;
 
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_disable(long l)
-            => _variant = new _VariantStorage(l);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_disable(double d)
-            => _variant = new _VariantStorage(d);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(d);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_disable(object o)
-            => _variant = new _VariantStorage(o);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(o);
 
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="long"/>.
@@ -399,7 +105,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
         public readonly void Match(out long l)
         {
-            if (!_variant.TryMatch(out l))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            {
+                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'long', actual '{_variant.TypeString}').");
             }
@@ -412,7 +122,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
         public readonly void Match(out double d)
         {
-            if (!_variant.TryMatch(out d))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            {
+                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'double', actual '{_variant.TypeString}').");
             }
@@ -425,7 +139,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
         public readonly void Match(out object o)
         {
-            if (!_variant.TryMatch(out o))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            {
+                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'object', actual '{_variant.TypeString}').");
             }
@@ -437,21 +155,54 @@ namespace Foo
         /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
         public readonly bool TryMatch(out long l)
-            => _variant.TryMatch(out l);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            {
+                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value;
+                return true;
+            }
+            else
+            {
+                l = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
         public readonly bool TryMatch(out double d)
-            => _variant.TryMatch(out d);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            {
+                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value;
+                return true;
+            }
+            else
+            {
+                d = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
         public readonly bool TryMatch(out object o)
-            => _variant.TryMatch(out o);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            {
+                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value;
+                return true;
+            }
+            else
+            {
+                o = default;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>.
@@ -461,12 +212,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<long> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
@@ -476,12 +230,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<double> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
@@ -491,12 +248,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<object> o)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                o(_value);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -508,9 +268,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -526,9 +286,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -544,9 +304,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                o(_value);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -563,9 +323,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -581,9 +341,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d, global::System.Action _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -599,9 +359,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o, global::System.Action _)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                o(_value);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -619,9 +379,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -638,9 +398,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -657,9 +417,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                return o(_value);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -677,9 +437,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -696,9 +456,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -715,9 +475,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                return o(_value);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -734,9 +494,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
             }
             else
             {
@@ -752,9 +512,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
             }
             else
             {
@@ -770,9 +530,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out object _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
             {
-                return o(_value);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
             }
             else
             {
@@ -790,7 +550,24 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-            => _variant.Visit(l, d, o);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                case 1:
+                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    break;
+                case 2:
+                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    break;
+                case 3:
+                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable,
@@ -802,7 +579,25 @@ namespace Foo
         /// <param name="_">The delegate to invoke if Variant_struct_nullable_disable is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-            => _variant.Visit(l, d, o, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    break;
+                case 2:
+                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    break;
+                case 3:
+                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_disable and return the result,
@@ -815,7 +610,21 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-            => _variant.Visit(l, d, o);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                case 1:
+                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                case 2:
+                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                case 3:
+                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable and return the result,
@@ -828,9 +637,337 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-            => _variant.Visit(l, d, o, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                case 2:
+                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                case 3:
+                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object Value { get; }
+            public _VariantTypeProxy(Variant_struct_nullable_disable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default, default);
+            }
+        }
+
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_N(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_1(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_2(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_3(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)v._variant;
     }
 }
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_disable
+    {
+        private readonly Variant_struct_nullable_disable_Union _x;
+        private readonly uint _n;
+
+        public Variant_struct_nullable_disable(long l)
+        {
+            _n = 1;
+            _x = new Variant_struct_nullable_disable_Union(l);
+        }
+        public Variant_struct_nullable_disable(double d)
+        {
+            _n = 2;
+            _x = new Variant_struct_nullable_disable_Union(d);
+        }
+        public Variant_struct_nullable_disable(object o)
+        {
+            _n = 3;
+            _x = new Variant_struct_nullable_disable_Union(o);
+        }
+
+
+        public static explicit operator Variant_struct_nullable_disable_N(Variant_struct_nullable_disable v) => new Variant_struct_nullable_disable_N(v._n);
+        public static explicit operator Variant_struct_nullable_disable_1(Variant_struct_nullable_disable v) => v._x._1;
+        public static explicit operator Variant_struct_nullable_disable_2(Variant_struct_nullable_disable v) => v._x._2;
+        public static explicit operator Variant_struct_nullable_disable_3(Variant_struct_nullable_disable v) => v._x._3;
+
+        public bool IsEmpty => _n == 0;
+
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "long";
+                    case 2:
+                        return "double";
+                    case 3:
+                        return "object";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    case 1:
+                        return _x._1.Value.ToString();
+                    case 2:
+                        return _x._2.Value.ToString();
+                    case 3:
+                        return _x._3.Value?.ToString() ?? "null";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public object AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1.Value;
+                    case 2:
+                        return _x._2.Value;
+                    case 3:
+                        return _x._3.Value;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_struct_nullable_disable other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
+                case 3:
+                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    case 1:
+                        return global::System.HashCode.Combine(_x._1.Value);
+                    case 2:
+                        return global::System.HashCode.Combine(_x._2.Value);
+                    case 3:
+                        return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool TryMatch(out long l)
+        {
+            l = _n == 1 ? _x._1.Value : default;
+            return _n == 1;
+        }
+        public bool TryMatch(out double d)
+        {
+            d = _n == 2 ? _x._2.Value : default;
+            return _n == 2;
+        }
+        public bool TryMatch(out object o)
+        {
+            o = _n == 3 ? _x._3.Value : default;
+            return _n == 3;
+        }
+
+        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    l(_x._1.Value);
+                    break;
+                case 2:
+                    d(_x._2.Value);
+                    break;
+                case 3:
+                    o(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                case 1:
+                    l(_x._1.Value);
+                    break;
+                case 2:
+                    d(_x._2.Value);
+                    break;
+                case 3:
+                    o(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return l(_x._1.Value);
+                case 2:
+                    return d(_x._2.Value);
+                case 3:
+                    return o(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                case 1:
+                    return l(_x._1.Value);
+                case 2:
+                    return d(_x._2.Value);
+                case 3:
+                    return o(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+    }
+
+    internal readonly ref struct Variant_struct_nullable_disable_N
+    {
+        public readonly uint N;
+        public Variant_struct_nullable_disable_N(uint n) => N = n;
+    }
+
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_disable_Union
+    {
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_disable_1 _1;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_disable_2 _2;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_disable_3 _3;
+
+        public Variant_struct_nullable_disable_Union(long value)
+        {
+            _2 = default;
+            _3 = default;
+            _1 = new Variant_struct_nullable_disable_1(value);
+        }
+        public Variant_struct_nullable_disable_Union(double value)
+        {
+            _1 = default;
+            _3 = default;
+            _2 = new Variant_struct_nullable_disable_2(value);
+        }
+        public Variant_struct_nullable_disable_Union(object value)
+        {
+            _1 = default;
+            _2 = default;
+            _3 = new Variant_struct_nullable_disable_3(value);
+        }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_disable_1
+    {
+        public readonly long Value;
+        public readonly object _dummy1;
+
+        public Variant_struct_nullable_disable_1(long value)
+        {
+            _dummy1 = null;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_disable_2
+    {
+        public readonly double Value;
+        public readonly object _dummy1;
+
+        public Variant_struct_nullable_disable_2(double value)
+        {
+            _dummy1 = null;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_disable_3
+    {
+        public readonly object Value;
+
+        public Variant_struct_nullable_disable_3(object value)
+        {
+            Value = value;
+        }
+    }
+}
+
 
 namespace Foo
 {
@@ -852,9 +989,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out long value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
                 {
-                    yield return l(value);
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
                 }
             }
         }
@@ -874,9 +1011,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out double value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
                 {
-                    yield return d(value);
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
                 }
             }
         }
@@ -896,9 +1033,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out object value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
                 {
-                    yield return o(value);
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
                 }
             }
         }
@@ -921,7 +1058,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(l, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
+                {
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -942,7 +1086,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(d, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
+                {
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -963,7 +1114,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(o, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
+                {
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
 
@@ -985,7 +1143,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(l, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
+                {
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1006,7 +1171,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(d, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
+                {
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1027,7 +1199,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(o, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
+                {
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
 
@@ -1051,7 +1230,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(l, d, o);
+                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                    case 1:
+                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
 
@@ -1075,7 +1269,23 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(l, d, o, _);
+                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
     }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -14,320 +14,26 @@ namespace Foo
         : global::System.IEquatable<Variant_struct_nullable_enable>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object? Value { get; }
-            public _VariantTypeProxy(Variant_struct_nullable_enable v)
-            {
-                Value = v._variant.AsObject;
-                VariantOf(default, default, default!);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-        {
-            private readonly int _n;
-            private readonly Union _x;
-
-            public _VariantStorage(long l)
-            {
-                _n = 1;
-                _x = new Union(l);
-            }
-            public _VariantStorage(double d)
-            {
-                _n = 2;
-                _x = new Union(d);
-            }
-            public _VariantStorage(object o)
-            {
-                _n = 3;
-                _x = new Union(o);
-            }
-
-
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union1 _1;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union2 _2;
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union3 _3;
-
-                public Union(long value)
-                {
-                    _2 = default;
-                    _3 = default;
-                    _1 = new Union1(value);
-                }
-                public Union(double value)
-                {
-                    _1 = default;
-                    _3 = default;
-                    _2 = new Union2(value);
-                }
-                public Union(object value)
-                {
-                    _1 = default;
-                    _2 = default;
-                    _3 = new Union3(value);
-                }
-
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union1
-                {
-                    public readonly long Value;
-                    public readonly object _dummy1;
-
-                    public Union1(long value)
-                    {
-                        _dummy1 = null!;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union2
-                {
-                    public readonly double Value;
-                    public readonly object _dummy1;
-
-                    public Union2(double value)
-                    {
-                        _dummy1 = null!;
-                        Value = value;
-                    }
-                }
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union3
-                {
-                    public readonly object Value;
-
-                    public Union3(object value)
-                    {
-                        Value = value;
-                    }
-                }
-            }
-
-            public bool IsEmpty => _n == 0;
-
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        case 1:
-                            return "long";
-                        case 2:
-                            return "double";
-                        case 3:
-                            return "object";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        case 1:
-                            return _x._1.Value.ToString();
-                        case 2:
-                            return _x._2.Value.ToString();
-                        case 3:
-                            return _x._3.Value.ToString() ?? "null";
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public object? AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        case 1:
-                            return _x._1.Value;
-                        case 2:
-                            return _x._2.Value;
-                        case 3:
-                            return _x._3.Value;
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    case 1:
-                        return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
-                    case 2:
-                        return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
-                    case 3:
-                        return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        case 1:
-                            return global::System.HashCode.Combine(_x._1.Value);
-                        case 2:
-                            return global::System.HashCode.Combine(_x._2.Value);
-                        case 3:
-                            return global::System.HashCode.Combine(_x._3.Value);
-                        default:
-                            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                    }
-                }
-            }
-
-            public bool TryMatch(out long l)
-            {
-                l = _n == 1 ? _x._1.Value : default;
-                return _n == 1;
-            }
-            public bool TryMatch(out double d)
-            {
-                d = _n == 2 ? _x._2.Value : default;
-                return _n == 2;
-            }
-            public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
-            {
-                o = _n == 3 ? _x._3.Value : default;
-                return _n == 3;
-            }
-
-            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    case 1:
-                        l(_x._1.Value);
-                        break;
-                    case 2:
-                        d(_x._2.Value);
-                        break;
-                    case 3:
-                        o(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
-                    case 1:
-                        l(_x._1.Value);
-                        break;
-                    case 2:
-                        d(_x._2.Value);
-                        break;
-                    case 3:
-                        o(_x._3.Value);
-                        break;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    case 1:
-                        return l(_x._1.Value);
-                    case 2:
-                        return d(_x._2.Value);
-                    case 3:
-                        return o(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                }
-            }
-
-            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
-                    case 1:
-                        return l(_x._1.Value);
-                    case 2:
-                        return d(_x._2.Value);
-                    case 3:
-                        return o(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is in a corrupted state.");
-                }
-            }
-        }
+        private readonly global::dotVariant._G.Foo.Variant_struct_nullable_enable _variant;
 
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_enable(long l)
-            => _variant = new _VariantStorage(l);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_enable(double d)
-            => _variant = new _VariantStorage(d);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(d);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
         public Variant_struct_nullable_enable(object o)
-            => _variant = new _VariantStorage(o);
+            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(o);
 
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="long"/>.
@@ -399,7 +105,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
         public readonly void Match(out long l)
         {
-            if (!_variant.TryMatch(out l))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            {
+                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'long', actual '{_variant.TypeString}').");
             }
@@ -412,7 +122,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
         public readonly void Match(out double d)
         {
-            if (!_variant.TryMatch(out d))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            {
+                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'double', actual '{_variant.TypeString}').");
             }
@@ -425,7 +139,11 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
         public readonly void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out object? o)
         {
-            if (!_variant.TryMatch(out o!))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            {
+                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value;
+            }
+            else
             {
                 throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'object', actual '{_variant.TypeString}').");
             }
@@ -437,21 +155,54 @@ namespace Foo
         /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
         public readonly bool TryMatch(out long l)
-            => _variant.TryMatch(out l);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            {
+                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value;
+                return true;
+            }
+            else
+            {
+                l = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
         public readonly bool TryMatch(out double d)
-            => _variant.TryMatch(out d);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            {
+                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value;
+                return true;
+            }
+            else
+            {
+                d = default;
+                return false;
+            }
+        }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
         public readonly bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
-            => _variant.TryMatch(out o);
+        {
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            {
+                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value;
+                return true;
+            }
+            else
+            {
+                o = default;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>.
@@ -461,12 +212,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<long> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
@@ -476,12 +230,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<double> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         /// <summary>
         /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
@@ -491,12 +248,15 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<object> o)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                o(_value!);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -508,9 +268,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -526,9 +286,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -544,9 +304,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                o(_value!);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -563,9 +323,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                l(_value);
+                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -581,9 +341,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d, global::System.Action _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                d(_value);
+                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -599,9 +359,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o, global::System.Action _)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                o(_value!);
+                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -619,9 +379,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -638,9 +398,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -657,9 +417,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                return o(_value!);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -677,9 +437,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -696,9 +456,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -715,9 +475,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                return o(_value!);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -734,9 +494,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out long _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
             {
-                return l(_value);
+                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
             }
             else
             {
@@ -752,9 +512,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out double _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
             {
-                return d(_value);
+                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
             }
             else
             {
@@ -770,9 +530,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out object? _value))
+            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
             {
-                return o(_value!);
+                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
             }
             else
             {
@@ -790,7 +550,24 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-            => _variant.Visit(l, d, o);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                case 1:
+                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    break;
+                case 2:
+                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    break;
+                case 3:
+                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable,
@@ -802,7 +579,25 @@ namespace Foo
         /// <param name="_">The delegate to invoke if Variant_struct_nullable_enable is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-            => _variant.Visit(l, d, o, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    break;
+                case 2:
+                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    break;
+                case 3:
+                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_enable and return the result,
@@ -815,7 +610,21 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-            => _variant.Visit(l, d, o);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                case 1:
+                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                case 2:
+                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                case 3:
+                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
 
         /// <summary>
         /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable and return the result,
@@ -828,9 +637,337 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-            => _variant.Visit(l, d, o, _);
+        {
+            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                case 2:
+                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                case 3:
+                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object? Value { get; }
+            public _VariantTypeProxy(Variant_struct_nullable_enable v)
+            {
+                Value = v._variant.AsObject;
+                VariantOf(default, default, default!);
+            }
+        }
+
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_N(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_1(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_2(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_3(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)v._variant;
     }
 }
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_enable
+    {
+        private readonly Variant_struct_nullable_enable_Union _x;
+        private readonly uint _n;
+
+        public Variant_struct_nullable_enable(long l)
+        {
+            _n = 1;
+            _x = new Variant_struct_nullable_enable_Union(l);
+        }
+        public Variant_struct_nullable_enable(double d)
+        {
+            _n = 2;
+            _x = new Variant_struct_nullable_enable_Union(d);
+        }
+        public Variant_struct_nullable_enable(object o)
+        {
+            _n = 3;
+            _x = new Variant_struct_nullable_enable_Union(o);
+        }
+
+
+        public static explicit operator Variant_struct_nullable_enable_N(Variant_struct_nullable_enable v) => new Variant_struct_nullable_enable_N(v._n);
+        public static explicit operator Variant_struct_nullable_enable_1(Variant_struct_nullable_enable v) => v._x._1;
+        public static explicit operator Variant_struct_nullable_enable_2(Variant_struct_nullable_enable v) => v._x._2;
+        public static explicit operator Variant_struct_nullable_enable_3(Variant_struct_nullable_enable v) => v._x._3;
+
+        public bool IsEmpty => _n == 0;
+
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "long";
+                    case 2:
+                        return "double";
+                    case 3:
+                        return "object";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    case 1:
+                        return _x._1.Value.ToString();
+                    case 2:
+                        return _x._2.Value.ToString();
+                    case 3:
+                        return _x._3.Value.ToString() ?? "null";
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public object? AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1.Value;
+                    case 2:
+                        return _x._2.Value;
+                    case 3:
+                        return _x._3.Value;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_struct_nullable_enable other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
+                case 3:
+                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    case 1:
+                        return global::System.HashCode.Combine(_x._1.Value);
+                    case 2:
+                        return global::System.HashCode.Combine(_x._2.Value);
+                    case 3:
+                        return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
+            }
+        }
+
+        public bool TryMatch(out long l)
+        {
+            l = _n == 1 ? _x._1.Value : default;
+            return _n == 1;
+        }
+        public bool TryMatch(out double d)
+        {
+            d = _n == 2 ? _x._2.Value : default;
+            return _n == 2;
+        }
+        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
+        {
+            o = _n == 3 ? _x._3.Value : default;
+            return _n == 3;
+        }
+
+        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    l(_x._1.Value);
+                    break;
+                case 2:
+                    d(_x._2.Value);
+                    break;
+                case 3:
+                    o(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                case 1:
+                    l(_x._1.Value);
+                    break;
+                case 2:
+                    d(_x._2.Value);
+                    break;
+                case 3:
+                    o(_x._3.Value);
+                    break;
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return l(_x._1.Value);
+                case 2:
+                    return d(_x._2.Value);
+                case 3:
+                    return o(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+
+        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                case 1:
+                    return l(_x._1.Value);
+                case 2:
+                    return d(_x._2.Value);
+                case 3:
+                    return o(_x._3.Value);
+                default:
+                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            }
+        }
+    }
+
+    internal readonly ref struct Variant_struct_nullable_enable_N
+    {
+        public readonly uint N;
+        public Variant_struct_nullable_enable_N(uint n) => N = n;
+    }
+
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_enable_Union
+    {
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_enable_1 _1;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_enable_2 _2;
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly Variant_struct_nullable_enable_3 _3;
+
+        public Variant_struct_nullable_enable_Union(long value)
+        {
+            _2 = default;
+            _3 = default;
+            _1 = new Variant_struct_nullable_enable_1(value);
+        }
+        public Variant_struct_nullable_enable_Union(double value)
+        {
+            _1 = default;
+            _3 = default;
+            _2 = new Variant_struct_nullable_enable_2(value);
+        }
+        public Variant_struct_nullable_enable_Union(object value)
+        {
+            _1 = default;
+            _2 = default;
+            _3 = new Variant_struct_nullable_enable_3(value);
+        }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_enable_1
+    {
+        public readonly long Value;
+        public readonly object _dummy1;
+
+        public Variant_struct_nullable_enable_1(long value)
+        {
+            _dummy1 = null!;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_enable_2
+    {
+        public readonly double Value;
+        public readonly object _dummy1;
+
+        public Variant_struct_nullable_enable_2(double value)
+        {
+            _dummy1 = null!;
+            Value = value;
+        }
+    }
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct Variant_struct_nullable_enable_3
+    {
+        public readonly object Value;
+
+        public Variant_struct_nullable_enable_3(object value)
+        {
+            Value = value;
+        }
+    }
+}
+
 
 namespace Foo
 {
@@ -852,9 +989,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out long value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
                 {
-                    yield return l(value);
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
                 }
             }
         }
@@ -874,9 +1011,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out double value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
                 {
-                    yield return d(value);
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
                 }
             }
         }
@@ -896,9 +1033,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (variant.TryMatch(out object? value))
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
                 {
-                    yield return o(value);
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
                 }
             }
         }
@@ -921,7 +1058,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(l, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
+                {
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -942,7 +1086,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(d, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
+                {
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
         /// <summary>
@@ -963,7 +1114,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(o, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
+                {
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _;
+                }
             }
         }
 
@@ -985,7 +1143,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(l, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
+                {
+                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1006,7 +1171,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(d, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
+                {
+                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
         /// <summary>
@@ -1027,7 +1199,14 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Match(o, _);
+                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
+                {
+                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                }
+                else
+                {
+                    yield return _();
+                }
             }
         }
 
@@ -1051,7 +1230,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(l, d, o);
+                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N)
+                {
+                    case 0:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                    case 1:
+                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
 
@@ -1075,7 +1269,23 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                yield return variant.Visit(l, d, o, _);
+                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                        break;
+                    case 2:
+                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                        break;
+                    case 3:
+                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                        break;
+                    default:
+                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                }
             }
         }
     }

--- a/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
@@ -1,0 +1,185 @@
+{{~
+# Copyright Miro Knejp 2021.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+~}}
+{{~
+func $get_n()
+    ret get_n "variant"
+end
+func $get_value(param)
+    ret get_value param "variant"
+end
+~}}
+{{~ if Options.ExtensionClassNamespace ~}}
+namespace {{ Options.ExtensionClassNamespace }}
+{
+{{~ end ~}}
+    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
+    {
+        {{~ ## Match(IEnumerable<V>, Func<A, R>) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and dropping all others.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }})
+        {
+            foreach (var variant in source)
+            {
+                if ({{ $get_n }} == {{ $p.Index }})
+                {
+                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                }
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Match(IEnumerable<V>, Func<A, R>, R) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }},
+                TResult _)
+        {
+            foreach (var variant in source)
+            {
+                if ({{ $get_n }} == {{ $p.Index }})
+                {
+                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Match(IEnumerable<V>, Func<A, R>, Func<R>) ## ~}}
+        {{~ for $p in Params ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_type $p }} {{ $p.Hint }},
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                if ({{ $get_n }} == {{ $p.Index }})
+                {
+                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ...) ## ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        {{~ for $p in Params ~}}
+        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
+        {{~ end ~}}
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty {{ Variant.Name }}.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_params }})
+        {
+            foreach (var variant in source)
+            {
+                switch ({{ $get_n }})
+                {
+                    case 0:
+                        throw {{ empty_exception }};
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        yield return {{ $p.Hint }}({{ $get_value $p }});
+                        break;
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+
+        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ..., empty) ## ~}}
+        /// <summary>
+        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="source">An enumerable sequence whose elements to match on.</param>
+        {{~ for $p in Params ~}}
+        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
+        {{~ end ~}}
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                {{ func_params }},
+                global::System.Func<TResult> _)
+        {
+            foreach (var variant in source)
+            {
+                switch ({{ $get_n }})
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        yield return {{ $p.Hint }}({{ $get_value $p }});
+                        break;
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+    }
+{{~ if Options.ExtensionClassNamespace ~}}
+}
+{{~ end ~}}

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -1,0 +1,399 @@
+{{~
+# Copyright Miro Knejp 2021.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+~}}
+{{~ ##
+Variant tries to use as little space as possible by using an Explicit layout
+for its possible option types. Because Variant is a sum type there can only
+ever be a single "active" field, i.e. holding real data.
+
+This means we can use explicit layout and overlap those types onto the same
+area of memory. There is only one restriction that we must adhere to:
+
+    An unmanaged field and a reference field cannot occupiy the same space.
+
+To ensure this the CLR switches the layout of structs containing reference
+fields from the default "Sequential" to "Auto" and seems to separate all
+reference fields from unmanaged fields. Let's look at this with a concrete
+example:
+
+struct A { public IntPtr i; public IntPtr j; }
+struct B { public object o; public IntPtr x; }
+
+Have a look at the memory layout of
+
+[StructLayout(LayoutKind.Explicit)]
+class Variant { [FieldOffset(0)] public A a; [FieldOffset(0)] public B b; }
+
++--------+-----------------+
+| offset | Variant         |
++--------+-----------------+
+|        | +-----+ +-----+ |
+|      0 | | A.i | | B.o | | <- ERROR: TypeLoadException
+|        | +-----+ +-----+ |
+|      8 | | A.j | | B.x | |
+|        | +-----+ +-----+ |
++--------+-----------------+
+
+The line marked above shows how an object reference (B.o) is now sharing
+space with an unmanaged type (A.i). Trying to load this type will trigger a
+TypeLoadException saying Variant "contains an object field at offset 0
+that is incorrectly aligned or overlapped by a non-object field".
+
+The way we fix this is by wrapping A in a new struct and adding an object reference
+to it:
+
+struct WrapA { public A a; public object o; }
+
+[StructLayout(LayoutKind.Explicit)]
+class Variant { [FieldOffset(0)] private WrapA a; [FieldOffset(0)] private B b; }
+
+Leading to this layout:
+
++--------+---------------------------+
+| offset | Variant                   |
++--------+---------------------------+
+|        | +---------------+ +-----+ |
+|      0 | | WrapA.o       | | B.o | | <- OK
+|        | +---------------+ |     | |
+|        | | +-----------+ | +-----+ |
+|      8 | | | WrapA.a.i | | | B.x | |
+|        | | +-----------+ | +-----+ |
+|     16 | | | WrapA.a.j | |         |
+|        | | +-----------+ |         |
+|        | +---------------+         |
++------------------------------------+
+
+This layout no longer causes exceptions and can be loaded but at the cost
+of extra memory consumption and unused "dummy" fields.
+
+We still have one issue though: where do we put the discriminator (the
+integer telling us which value is "active" in the Variant)? It needs to
+always be at the same memory location regardless of the currently active
+type. We also cannot force it to offset 0 because that's where the managed
+types will go. The solution here is an extra level of indirection:
+
+    Put all the WrapX types inside a new struct with the explicit layout
+    and leave the discriminator integer outside:
+
+[StructLayout(LayoutKind.Explicit)]
+struct Values
+{
+    [FieldOffset(0)] public WrapA a;
+    [FieldOffset(0)] public WrapB b;
+    ...
+    [FieldOffset(0)] public WrapN n;
+}
+
+class Variant { private int discriminator; private Values values; }
+
++--------+-------------------------------------+
+| offset | Variant                             |
++--------+-------------------------------------+
+|      0 | discriminator                       |
++--------+-------------------------------------+
+|        | values                              |
+|        | +---------------------------------+ |
+|        | | +---------------+ +-----------+ | |
+|      8 | | | WrapA.o       | | WrapB.b.o | | |
+|        | | +---------------+ |           | | |
+|        | | | +-----------+ | +-----------+ | |
+|     16 | | | | WrapA.a.i | | | WrapB.b.x | | |
+|        | | | +-----------+ | +-----------+ | |
+|     24 | | | | WrapA.a.j | |               | |
+|        | | | +-----------+ |               | |
+|        | | +---------------+               | |
+|        | +---------------------------------+ |
++--------+-------------------------------------+
+
+While this results in some overhead, as the Variant's size is
+the sum of max(object fields) + max(non-object fields) for all
+possible values it can hold, it allows for the elision of boxing
+for value types and still consumes *much* less memory than if
+it had to store all values side-by-side.
+## ~}}
+{{~
+func $storage(param)
+    ret "_x._" + param.Index + ".Value"
+end
+~}}
+{{~ ## STORAGE WRAPPER ## ~}}
+namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct {{ Variant.Name }}
+    {{~ if needs_dispose ~}}
+        : global::System.IDisposable
+    {{~ end ~}}
+    {
+        private readonly {{ Variant.Name }}_Union _x;
+        private readonly uint _n;
+
+        {{~ ## STORAGE CONSTRUCTORS ## ~}}
+        {{~ for $p in Params ~}}
+        public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
+        {
+            _n = {{ $p.Index }};
+            _x = new {{ Variant.Name }}_Union({{ $p.Hint }});
+        }
+        {{~ end ~}}
+
+        {{~ if needs_dispose ~}}
+        public void Dispose()
+        {
+            switch (_n)
+            {
+                case 0:
+                    break;
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    {{~ if $p.IsDisposable ~}}
+                    {{ coalesce $p ($storage $p) ".Dispose()" }};
+                    {{~ end ~}}
+                    break;
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+        {{~ end ~}}
+
+        {{~ ## INTERNAL ACCESS ## ~}}
+        public static explicit operator {{ Variant.Name }}_N({{ Variant.Name }} v) => new {{ Variant.Name }}_N(v._n);
+        {{~ for $p in Params ~}}
+        public static explicit operator {{ Variant.Name }}_{{ $p.Index }}({{ Variant.Name }} v) => v._x._{{ $p.Index }};
+        {{~ end ~}}
+
+        {{~ ## UNION IsEmpty ## ~}}
+        public bool IsEmpty => _n == 0;
+
+        {{~ ## UNION TypeString ## ~}}
+        public string TypeString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "<empty>";
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        return "{{ $p.DiagName }}";
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+
+        {{~ ## UNION ValueString ## ~}}
+        public string ValueString
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return "";
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        return {{ coalesce_ToString $p ($storage $p) }};
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+
+        {{~ ## UNION AsObject ## ~}}
+        public object{{ global_nullable }} AsObject
+        {
+            get
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return null;
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        return {{ $storage $p }};
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+
+        {{~ ## UNION Equals ## ~}}
+        public bool Equals(in {{ Variant.Name }} other)
+        {
+            if (_n != other._n)
+            {
+                return false;
+            }
+            switch (_n)
+            {
+                case 0:
+                    return true;
+                {{~ for $p in Params ~}}
+                {{~ $i = $p.Index ~}}
+                case {{ $i }}:
+                    return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+
+        {{~ ## UNION GetHashCode ## ~}}
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return 0;
+                    {{~ for $p in Params ~}}
+                    {{~ $i = $p.Index ~}}
+                    case {{ $i }}:
+                        {{~ if Runtime.HasHashCode ~}}
+                        return global::System.HashCode.Combine({{ $storage $p }});
+                        {{~ else ~}}
+                        return {{ coalesce $p ($storage $p) ".GetHashCode()" "0"}};
+                        {{~ end ~}}
+                    {{~ end ~}}
+                    default:
+                        throw {{ corrupt_exception }};
+                }
+            }
+        }
+
+        {{~ ## UNION TryMatch ## ~}}
+        {{~ for $p in Params ~}}
+        public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
+        {
+            {{ $p.Hint }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
+            return _n == {{ $p.Index }};
+        }
+        {{~ end ~}}
+
+        {{~ ## UNION Visit(Action) ## ~}}
+        public void Visit({{ action_params }}, global::System.Action _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    _();
+                    break;
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    {{ $p.Hint }}({{ $storage $p }});
+                    break;
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+
+        {{~ ## UNION Visit(Action) ## ~}}
+        public void Visit({{ action_params }})
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    {{ $p.Hint }}({{ $storage $p }});
+                    break;
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+
+        {{~ ## UNION Visit(Func) ## ~}}
+        public TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
+        {
+            switch (_n)
+            {
+                case 0:
+                    return _();
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    return {{ $p.Hint }}({{ $storage $p }});
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+
+        {{~ ## UNION Visit(Func) ## ~}}
+        public TResult Visit<TResult>({{ func_params }})
+        {
+            switch (_n)
+            {
+                case 0:
+                    throw {{ empty_exception }};
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    return {{ $p.Hint }}({{ $storage $p }});
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+    }
+
+    {{~ ## DISCRIMINATOR COVERTER ## ~}}
+    internal readonly ref struct {{ Variant.Name }}_N
+    {
+        public readonly uint N;
+        public {{ Variant.Name }}_N(uint n) => N = n;
+    }
+
+    {{~ ## UNION TYPE ## ~}}
+    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct {{ Variant.Name }}_Union
+    {
+        {{~ ## UNION MEMBERS ## ~}}
+        {{~ for $p in Params ~}}
+        [global::System.Runtime.InteropServices.FieldOffset(0)]
+        public readonly {{ Variant.Name }}_{{ $p.Index }} _{{ $p.Index }};
+        {{~ end ~}}
+
+        {{~ ## UNION CONSTRUCTORS ## ~}}
+        {{~ for $p in Params ~}}
+        public {{ Variant.Name }}_Union({{ value_type $p }} value)
+        {
+            {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
+            _{{ $other.Index }} = default;
+            {{~ end ~}}
+            _{{ $p.Index }} = new {{ Variant.Name }}_{{ $p.Index }}(value);
+        }
+        {{~ end ~}}
+    }
+
+    {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
+    {{~ for $p in Params ~}}
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    internal readonly struct {{ Variant.Name }}_{{ $p.Index }}
+    {
+        public readonly {{ value_type $p }} Value;
+        {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+        public readonly object _dummy{{ $dummy }};
+        {{~ end ~}}
+
+        public {{ Variant.Name }}_{{ $p.Index }}({{ value_type $p }} value)
+        {
+            {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+            _dummy{{ $dummy }} = null{{ global_forgive }};
+            {{~ end ~}}
+            Value = value;
+        }
+    }
+    {{~ end ~}}
+}

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -76,10 +76,6 @@ func coalesce_ToString(type, expression)
     end
 end
 
-func storage(param)
-    ret "_x._" + param.Index + ".Value"
-end
-
 func param_hint(param)
     ret param.Hint
 end
@@ -105,6 +101,15 @@ func throw_InvalidOperation(expected, actual)
     ret "throw new global::System.InvalidOperationException(" + $msg + ")"
 end
 
+storage_type = "global::dotVariant._G." + (Variant.Namespace ? (Variant.Namespace + ".") : "") + Variant.Name
+func get_value(param, expression = "_variant")
+    ret "((" + storage_type + "_" + param.Index + ")" + expression + ").Value"
+end
+
+func get_n(expression = "_variant")
+    ret "((" + storage_type + "_N)" + expression + ").N"
+end
+
 func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Hint; end) | array.join ", "
 action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Hint; end) | array.join ", "
 method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : ""
@@ -112,12 +117,20 @@ param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 
 global_nullable = emit_nullability ? "?" : ""
 global_forgive = emit_nullability ? "!" : ""
 needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
+empty_exception = "new global::System.InvalidOperationException(\"" + Variant.Name + " is empty.\")"
+corrupt_exception = "new global::System.InvalidOperationException(\"" + Variant.Name + " has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant\")"
 
+readonly storage_type
+readonly get_value
 readonly func_params
 readonly action_params
 readonly method_modifiers
 readonly param_modifiers
 readonly global_nullable
+readonly global_forgive
+readonly needs_dispose
+readonly empty_exception
+readonly corrupt_string
 ~}}
 {{~ if Language.Version >= 800 ~}}
 #nullable {{ Language.Nullable }}
@@ -136,392 +149,7 @@ namespace {{ Variant.Namespace }}
         {{~ end ~}}
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly _VariantStorage _variant;
-
-        private sealed class _VariantTypeProxy
-        {
-            public object{{ global_nullable }} Value { get; }
-            public _VariantTypeProxy({{ Variant.Name }} v)
-            {
-                Value = v._variant.AsObject;
-                {{~ # Force a reference to the VariantOf function so the user doesn't get IDE0051 "Private member 'VariantOf' is unused." ~}}
-                VariantOf({{ Params | array.each @(do; ret forgive $0 "default"; end) | array.join ", " }});
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct _VariantStorage
-        {{~ if needs_dispose ~}}
-            : global::System.IDisposable
-        {{~ end ~}}
-        {
-            private readonly int _n;
-            private readonly Union _x;
-            {{~ ##
-            Variant tries to use as little space as possible by using an Explicit layout
-            for its possible option types. Because Variant is a sum type there can only
-            ever be a single "active" field, i.e. holding real data.
-
-            This means we can use explicit layout and overlap those types onto the same
-            area of memory. There is only one restriction that we must adhere to:
-
-                An unmanaged field and a reference field cannot occupiy the same space.
-
-            To ensure this the CLR switches the layout of structs containing reference
-            fields from the default "Sequential" to "Auto" and seems to separate all
-            reference fields from unmanaged fields. Let's look at this with a concrete
-            example:
-
-            struct A { public IntPtr i; public IntPtr j; }
-            struct B { public object o; public IntPtr x; }
-
-            Have a look at the memory layout of
-
-            [StructLayout(LayoutKind.Explicit)]
-            class Variant { [FieldOffset(0)] public A a; [FieldOffset(0)] public B b; }
-
-            +--------+-----------------+
-            | offset | Variant         |
-            +--------+-----------------+
-            |        | +-----+ +-----+ |
-            |      0 | | A.i | | B.o | | <- ERROR: TypeLoadException
-            |        | +-----+ +-----+ |
-            |      8 | | A.j | | B.x | |
-            |        | +-----+ +-----+ |
-            +--------+-----------------+
-
-            The line marked above shows how an object reference (B.o) is now sharing
-            space with an unmanaged type (A.i). Trying to load this type will trigger a
-            TypeLoadException saying Variant "contains an object field at offset 0
-            that is incorrectly aligned or overlapped by a non-object field".
-
-            The way we fix this is by wrapping A in a new struct and adding an object reference
-            to it:
-
-            struct WrapA { public A a; public object o; }
-
-            [StructLayout(LayoutKind.Explicit)]
-            class Variant { [FieldOffset(0)] private WrapA a; [FieldOffset(0)] private B b; }
-
-            Leading to this layout:
-
-            +--------+---------------------------+
-            | offset | Variant                   |
-            +--------+---------------------------+
-            |        | +---------------+ +-----+ |
-            |      0 | | WrapA.o       | | B.o | | <- OK
-            |        | +---------------+ |     | |
-            |        | | +-----------+ | +-----+ |
-            |      8 | | | WrapA.a.i | | | B.x | |
-            |        | | +-----------+ | +-----+ |
-            |     16 | | | WrapA.a.j | |         |
-            |        | | +-----------+ |         |
-            |        | +---------------+         |
-            +------------------------------------+
-
-            This layout no longer causes exceptions and can be loaded but at the cost
-            of extra memory consumption and unused "dummy" fields.
-
-            We still have one issue though: where do we put the discriminator (the
-            integer telling us which value is "active" in the Variant)? It needs to
-            always be at the same memory location regardless of the currently active
-            type. We also cannot force it to offset 0 because that's where the managed
-            types will go. The solution here is an extra level of indirection:
-
-                Put all the WrapX types inside a new struct with the explicit layout
-                and leave the discriminator integer outside:
-
-            [StructLayout(LayoutKind.Explicit)]
-            struct Values
-            {
-                [FieldOffset(0)] public WrapA a;
-                [FieldOffset(0)] public WrapB b;
-                ...
-                [FieldOffset(0)] public WrapN n;
-            }
-
-            class Variant { private int discriminator; private Values values; }
-
-            +--------+-------------------------------------+
-            | offset | Variant                             |
-            +--------+-------------------------------------+
-            |      0 | discriminator                       |
-            +--------+-------------------------------------+
-            |        | values                              |
-            |        | +---------------------------------+ |
-            |        | | +---------------+ +-----------+ | |
-            |      8 | | | WrapA.o       | | WrapB.b.o | | |
-            |        | | +---------------+ |           | | |
-            |        | | | +-----------+ | +-----------+ | |
-            |     16 | | | | WrapA.a.i | | | WrapB.b.x | | |
-            |        | | | +-----------+ | +-----------+ | |
-            |     24 | | | | WrapA.a.j | |               | |
-            |        | | | +-----------+ |               | |
-            |        | | +---------------+               | |
-            |        | +---------------------------------+ |
-            +--------+-------------------------------------+
-
-            While this results in some overhead, as the Variant's size is
-            the sum of max(object fields) + max(non-object fields) for all
-            possible values it can hold, it allows for the elision of boxing
-            for value types and still consumes *much* less memory than if
-            it had to store all values side-by-side.
-            ## ~}}
-
-            {{~ ## STORAGE CONSTRUCTORS ## ~}}
-            {{~ for $p in Params ~}}
-            public _VariantStorage({{ value_type $p }} {{ $p.Hint }})
-            {
-                _n = {{ $p.Index }};
-                _x = new Union({{ $p.Hint }});
-            }
-            {{~ end ~}}
-
-            {{~ if needs_dispose ~}}
-            public void Dispose()
-            {
-                switch (_n)
-                {
-                    case 0:
-                        break;
-                    {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        {{~ if $p.IsDisposable ~}}
-                        {{ coalesce $p ("_x._" + $p.Index + ".Value") ".Dispose()" }};
-                        {{~ end ~}}
-                        break;
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-
-                }
-            }
-            {{~ end ~}}
-
-            {{~ ## UNION TYPE ## ~}}
-            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-            [global::System.Diagnostics.DebuggerNonUserCode]
-            private readonly struct Union
-            {
-                {{~ ## UNION MEMBERS ## ~}}
-                {{~ for $p in Params ~}}
-                [global::System.Runtime.InteropServices.FieldOffset(0)]
-                public readonly Union{{ $p.Index }} _{{ $p.Index }};
-                {{~ end ~}}
-
-                {{~ ## UNION CONSTRUCTORS ## ~}}
-                {{~ for $p in Params ~}}
-                public Union({{ value_type $p }} value)
-                {
-                    {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
-                    _{{ $other.Index }} = default;
-                    {{~ end ~}}
-                    _{{ $p.Index }} = new Union{{ $p.Index }}(value);
-                }
-                {{~ end ~}}
-
-                {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
-                {{~ for $p in Params ~}}
-                [global::System.Diagnostics.DebuggerNonUserCode]
-                public readonly struct Union{{ $p.Index }}
-                {
-                    public readonly {{ value_type $p }} Value;
-                    {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-                    public readonly object _dummy{{ $dummy }};
-                    {{~ end ~}}
-
-                    public Union{{ $p.Index }}({{ value_type $p }} value)
-                    {
-                        {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-                        _dummy{{ $dummy }} = null{{ global_forgive }};
-                        {{~ end ~}}
-                        Value = value;
-                    }
-                }
-                {{~ end ~}}
-            }
-
-            {{~ ## UNION IsEmpty ## ~}}
-            public bool IsEmpty => _n == 0;
-
-            {{~ ## UNION TypeString ## ~}}
-            public string TypeString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "<empty>";
-                        {{~ for $p in Params ~}}
-                        case {{ $p.Index }}:
-                            return "{{ $p.DiagName }}";
-                        {{~ end ~}}
-                        default:
-                            throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                    }
-                }
-            }
-
-            {{~ ## UNION ValueString ## ~}}
-            public string ValueString
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return "";
-                        {{~ for $p in Params ~}}
-                        case {{ $p.Index }}:
-                            return {{ coalesce_ToString $p (storage $p) }};
-                        {{~ end ~}}
-                        default:
-                            throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                    }
-                }
-            }
-
-            {{~ ## UNION AsObject ## ~}}
-            public object{{ global_nullable }} AsObject
-            {
-                get
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return null;
-                        {{~ for $p in Params ~}}
-                        case {{ $p.Index }}:
-                            return {{ storage $p }};
-                        {{~ end ~}}
-                        default:
-                            throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                    }
-                }
-            }
-
-            {{~ ## UNION Equals ## ~}}
-            public bool Equals(in _VariantStorage other)
-            {
-                if (_n != other._n)
-                {
-                    return false;
-                }
-                switch (_n)
-                {
-                    case 0:
-                        return true;
-                    {{~ for $p in Params ~}}
-                    {{~ $i = $p.Index ~}}
-                    case {{ $i }}:
-                        return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ storage $p }}, other.{{ storage $p }});
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                }
-            }
-
-            {{~ ## UNION GetHashCode ## ~}}
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    switch (_n)
-                    {
-                        case 0:
-                            return 0;
-                        {{~ for $p in Params ~}}
-                        {{~ $i = $p.Index ~}}
-                        case {{ $i }}:
-                            {{~ if Runtime.HasHashCode ~}}
-                            return global::System.HashCode.Combine({{ storage $p }});
-                            {{~ else ~}}
-                            return {{ coalesce $p (storage $p) ".GetHashCode()" "0"}};
-                            {{~ end ~}}
-                        {{~ end ~}}
-                        default:
-                            throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                    }
-                }
-            }
-
-            {{~ ## UNION TryMatch ## ~}}
-            {{~ for $p in Params ~}}
-            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
-            {
-                {{ $p.Hint }} = _n == {{ $p.Index }} ? {{ storage $p }} : default;
-                return _n == {{ $p.Index }};
-            }
-            {{~ end ~}}
-
-            {{~ ## UNION Visit(Action) ## ~}}
-            public void Visit({{ action_params }}, global::System.Action _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        _();
-                        break;
-                    {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        {{ $p.Hint }}({{ storage $p }});
-                        break;
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                }
-            }
-
-            {{~ ## UNION Visit(Action) ## ~}}
-            public void Visit({{ action_params }})
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
-                    {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        {{ $p.Hint }}({{ storage $p }});
-                        break;
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                }
-            }
-
-            {{~ ## UNION Visit(Func) ## ~}}
-            public TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
-            {
-                switch (_n)
-                {
-                    case 0:
-                        return _();
-                    {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ storage $p }});
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                }
-            }
-
-            {{~ ## UNION Visit(Func) ## ~}}
-            public TResult Visit<TResult>({{ func_params }})
-            {
-                switch (_n)
-                {
-                    case 0:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
-                    {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ storage $p }});
-                    {{~ end ~}}
-                    default:
-                        throw new global::System.InvalidOperationException("{{ Variant.Name }} is in a corrupted state.");
-                }
-            }
-        }
+        private readonly {{ storage_type }} _variant;
 
         {{~ ## VARIANT CONSTRUCTORS ## ~}}
         {{~ for $p in Params ~}}
@@ -530,7 +158,7 @@ namespace {{ Variant.Namespace }}
         /// </summary>
         /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
         public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
-            => _variant = new _VariantStorage({{ $p.Hint }});
+            => _variant = new {{ storage_type }}({{ $p.Hint }});
         {{~ end ~}}
 
         {{~ ## IMPLICIT CONVERSIONS ## ~}}
@@ -609,7 +237,11 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ $p.Name }}"/></exception>
         public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
         {
-            if (!_variant.TryMatch(out {{ forgive $p $p.Hint }}))
+            if ({{ get_n }} == {{ $p.Index }})
+            {
+                {{ $p.Hint }} = {{ get_value $p }};
+            }
+            else
             {
                 {{ throw_InvalidOperation $p.DiagName "{_variant.TypeString}" }};
             }
@@ -624,7 +256,18 @@ namespace {{ Variant.Namespace }}
         /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ $p.Name }}"/>.</param>
         /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ $p.Name }}"/>.</returns>
         public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
-            => _variant.TryMatch(out {{ $p.Hint }});
+        {
+            if ({{ get_n }} == {{ $p.Index }})
+            {
+                {{ $p.Hint }} = {{ get_value $p }};
+                return true;
+            }
+            else
+            {
+                {{ $p.Hint }} = default;
+                return false;
+            }
+        }
         {{~ end ~}}
 
         {{~ ## VARIANT TryMatch(Action<T>) ## ~}}
@@ -637,12 +280,15 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
         public {{ method_modifiers }}bool TryMatch({{ action_type $p }} {{ $p.Hint }})
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                {{ $p.Hint }}({{ forgive $p "_value" }});
+                {{ $p.Hint }}({{ get_value $p }});
                 return true;
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
         {{~ end ~}}
 
@@ -657,9 +303,9 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
         public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }})
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                {{ $p.Hint }}({{ forgive $p "_value" }});
+                {{ $p.Hint }}({{ get_value $p }});
             }
             else
             {
@@ -679,9 +325,9 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
         public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }}, global::System.Action _)
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                {{ $p.Hint }}({{ forgive $p "_value" }});
+                {{ $p.Hint }}({{ get_value $p }});
             }
             else
             {
@@ -702,9 +348,9 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }})
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                return {{ $p.Hint }}({{ forgive $p "_value" }});
+                return {{ $p.Hint }}({{ get_value $p }});
             }
             else
             {
@@ -725,9 +371,9 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="other"> is rethrown.</exception>
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, TResult _)
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                return {{ $p.Hint }}({{ forgive $p "_value" }});
+                return {{ $p.Hint }}({{ get_value $p }});
             }
             else
             {
@@ -747,9 +393,9 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, global::System.Func<TResult> _)
         {
-            if (_variant.TryMatch(out {{ outref_type $p }} _value))
+            if ({{ get_n }} == {{ $p.Index }})
             {
-                return {{ $p.Hint }}({{ forgive $p "_value" }});
+                return {{ $p.Hint }}({{ get_value $p }});
             }
             else
             {
@@ -769,7 +415,20 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public {{ method_modifiers }}void Visit({{ action_params }})
-            => _variant.Visit({{ Params | array.each @param_hint | array.join ", " }});
+        {
+            switch ({{ get_n }})
+            {
+                case 0:
+                    throw {{ empty_exception }};
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    {{ $p.Hint }}({{ get_value $p }});
+                    break;
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
 
         {{~ ## VARIANT Visit(Action<A>, Action<B>, ..., empty) ## ~}}
         /// <summary>
@@ -782,7 +441,21 @@ namespace {{ Variant.Namespace }}
         /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public {{ method_modifiers }}void Visit({{ action_params }}, global::System.Action _)
-            => _variant.Visit({{ Params | array.each @param_hint | array.join ", "  }}, _);
+        {
+            switch ({{ get_n }})
+            {
+                case 0:
+                    _();
+                    break;
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    {{ $p.Hint }}({{ get_value $p }});
+                    break;
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ...) ## ~}}
         /// <summary>
@@ -796,7 +469,19 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public {{ method_modifiers }}TResult Visit<TResult>({{ func_params }})
-            => _variant.Visit({{ Params | array.each @param_hint | array.join ", "  }});
+        {
+            switch ({{ get_n }})
+            {
+                case 0:
+                    throw {{ empty_exception }};
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    return {{ $p.Hint }}({{ get_value $p }});
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ..., empty) ## ~}}
         /// <summary>
@@ -810,146 +495,43 @@ namespace {{ Variant.Namespace }}
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public {{ method_modifiers }}TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
-            => _variant.Visit({{ Params | array.each @param_hint | array.join ", "  }}, _);
+        {
+            switch ({{ get_n }})
+            {
+                case 0:
+                    return _();
+                {{~ for $p in Params ~}}
+                case {{ $p.Index }}:
+                    return {{ $p.Hint }}({{ get_value $p }});
+                {{~ end ~}}
+                default:
+                    throw {{ corrupt_exception }};
+            }
+        }
+
+        private sealed class _VariantTypeProxy
+        {
+            public object{{ global_nullable }} Value { get; }
+            public _VariantTypeProxy({{ Variant.Name }} v)
+            {
+                Value = v._variant.AsObject;
+                {{~ # Force a reference to the VariantOf function so the user doesn't get IDE0051 "Private member 'VariantOf' is unused." ~}}
+                VariantOf({{ Params | array.each @(do; ret forgive $0 "default"; end) | array.join ", " }});
+            }
+        }
+
+        {{~ ## INTERNAL ACCESS ## ~}}
+        public static explicit operator {{ storage_type }}_N({{ Variant.Name }} v) => ({{ storage_type }}_N)v._variant;
+        {{~ for $p in Params ~}}
+        public static explicit operator {{ storage_type }}_{{ $p.Index }}({{ Variant.Name }} v) => ({{ storage_type }}_{{ $p.Index }})v._variant;
+        {{~ end ~}}
     }
 {{~ if Variant.Namespace ~}}
 }
 {{~ end ~}}
 
+{{ include "Union" }}
+
 {{~ if Variant.ExtensionsAccessibility ~}}
-{{~ if Options.ExtensionClassNamespace ~}}
-namespace {{ Options.ExtensionClassNamespace }}
-{
-{{~ end ~}}
-    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
-    {
-        {{~ ## Match(IEnumerable<V>, Func<A, R>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ $p.Name }}"/> and dropping all others.
-        /// </summary>
-        /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
-        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
-        public static global::System.Collections.Generic.IEnumerable<TResult>
-            Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }})
-        {
-            foreach (var variant in source)
-            {
-                if (variant.TryMatch(out {{ outref_type $p }} value))
-                {
-                    yield return {{ $p.Hint }}(value);
-                }
-            }
-        }
-        {{~ end ~}}
-
-        {{~ ## Match(IEnumerable<V>, Func<A, R>, R) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others by a fallback value.
-        /// </summary>
-        /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
-        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
-        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
-        public static global::System.Collections.Generic.IEnumerable<TResult>
-            Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
-                TResult _)
-        {
-            foreach (var variant in source)
-            {
-                yield return variant.Match({{ $p.Hint }}, _);
-            }
-        }
-        {{~ end ~}}
-
-        {{~ ## Match(IEnumerable<V>, Func<A, R>, Func<R>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ $p.Name }}"/> and replacing all others with the result of a fallback selector.
-        /// </summary>
-        /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
-        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
-        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
-        public static global::System.Collections.Generic.IEnumerable<TResult>
-            Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
-                global::System.Func<TResult> _)
-        {
-            foreach (var variant in source)
-            {
-                yield return variant.Match({{ $p.Hint }}, _);
-            }
-        }
-        {{~ end ~}}
-
-        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ...) ## ~}}
-        /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
-        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
-        /// if an element is empty.
-        /// </summary>
-        /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty {{ Variant.Name }}.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
-        public static global::System.Collections.Generic.IEnumerable<TResult>
-            Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_params }})
-        {
-            foreach (var variant in source)
-            {
-                yield return variant.Visit({{ Params | array.each @param_hint | array.join ", "  }});
-            }
-        }
-
-        {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ..., empty) ## ~}}
-        /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
-        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
-        /// </summary>
-        /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <param name="_">The delegate to invoke if an element is empty.</param>
-        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
-        public static global::System.Collections.Generic.IEnumerable<TResult>
-            Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_params }},
-                global::System.Func<TResult> _)
-        {
-            foreach (var variant in source)
-            {
-                yield return variant.Visit({{ Params | array.each @param_hint | array.join ", "  }}, _);
-            }
-        }
-    }
-{{~ if Options.ExtensionClassNamespace ~}}
-}
-{{~ end ~}}
+{{~ include "IEnumerable" ~}}
 {{~ end ~}}


### PR DESCRIPTION
- Instead of nesting everything inside a single private class generate
  new types in a separate namespace with hopefully obscure enough name
  users won't try to access it.
- Add explicit conversions towards these "implementation detail" types
  giving out-of-class generated methods direct access to the private
  values without exposing them in the public interface. This direct
  access should improve code generation and inlining potential by
  eliminating the amount of closures/delegates being passed around.
- Split the generator into multiple template files as its getting rather
  big.