### PR TITLE
Outline throw statements for cold paths

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -555,7 +555,8 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
+                    break;
                 case 1:
                     i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
                     break;
@@ -565,9 +566,8 @@ namespace Foo
                 case 3:
                     s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -595,9 +595,8 @@ namespace Foo
                 case 3:
                     s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-            }
+                }
+            global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -615,16 +614,15 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError<TResult>();
                 case 1:
                     return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
                 case 2:
                     return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
                 case 3:
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -649,9 +647,8 @@ namespace Foo
                     return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
                 case 3:
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -701,6 +698,34 @@ namespace dotVariant._G.Foo
         public static explicit operator Variant_class_nullable_disable_2(Variant_class_nullable_disable v) => v._x._2;
         public static explicit operator Variant_class_nullable_disable_3(Variant_class_nullable_disable v) => v._x._3;
 
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
         public bool IsEmpty => _n == 0;
 
         public string TypeString
@@ -717,9 +742,8 @@ namespace dotVariant._G.Foo
                         return "float";
                     case 3:
                         return "string";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -737,9 +761,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -757,9 +780,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<object>();
             }
         }
 
@@ -779,9 +801,8 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -798,9 +819,8 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -836,9 +856,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     s(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
@@ -846,7 +865,8 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                    ThrowEmptyError();
+                    break;
                 case 1:
                     i(_x._1.Value);
                     break;
@@ -856,9 +876,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     s(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
@@ -873,9 +892,8 @@ namespace dotVariant._G.Foo
                     return f(_x._2.Value);
                 case 3:
                     return s(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
@@ -883,16 +901,15 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                    return ThrowEmptyError<TResult>();
                 case 1:
                     return i(_x._1.Value);
                 case 2:
                     return f(_x._2.Value);
                 case 3:
                     return s(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
     }
 
@@ -1234,7 +1251,8 @@ namespace Foo
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N)
                 {
                     case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
+                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
+                        yield break;
                     case 1:
                         yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
                         break;
@@ -1245,7 +1263,8 @@ namespace Foo
                         yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -1285,7 +1304,8 @@ namespace Foo
                         yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -719,7 +719,8 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
+                    break;
                 case 1:
                     i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
                     break;
@@ -732,9 +733,8 @@ namespace Foo
                 case 4:
                     a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -766,9 +766,8 @@ namespace Foo
                 case 4:
                     a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-            }
+                }
+            global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -787,7 +786,7 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError<TResult>();
                 case 1:
                     return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
                 case 2:
@@ -796,9 +795,8 @@ namespace Foo
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
                 case 4:
                     return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -826,9 +824,8 @@ namespace Foo
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
                 case 4:
                     return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -885,6 +882,34 @@ namespace dotVariant._G.Foo
         public static explicit operator Variant_class_nullable_enable_3(Variant_class_nullable_enable v) => v._x._3;
         public static explicit operator Variant_class_nullable_enable_4(Variant_class_nullable_enable v) => v._x._4;
 
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
         public bool IsEmpty => _n == 0;
 
         public string TypeString
@@ -903,9 +928,8 @@ namespace dotVariant._G.Foo
                         return "string";
                     case 4:
                         return "System.Array?";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -925,9 +949,8 @@ namespace dotVariant._G.Foo
                         return _x._3.Value.ToString();
                     case 4:
                         return _x._4.Value?.ToString() ?? "null";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -947,9 +970,8 @@ namespace dotVariant._G.Foo
                         return _x._3.Value;
                     case 4:
                         return _x._4.Value;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<object?>();
             }
         }
 
@@ -971,9 +993,8 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
                 case 4:
                     return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -992,9 +1013,8 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._3.Value);
                     case 4:
                         return global::System.HashCode.Combine(_x._4.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -1038,9 +1058,8 @@ namespace dotVariant._G.Foo
                 case 4:
                     a(_x._4.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
@@ -1048,7 +1067,8 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                    ThrowEmptyError();
+                    break;
                 case 1:
                     i(_x._1.Value);
                     break;
@@ -1061,9 +1081,8 @@ namespace dotVariant._G.Foo
                 case 4:
                     a(_x._4.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
@@ -1080,9 +1099,8 @@ namespace dotVariant._G.Foo
                     return s(_x._3.Value);
                 case 4:
                     return a(_x._4.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
@@ -1090,7 +1108,7 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                    return ThrowEmptyError<TResult>();
                 case 1:
                     return i(_x._1.Value);
                 case 2:
@@ -1099,9 +1117,8 @@ namespace dotVariant._G.Foo
                     return s(_x._3.Value);
                 case 4:
                     return a(_x._4.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
     }
 
@@ -1544,7 +1561,8 @@ namespace Foo
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N)
                 {
                     case 0:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
+                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
+                        yield break;
                     case 1:
                         yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
                         break;
@@ -1558,7 +1576,8 @@ namespace Foo
                         yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -1602,7 +1621,8 @@ namespace Foo
                         yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -398,16 +398,16 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
+                    break;
                 case 1:
                     i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                     break;
                 case 2:
                     stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
         }
 
         /// <summary>
@@ -431,9 +431,8 @@ namespace Foo
                 case 2:
                     stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-            }
+                }
+            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
         }
 
         /// <summary>
@@ -450,14 +449,13 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
                 case 1:
                     return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                 case 2:
                     return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -479,9 +477,8 @@ namespace Foo
                     return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                 case 2:
                     return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -531,14 +528,41 @@ namespace dotVariant._G.Foo
                 case 2:
                     _x._2.Value?.Dispose();
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public static explicit operator Variant_disposable_N(Variant_disposable v) => new Variant_disposable_N(v._n);
         public static explicit operator Variant_disposable_1(Variant_disposable v) => v._x._1;
         public static explicit operator Variant_disposable_2(Variant_disposable v) => v._x._2;
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
 
         public bool IsEmpty => _n == 0;
 
@@ -554,9 +578,8 @@ namespace dotVariant._G.Foo
                         return "int";
                     case 2:
                         return "System.IO.Stream";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -572,9 +595,8 @@ namespace dotVariant._G.Foo
                         return _x._1.Value.ToString();
                     case 2:
                         return _x._2.Value?.ToString() ?? "null";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -590,9 +612,8 @@ namespace dotVariant._G.Foo
                         return _x._1.Value;
                     case 2:
                         return _x._2.Value;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<object>();
             }
         }
 
@@ -610,9 +631,8 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                 case 2:
                     return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -627,9 +647,8 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._1.Value);
                     case 2:
                         return global::System.HashCode.Combine(_x._2.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -657,9 +676,8 @@ namespace dotVariant._G.Foo
                 case 2:
                     stream(_x._2.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
@@ -667,16 +685,16 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    ThrowEmptyError();
+                    break;
                 case 1:
                     i(_x._1.Value);
                     break;
                 case 2:
                     stream(_x._2.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
@@ -689,9 +707,8 @@ namespace dotVariant._G.Foo
                     return i(_x._1.Value);
                 case 2:
                     return stream(_x._2.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
@@ -699,14 +716,13 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                    return ThrowEmptyError<TResult>();
                 case 1:
                     return i(_x._1.Value);
                 case 2:
                     return stream(_x._2.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
     }
 
@@ -947,7 +963,8 @@ namespace Foo
                 switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
                 {
                     case 0:
-                        throw new global::System.InvalidOperationException("Variant_disposable is empty.");
+                        global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
+                        yield break;
                     case 1:
                         yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
                         break;
@@ -955,7 +972,8 @@ namespace Foo
                         yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -991,7 +1009,8 @@ namespace Foo
                         yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -554,7 +554,8 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
+                    break;
                 case 1:
                     l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
                     break;
@@ -564,9 +565,8 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -594,9 +594,8 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-            }
+                }
+            global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -614,16 +613,15 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError<TResult>();
                 case 1:
                     return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
                 case 2:
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -648,9 +646,8 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -700,6 +697,34 @@ namespace dotVariant._G.Foo
         public static explicit operator Variant_struct_nullable_disable_2(Variant_struct_nullable_disable v) => v._x._2;
         public static explicit operator Variant_struct_nullable_disable_3(Variant_struct_nullable_disable v) => v._x._3;
 
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
         public bool IsEmpty => _n == 0;
 
         public string TypeString
@@ -716,9 +741,8 @@ namespace dotVariant._G.Foo
                         return "double";
                     case 3:
                         return "object";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -736,9 +760,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -756,9 +779,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<object>();
             }
         }
 
@@ -778,9 +800,8 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -797,9 +818,8 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -835,9 +855,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
@@ -845,7 +864,8 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                    ThrowEmptyError();
+                    break;
                 case 1:
                     l(_x._1.Value);
                     break;
@@ -855,9 +875,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
@@ -872,9 +891,8 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
@@ -882,16 +900,15 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                    return ThrowEmptyError<TResult>();
                 case 1:
                     return l(_x._1.Value);
                 case 2:
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
     }
 
@@ -1233,7 +1250,8 @@ namespace Foo
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N)
                 {
                     case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
+                        yield break;
                     case 1:
                         yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
                         break;
@@ -1244,7 +1262,8 @@ namespace Foo
                         yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -1284,7 +1303,8 @@ namespace Foo
                         yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -554,7 +554,8 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
+                    break;
                 case 1:
                     l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
                     break;
@@ -564,9 +565,8 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -594,9 +594,8 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-            }
+                }
+            global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -614,16 +613,15 @@ namespace Foo
             switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError<TResult>();
                 case 1:
                     return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
                 case 2:
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -648,9 +646,8 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -700,6 +697,34 @@ namespace dotVariant._G.Foo
         public static explicit operator Variant_struct_nullable_enable_2(Variant_struct_nullable_enable v) => v._x._2;
         public static explicit operator Variant_struct_nullable_enable_3(Variant_struct_nullable_enable v) => v._x._3;
 
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
         public bool IsEmpty => _n == 0;
 
         public string TypeString
@@ -716,9 +741,8 @@ namespace dotVariant._G.Foo
                         return "double";
                     case 3:
                         return "object";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -736,9 +760,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value.ToString() ?? "null";
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -756,9 +779,8 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<object?>();
             }
         }
 
@@ -778,9 +800,8 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -797,9 +818,8 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
-                    default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -835,9 +855,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
@@ -845,7 +864,8 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                    ThrowEmptyError();
+                    break;
                 case 1:
                     l(_x._1.Value);
                     break;
@@ -855,9 +875,8 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
@@ -872,9 +891,8 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
@@ -882,16 +900,15 @@ namespace dotVariant._G.Foo
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                    return ThrowEmptyError<TResult>();
                 case 1:
                     return l(_x._1.Value);
                 case 2:
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
-                default:
-                    throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
             }
+            return ThrowInternalError<TResult>();
         }
     }
 
@@ -1233,7 +1250,8 @@ namespace Foo
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N)
                 {
                     case 0:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
+                        yield break;
                     case 1:
                         yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
                         break;
@@ -1244,7 +1262,8 @@ namespace Foo
                         yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -1284,7 +1303,8 @@ namespace Foo
                         yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
                         break;
                     default:
-                        throw new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
@@ -131,14 +131,16 @@ namespace {{ Options.ExtensionClassNamespace }}
                 switch ({{ $get_n }})
                 {
                     case 0:
-                        throw {{ empty_exception }};
+                        {{ storage_type }}.ThrowEmptyError();
+                        yield break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
                         yield return {{ $p.Hint }}({{ $get_value $p }});
                         break;
                     {{~ end ~}}
                     default:
-                        throw {{ corrupt_exception }};
+                        {{ storage_type }}.ThrowInternalError();
+                        yield break;
                 }
             }
         }
@@ -175,7 +177,8 @@ namespace {{ Options.ExtensionClassNamespace }}
                         break;
                     {{~ end ~}}
                     default:
-                        throw {{ corrupt_exception }};
+                        {{ storage_type }}.ThrowInternalError();
+                        yield break;
                 }
             }
         }

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -153,9 +153,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     {{~ end ~}}
                     break;
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            ThrowInternalError();
         }
         {{~ end ~}}
 
@@ -164,6 +163,42 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
         {{~ for $p in Params ~}}
         public static explicit operator {{ Variant.Name }}_{{ $p.Index }}({{ Variant.Name }} v) => v._x._{{ $p.Index }};
         {{~ end ~}}
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        {{~ if Language.Version >= 800 ~}}
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        {{~ end ~}}
+        public static void ThrowEmptyError()
+        {
+            throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        {{~ if Language.Version >= 800 ~}}
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        {{~ end ~}}
+        public static T ThrowEmptyError<T>()
+        {
+            throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        {{~ if Language.Version >= 800 ~}}
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        {{~ end ~}}
+        public static void ThrowInternalError()
+        {
+            throw new global::System.InvalidOperationException("{{ Variant.Name }} has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        {{~ if Language.Version >= 800 ~}}
+        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        {{~ end ~}}
+        public static T ThrowInternalError<T>()
+        {
+            throw new global::System.InvalidOperationException("{{ Variant.Name }} has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
 
         {{~ ## UNION IsEmpty ## ~}}
         public bool IsEmpty => _n == 0;
@@ -181,9 +216,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return "{{ $p.DiagName }}";
                     {{~ end ~}}
-                    default:
-                        throw {{ corrupt_exception }};
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -200,9 +234,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return {{ coalesce_ToString $p ($storage $p) }};
                     {{~ end ~}}
-                    default:
-                        throw {{ corrupt_exception }};
                 }
+                return ThrowInternalError<string>();
             }
         }
 
@@ -219,9 +252,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return {{ $storage $p }};
                     {{~ end ~}}
-                    default:
-                        throw {{ corrupt_exception }};
                 }
+                return ThrowInternalError<object{{ global_nullable }}>();
             }
         }
 
@@ -241,9 +273,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                 case {{ $i }}:
                     return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            return ThrowInternalError<bool>();
         }
 
         {{~ ## UNION GetHashCode ## ~}}
@@ -264,9 +295,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                         return {{ coalesce $p ($storage $p) ".GetHashCode()" "0"}};
                         {{~ end ~}}
                     {{~ end ~}}
-                    default:
-                        throw {{ corrupt_exception }};
                 }
+                return ThrowInternalError<int>();
             }
         }
 
@@ -292,9 +322,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     {{ $p.Hint }}({{ $storage $p }});
                     break;
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            ThrowInternalError();
         }
 
         {{~ ## UNION Visit(Action) ## ~}}
@@ -303,15 +332,15 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
             switch (_n)
             {
                 case 0:
-                    throw new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
+                    ThrowEmptyError();
+                    break;
                 {{~ for $p in Params ~}}
                 case {{ $p.Index }}:
                     {{ $p.Hint }}({{ $storage $p }});
                     break;
-                {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
+                    {{~ end ~}}
             }
+            ThrowInternalError();
         }
 
         {{~ ## UNION Visit(Func) ## ~}}
@@ -325,9 +354,8 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ $storage $p }});
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            return ThrowInternalError<TResult>();
         }
 
         {{~ ## UNION Visit(Func) ## ~}}
@@ -336,14 +364,13 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
             switch (_n)
             {
                 case 0:
-                    throw {{ empty_exception }};
+                    return ThrowEmptyError<TResult>();
                 {{~ for $p in Params ~}}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ $storage $p }});
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -117,8 +117,6 @@ param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 
 global_nullable = emit_nullability ? "?" : ""
 global_forgive = emit_nullability ? "!" : ""
 needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
-empty_exception = "new global::System.InvalidOperationException(\"" + Variant.Name + " is empty.\")"
-corrupt_exception = "new global::System.InvalidOperationException(\"" + Variant.Name + " has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant\")"
 
 readonly storage_type
 readonly get_value
@@ -129,8 +127,6 @@ readonly param_modifiers
 readonly global_nullable
 readonly global_forgive
 readonly needs_dispose
-readonly empty_exception
-readonly corrupt_string
 ~}}
 {{~ if Language.Version >= 800 ~}}
 #nullable {{ Language.Nullable }}
@@ -419,15 +415,15 @@ namespace {{ Variant.Namespace }}
             switch ({{ get_n }})
             {
                 case 0:
-                    throw {{ empty_exception }};
+                    {{ storage_type }}.ThrowEmptyError();
+                    break;
                 {{~ for $p in Params ~}}
                 case {{ $p.Index }}:
                     {{ $p.Hint }}({{ get_value $p }});
                     break;
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            {{ storage_type }}.ThrowInternalError();
         }
 
         {{~ ## VARIANT Visit(Action<A>, Action<B>, ..., empty) ## ~}}
@@ -452,9 +448,8 @@ namespace {{ Variant.Namespace }}
                     {{ $p.Hint }}({{ get_value $p }});
                     break;
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
-            }
+                }
+            {{ storage_type }}.ThrowInternalError();
         }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ...) ## ~}}
@@ -473,14 +468,13 @@ namespace {{ Variant.Namespace }}
             switch ({{ get_n }})
             {
                 case 0:
-                    throw {{ empty_exception }};
+                    return {{ storage_type }}.ThrowEmptyError<TResult>();
                 {{~ for $p in Params ~}}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ get_value $p }});
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            return {{ storage_type }}.ThrowInternalError<TResult>();
         }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ..., empty) ## ~}}
@@ -504,9 +498,8 @@ namespace {{ Variant.Namespace }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ get_value $p }});
                 {{~ end ~}}
-                default:
-                    throw {{ corrupt_exception }};
             }
+            return {{ storage_type }}.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy


### PR DESCRIPTION
The internal error case is hopefully never hit, so moving it out of the
hot path reduces the size of the generated code without affecting
performance.

The empty path should be hit rarely, at least for functions that have no
dedicated empty handler, so the same principle applies.