### PR TITLE
Correctly handle access modifiers of generated code

### DIFF
--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -45,6 +45,7 @@ namespace dotVariant.Generator.Test
                     ("Variant-class-nullable-disable", "Foo.Variant_class_nullable_disable"),
                     ("Variant-class-nullable-enable", "Foo.Variant_class_nullable_enable"),
                     ("Variant-disposable", "Foo.Variant_disposable"),
+                    ("Variant-public", "Foo.Variant_public"),
                     ("Variant-struct-nullable-disable", "Foo.Variant_struct_nullable_disable"),
                     ("Variant-struct-nullable-enable", "Foo.Variant_struct_nullable_enable"),
                 }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -923,7 +923,7 @@ namespace dotVariant._G.Foo
         }
     }
 
-    internal readonly ref struct Variant_class_nullable_disable_N
+    public readonly ref struct Variant_class_nullable_disable_N
     {
         public readonly uint N;
         public Variant_class_nullable_disable_N(uint n) => N = n;
@@ -961,7 +961,7 @@ namespace dotVariant._G.Foo
     }
 
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_disable_1
+    public readonly struct Variant_class_nullable_disable_1
     {
         public readonly int Value;
         public readonly object _dummy1;
@@ -973,7 +973,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_disable_2
+    public readonly struct Variant_class_nullable_disable_2
     {
         public readonly float Value;
         public readonly object _dummy1;
@@ -985,7 +985,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_disable_3
+    public readonly struct Variant_class_nullable_disable_3
     {
         public readonly string Value;
 

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -1132,7 +1132,7 @@ namespace dotVariant._G.Foo
         }
     }
 
-    internal readonly ref struct Variant_class_nullable_enable_N
+    public readonly ref struct Variant_class_nullable_enable_N
     {
         public readonly uint N;
         public Variant_class_nullable_enable_N(uint n) => N = n;
@@ -1182,7 +1182,7 @@ namespace dotVariant._G.Foo
     }
 
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable_1
+    public readonly struct Variant_class_nullable_enable_1
     {
         public readonly int Value;
         public readonly object _dummy1;
@@ -1194,7 +1194,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable_2
+    public readonly struct Variant_class_nullable_enable_2
     {
         public readonly float Value;
         public readonly object _dummy1;
@@ -1206,7 +1206,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable_3
+    public readonly struct Variant_class_nullable_enable_3
     {
         public readonly string Value;
 
@@ -1216,7 +1216,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable_4
+    public readonly struct Variant_class_nullable_enable_4
     {
         public readonly global::System.Array? Value;
 

--- a/src/dotVariant.Generator.Test/samples/Variant-public.in.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.in.cs
@@ -1,0 +1,15 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable disable
+namespace Foo
+{
+    [dotVariant.Variant]
+    public partial class Variant_public
+    {
+        static partial void VariantOf(int i, string s);
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -10,75 +10,68 @@ namespace Foo
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    partial class Variant_disposable
-        : global::System.IEquatable<Variant_disposable>
-        , global::System.IDisposable
+    partial class Variant_public
+        : global::System.IEquatable<Variant_public>
     {
         [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_disposable _variant;
+        private readonly global::dotVariant._G.Foo.Variant_public _variant;
 
         /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="int"/>.
+        /// Create a Variant_public with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
-        public Variant_disposable(int i)
-            => _variant = new global::dotVariant._G.Foo.Variant_disposable(i);
+        public Variant_public(int i)
+            => _variant = new global::dotVariant._G.Foo.Variant_public(i);
         /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
+        /// Create a Variant_public with a value of type <see cref="string"/>.
         /// </summary>
-        /// <param name="stream">The value to initlaize the variant with.</param>
-        public Variant_disposable(global::System.IO.Stream stream)
-            => _variant = new global::dotVariant._G.Foo.Variant_disposable(stream);
+        /// <param name="s">The value to initlaize the variant with.</param>
+        public Variant_public(string s)
+            => _variant = new global::dotVariant._G.Foo.Variant_public(s);
 
         /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">The value to initlaize the variant with.</param>
-        public static implicit operator Variant_disposable(int i)
-            => new Variant_disposable(i);
-        /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
-        /// </summary>
-        /// <param name="stream">The value to initlaize the variant with.</param>
-        public static implicit operator Variant_disposable(global::System.IO.Stream stream)
-            => new Variant_disposable(stream);
-
-        /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="int"/>.
+        /// Create a Variant_public with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
-        public static Variant_disposable Create(int i)
-            => new Variant_disposable(i);
+        public static implicit operator Variant_public(int i)
+            => new Variant_public(i);
         /// <summary>
-        /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
+        /// Create a Variant_public with a value of type <see cref="string"/>.
         /// </summary>
-        /// <param name="stream">The value to initlaize the variant with.</param>
-        public static Variant_disposable Create(global::System.IO.Stream stream)
-            => new Variant_disposable(stream);
-
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _variant.Dispose();
-        }
+        /// <param name="s">The value to initlaize the variant with.</param>
+        public static implicit operator Variant_public(string s)
+            => new Variant_public(s);
 
         /// <summary>
-        /// <see langword="true"/> if Variant_disposable was constructed without a value.
+        /// Create a Variant_public with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        public static Variant_public Create(int i)
+            => new Variant_public(i);
+        /// <summary>
+        /// Create a Variant_public with a value of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">The value to initlaize the variant with.</param>
+        public static Variant_public Create(string s)
+            => new Variant_public(s);
+
+
+        /// <summary>
+        /// <see langword="true"/> if Variant_public was constructed without a value.
         /// </summary>
         public bool IsEmpty
             => _variant.IsEmpty;
 
         public override bool Equals(object other)
-            => other is Variant_disposable v && Equals(v);
+            => other is Variant_public v && Equals(v);
 
-        public bool Equals(Variant_disposable other)
+        public bool Equals(Variant_public other)
             => !(other is null) && _variant.Equals(other._variant);
 
-        public static bool operator ==(Variant_disposable lhs, Variant_disposable rhs)
+        public static bool operator ==(Variant_public lhs, Variant_public rhs)
             => lhs?.Equals(rhs) ?? (rhs is null);
 
-        public static bool operator !=(Variant_disposable lhs, Variant_disposable rhs)
+        public static bool operator !=(Variant_public lhs, Variant_public rhs)
             => !(lhs == rhs);
 
         public override int GetHashCode()
@@ -88,50 +81,50 @@ namespace Foo
             => _variant.ValueString;
 
         /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
         /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+                i = ((global::dotVariant._G.Foo.Variant_public_1)_variant).Value;
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
             }
         }
         /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
-        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        public void Match(out global::System.IO.Stream stream)
+        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+        public void Match(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+                s = ((global::dotVariant._G.Foo.Variant_public_2)_variant).Value;
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
             }
         }
 
         /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>.
+        /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+                i = ((global::dotVariant._G.Foo.Variant_public_1)_variant).Value;
                 return true;
             }
             else
@@ -141,35 +134,35 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+        /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>.
         /// </summary>
-        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
-        public bool TryMatch(out global::System.IO.Stream stream)
+        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
+        public bool TryMatch(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+                s = ((global::dotVariant._G.Foo.Variant_public_2)_variant).Value;
                 return true;
             }
             else
             {
-                stream = default;
+                s = default;
                 return false;
             }
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>.
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 return true;
             }
             else
@@ -178,16 +171,16 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                 return true;
             }
             else
@@ -197,44 +190,44 @@ namespace Foo
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.IO.Stream> stream)
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+        public void Match(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
             }
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
         /// otherwise invoke an alternative delegate.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
@@ -242,9 +235,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
             }
             else
             {
@@ -252,17 +245,17 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
         /// otherwise invoke an alternative delegate.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
         /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+        public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
             else
             {
@@ -271,46 +264,46 @@ namespace Foo
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
         /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
         /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="stream"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
             else
             {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
+                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
             }
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
         /// otherwise return a provided value.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
@@ -319,9 +312,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
             }
             else
             {
@@ -329,18 +322,18 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
         /// otherwise return a provided value.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
         /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="stream"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
+        /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
             else
             {
@@ -349,7 +342,7 @@ namespace Foo
         }
 
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
         /// otherwise invoke an alternative delegate and return its result.
         /// </summary>
         /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
@@ -357,9 +350,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
             }
             else
             {
@@ -367,17 +360,17 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
         /// otherwise invoke an alternative delegate and return its result.
         /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
         /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
             else
             {
@@ -386,155 +379,140 @@ namespace Foo
         }
 
         /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable,
-        /// and throw an exception if Variant_disposable is empty.
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public,
+        /// and throw an exception if Variant_public is empty.
         /// </summary>
         /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
             {
                 case 0:
-                    global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
+                    global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                     break;
                 case 2:
-                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     break;
             }
-            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+            global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
         }
 
         /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable,
-        /// and invoke a special delegate if Variant_disposable is empty.
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public,
+        /// and invoke a special delegate if Variant_public is empty.
         /// </summary>
         /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                     break;
                 case 2:
-                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     break;
                 }
-            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+            global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
         }
 
         /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable and return the result,
-        /// and throw an exception if Variant_disposable is empty.
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public and return the result,
+        /// and throw an exception if Variant_public is empty.
         /// </summary>
         /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
             {
                 case 0:
-                    return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
+                    return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 case 2:
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
-            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+            return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
         }
 
         /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable and return the result,
-        /// and invoke a special delegate if Variant_disposable is empty and return its result.
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public and return the result,
+        /// and invoke a special delegate if Variant_public is empty and return its result.
         /// </summary>
         /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 case 2:
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
             }
-            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+            return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
         {
             public object Value { get; }
-            public _VariantTypeProxy(Variant_disposable v)
+            public _VariantTypeProxy(Variant_public v)
             {
                 Value = v._variant.AsObject;
                 VariantOf(default, default);
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_N(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_1(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_2(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_2)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_public_N(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_N)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_public_1(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_1)v._variant;
+        public static explicit operator global::dotVariant._G.Foo.Variant_public_2(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_2)v._variant;
     }
 }
 
 namespace dotVariant._G.Foo
 {
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_disposable
-        : global::System.IDisposable
+    internal readonly struct Variant_public
     {
-        private readonly Variant_disposable_Union _x;
+        private readonly Variant_public_Union _x;
         private readonly uint _n;
 
-        public Variant_disposable(int i)
+        public Variant_public(int i)
         {
             _n = 1;
-            _x = new Variant_disposable_Union(i);
+            _x = new Variant_public_Union(i);
         }
-        public Variant_disposable(global::System.IO.Stream stream)
+        public Variant_public(string s)
         {
             _n = 2;
-            _x = new Variant_disposable_Union(stream);
+            _x = new Variant_public_Union(s);
         }
 
-        public void Dispose()
-        {
-            switch (_n)
-            {
-                case 0:
-                    break;
-                case 1:
-                    break;
-                case 2:
-                    _x._2.Value?.Dispose();
-                    break;
-            }
-            ThrowInternalError();
-        }
 
-        public static explicit operator Variant_disposable_N(Variant_disposable v) => new Variant_disposable_N(v._n);
-        public static explicit operator Variant_disposable_1(Variant_disposable v) => v._x._1;
-        public static explicit operator Variant_disposable_2(Variant_disposable v) => v._x._2;
+        public static explicit operator Variant_public_N(Variant_public v) => new Variant_public_N(v._n);
+        public static explicit operator Variant_public_1(Variant_public v) => v._x._1;
+        public static explicit operator Variant_public_2(Variant_public v) => v._x._2;
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -552,7 +530,7 @@ namespace dotVariant._G.Foo
 
         public static global::System.Exception MakeEmptyError()
         {
-            return new global::System.InvalidOperationException("Variant_disposable is empty.");
+            return new global::System.InvalidOperationException("Variant_public is empty.");
         }
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -571,7 +549,7 @@ namespace dotVariant._G.Foo
 
         public static global::System.Exception MakeInternalError()
         {
-            return new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+            return new global::System.InvalidOperationException("Variant_public has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
         }
 
         public bool IsEmpty => _n == 0;
@@ -587,7 +565,7 @@ namespace dotVariant._G.Foo
                     case 1:
                         return "int";
                     case 2:
-                        return "System.IO.Stream";
+                        return "string";
                 }
                 return ThrowInternalError<string>();
             }
@@ -627,7 +605,7 @@ namespace dotVariant._G.Foo
             }
         }
 
-        public bool Equals(in Variant_disposable other)
+        public bool Equals(in Variant_public other)
         {
             if (_n != other._n)
             {
@@ -640,7 +618,7 @@ namespace dotVariant._G.Foo
                 case 1:
                     return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2.Value, other._x._2.Value);
             }
             return ThrowInternalError<bool>();
         }
@@ -667,13 +645,13 @@ namespace dotVariant._G.Foo
             i = _n == 1 ? _x._1.Value : default;
             return _n == 1;
         }
-        public bool TryMatch(out global::System.IO.Stream stream)
+        public bool TryMatch(out string s)
         {
-            stream = _n == 2 ? _x._2.Value : default;
+            s = _n == 2 ? _x._2.Value : default;
             return _n == 2;
         }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
         {
             switch (_n)
             {
@@ -684,13 +662,13 @@ namespace dotVariant._G.Foo
                     i(_x._1.Value);
                     break;
                 case 2:
-                    stream(_x._2.Value);
+                    s(_x._2.Value);
                     break;
             }
             ThrowInternalError();
         }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s)
         {
             switch (_n)
             {
@@ -701,13 +679,13 @@ namespace dotVariant._G.Foo
                     i(_x._1.Value);
                     break;
                 case 2:
-                    stream(_x._2.Value);
+                    s(_x._2.Value);
                     break;
             }
             ThrowInternalError();
         }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
             switch (_n)
             {
@@ -716,12 +694,12 @@ namespace dotVariant._G.Foo
                 case 1:
                     return i(_x._1.Value);
                 case 2:
-                    return stream(_x._2.Value);
+                    return s(_x._2.Value);
             }
             return ThrowInternalError<TResult>();
         }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
             switch (_n)
             {
@@ -730,57 +708,57 @@ namespace dotVariant._G.Foo
                 case 1:
                     return i(_x._1.Value);
                 case 2:
-                    return stream(_x._2.Value);
+                    return s(_x._2.Value);
             }
             return ThrowInternalError<TResult>();
         }
     }
 
-    public readonly ref struct Variant_disposable_N
+    public readonly ref struct Variant_public_N
     {
         public readonly uint N;
-        public Variant_disposable_N(uint n) => N = n;
+        public Variant_public_N(uint n) => N = n;
     }
 
     [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_disposable_Union
+    internal readonly struct Variant_public_Union
     {
         [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_disposable_1 _1;
+        public readonly Variant_public_1 _1;
         [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_disposable_2 _2;
+        public readonly Variant_public_2 _2;
 
-        public Variant_disposable_Union(int value)
+        public Variant_public_Union(int value)
         {
             _2 = default;
-            _1 = new Variant_disposable_1(value);
+            _1 = new Variant_public_1(value);
         }
-        public Variant_disposable_Union(global::System.IO.Stream value)
+        public Variant_public_Union(string value)
         {
             _1 = default;
-            _2 = new Variant_disposable_2(value);
+            _2 = new Variant_public_2(value);
         }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_disposable_1
+    public readonly struct Variant_public_1
     {
         public readonly int Value;
         public readonly object _dummy1;
 
-        public Variant_disposable_1(int value)
+        public Variant_public_1(int value)
         {
             _dummy1 = null;
             Value = value;
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_disposable_2
+    public readonly struct Variant_public_2
     {
-        public readonly global::System.IO.Stream Value;
+        public readonly string Value;
 
-        public Variant_disposable_2(global::System.IO.Stream value)
+        public Variant_public_2(string value)
         {
             Value = value;
         }
@@ -790,10 +768,10 @@ namespace dotVariant._G.Foo
 
 namespace Foo
 {
-    public static partial class _Variant_disposable_Ex
+    public static partial class _Variant_public_Ex
     {
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
         /// containing a value of type <see cref="int"/> and dropping all others.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
@@ -803,42 +781,42 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
                 }
             }
         }
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.IO.Stream"/> and dropping all others.
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and dropping all others.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream)
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
                 }
             }
         }
 
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
         /// containing a value of type <see cref="int"/> and replacing all others by a fallback value.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
@@ -849,15 +827,15 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
                 }
                 else
                 {
@@ -866,26 +844,26 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.IO.Stream"/> and replacing all others by a fallback value.
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others by a fallback value.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s,
                 TResult _)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
                 }
                 else
                 {
@@ -895,7 +873,7 @@ namespace Foo
         }
 
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
         /// containing a value of type <see cref="int"/> and replacing all others with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
@@ -906,15 +884,15 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
                 }
                 else
                 {
@@ -923,26 +901,26 @@ namespace Foo
             }
         }
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.IO.Stream"/> and replacing all others with the result of a fallback selector.
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
                 }
                 else
                 {
@@ -952,74 +930,74 @@ namespace Foo
         }
 
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to each element
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to each element
         /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException">
         /// if an element is empty.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_disposable.</exception>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_public.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
-                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                switch (((global::dotVariant._G.Foo.Variant_public_N)variant).N)
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
+                        global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
                         yield break;
                 }
             }
         }
 
         /// <summary>
-        /// Transform a Variant_disposable-based enumerable sequence by applying a selector function to each element
+        /// Transform a Variant_public-based enumerable sequence by applying a selector function to each element
         /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_disposable> source,
-                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_public> source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                switch (((global::dotVariant._G.Foo.Variant_public_N)variant).N)
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
                         yield break;
                 }
             }
@@ -1031,7 +1009,7 @@ namespace Foo
     using System;
     using System.Reactive.Linq;
 
-    public static partial class _Variant_disposable_Ex
+    public static partial class _Variant_public_Ex
     {
         /// <summary>
         /// Projects each <see cref="int"/> element of an observable sequence
@@ -1043,29 +1021,29 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
+                this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i)
         {
             return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
-                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value));
+                .Where(_variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value));
         }
         /// <summary>
-        /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
+        /// Projects each <see cref="string"/> element of an observable sequence
         /// into a new form and drops all other elements.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream)
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s)
         {
             return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
-                .Select(_variant => stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value));
+                .Where(_variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+                .Select(_variant => s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value));
         }
 
         /// <summary>
@@ -1079,15 +1057,15 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
+                this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
             return source.Select(_variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 }
                 else
                 {
@@ -1096,25 +1074,25 @@ namespace Foo
             });
         }
         /// <summary>
-        /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
+        /// Projects each <see cref="string"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback value.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s,
                 TResult _)
         {
             return source.Select(_variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
                 {
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                 }
                 else
                 {
@@ -1134,15 +1112,15 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
+                this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
             return source.Select(_variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 }
                 else
                 {
@@ -1151,25 +1129,25 @@ namespace Foo
             });
         }
         /// <summary>
-        /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
+        /// Projects each <see cref="string"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback selector result.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="stream">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
             return source.Select(_variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
                 {
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                 }
                 else
                 {
@@ -1184,26 +1162,26 @@ namespace Foo
         /// </summary>
         /// <param name="source">An observable sequence whose elements to visit.</param>
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Visit<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
             return source.Select(_variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
+                        return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+                        return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
                 }
             });
         }
@@ -1214,34 +1192,34 @@ namespace Foo
         /// </summary>
         /// <param name="source">An observable sequence whose elements to visit.</param>
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the element's value is of type <see cref="global::System.IO.Stream"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Visit<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream,
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
             return source.Select(_variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+                        return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
                 }
             });
         }
 
         /// <summary>
-        /// Splits the observable sequence of Variant_disposable elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of Variant_public elements into one independent sub-sequences per value type,
         /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence,
         /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
         /// </summary>
@@ -1256,22 +1234,22 @@ namespace Foo
         /// </remarks>
         /// <param name="source">An observable sequence whose elements to split into sub-sequences.</param>
         /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
-        /// <param name="stream">Transform an observable sequence of <see cref="global::System.IO.Stream"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<TResult>> stream)
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<string>, global::System.IObservable<TResult>> s)
         {
             return VisitMany(source, (_1, _2) =>
             {
-                return Observable.Merge(i(_1), stream(_2));
+                return Observable.Merge(i(_1), s(_2));
             });
         }
 
         /// <summary>
-        /// Splits the observable sequence of Variant_disposable elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of Variant_public elements into one independent sub-sequences per value type,
         /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence.
         /// </summary>
         /// <remarks>
@@ -1285,24 +1263,24 @@ namespace Foo
         /// </remarks>
         /// <param name="source">An observable sequence whose elements to split into sub-sequences.</param>
         /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
-        /// <param name="stream">Transform an observable sequence of <see cref="global::System.IO.Stream"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<TResult>> stream,
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<string>, global::System.IObservable<TResult>> s,
                 global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
         {
             return VisitMany(source, (_1, _2, _0) =>
             {
-                return Observable.Merge(i(_1), stream(_2), _(_0));
+                return Observable.Merge(i(_1), s(_2), _(_0));
             });
         }
 
         /// <summary>
-        /// Splits the observable sequence of Variant_disposable elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of Variant_public elements into one independent sub-sequences per value type,
         /// and combines the resulting values into one observable sequence according to the combining selector,
         /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
         /// </summary>
@@ -1321,8 +1299,8 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IObservable<int>, global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<TResult>> selector)
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<TResult>> selector)
         {
             return Observable.Create<TResult>(_o =>
             {
@@ -1337,7 +1315,7 @@ namespace Foo
         }
 
         /// <summary>
-        /// Splits the observable sequence of Variant_disposable elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of Variant_public elements into one independent sub-sequences per value type,
         /// and combines the resulting values into one observable sequence according to the combining selector.
         /// </summary>
         /// <remarks>
@@ -1354,8 +1332,8 @@ namespace Foo
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<global::Foo.Variant_disposable> source,
-                global::System.Func<global::System.IObservable<int>, global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
+                this global::System.IObservable<global::Foo.Variant_public> source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
             return Observable.Create<TResult>(_o =>
             {
@@ -1369,11 +1347,11 @@ namespace Foo
             });
         }
 
-        private sealed class VisitManyObserver : global::System.IObserver<global::Foo.Variant_disposable>, global::System.IDisposable
+        private sealed class VisitManyObserver : global::System.IObserver<global::Foo.Variant_public>, global::System.IDisposable
         {
             public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
             public readonly global::System.Reactive.Subjects.Subject<int> Subject1 = new global::System.Reactive.Subjects.Subject<int>();
-            public readonly global::System.Reactive.Subjects.Subject<global::System.IO.Stream> Subject2 = new global::System.Reactive.Subjects.Subject<global::System.IO.Stream>();
+            public readonly global::System.Reactive.Subjects.Subject<string> Subject2 = new global::System.Reactive.Subjects.Subject<string>();
             private readonly bool _accept0;
 
             public VisitManyObserver(bool _accept0)
@@ -1388,9 +1366,9 @@ namespace Foo
                 Subject0.Dispose();
             }
 
-            public void OnNext(global::Foo.Variant_disposable _variant)
+            public void OnNext(global::Foo.Variant_public _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
                 {
                     case 0:
                         if (_accept0)
@@ -1399,17 +1377,17 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_disposable.MakeEmptyError());
+                            OnError(global::dotVariant._G.Foo.Variant_public.MakeEmptyError());
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_disposable.MakeInternalError());
+                        OnError(global::dotVariant._G.Foo.Variant_public.MakeInternalError());
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -922,7 +922,7 @@ namespace dotVariant._G.Foo
         }
     }
 
-    internal readonly ref struct Variant_struct_nullable_disable_N
+    public readonly ref struct Variant_struct_nullable_disable_N
     {
         public readonly uint N;
         public Variant_struct_nullable_disable_N(uint n) => N = n;
@@ -960,7 +960,7 @@ namespace dotVariant._G.Foo
     }
 
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_disable_1
+    public readonly struct Variant_struct_nullable_disable_1
     {
         public readonly long Value;
         public readonly object _dummy1;
@@ -972,7 +972,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_disable_2
+    public readonly struct Variant_struct_nullable_disable_2
     {
         public readonly double Value;
         public readonly object _dummy1;
@@ -984,7 +984,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_disable_3
+    public readonly struct Variant_struct_nullable_disable_3
     {
         public readonly object Value;
 

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -922,7 +922,7 @@ namespace dotVariant._G.Foo
         }
     }
 
-    internal readonly ref struct Variant_struct_nullable_enable_N
+    public readonly ref struct Variant_struct_nullable_enable_N
     {
         public readonly uint N;
         public Variant_struct_nullable_enable_N(uint n) => N = n;
@@ -960,7 +960,7 @@ namespace dotVariant._G.Foo
     }
 
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_enable_1
+    public readonly struct Variant_struct_nullable_enable_1
     {
         public readonly long Value;
         public readonly object _dummy1;
@@ -972,7 +972,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_enable_2
+    public readonly struct Variant_struct_nullable_enable_2
     {
         public readonly double Value;
         public readonly object _dummy1;
@@ -984,7 +984,7 @@ namespace dotVariant._G.Foo
         }
     }
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_enable_3
+    public readonly struct Variant_struct_nullable_enable_3
     {
         public readonly object Value;
 

--- a/src/dotVariant.Generator/Properties/launchSettings.json
+++ b/src/dotVariant.Generator/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "dotVariant.Generator": {
+      "commandName": "DebugRoslynComponent",
+      "targetProject": "..\\dotVariant.Test-net45\\dotVariant.Test-net45.csproj"
+    }
+  }
+}

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -55,7 +55,11 @@ namespace dotVariant.Generator
 
         public sealed record VariantInfo(
             /// <summary>
-            /// The fully qualified name of the type (without global:: alias, for diagnostic strings/messages)
+            /// The accessibility modifier of the variant class.
+            /// </summary>
+            string? Accessibility,
+            /// <summary>
+            /// The fully qualified name of the type (without global:: alias, for diagnostic strings/messages).
             /// </summary>
             string DiagName,
             /// <summary>
@@ -183,6 +187,7 @@ namespace dotVariant.Generator
                     HasHashCode: compilation.GetTypeByMetadataName("System.HashCode") is not null,
                     HasSystemReactiveLinq: HasReactive(compilation)),
                 Variant: new(
+                    Accessibility: VariantAccessibility(type),
                     DiagName: type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
                     ExtensionsAccessibility: ExtensionsAccessibility(type),
                     FullName: type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
@@ -207,6 +212,20 @@ namespace dotVariant.Generator
                 Accessibility.ProtectedAndInternal => null,
                 Accessibility.Protected => null,
                 Accessibility.ProtectedOrInternal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
+                _ => null,
+            };
+
+        private static string? VariantAccessibility(ITypeSymbol type)
+            => EffectiveAccessibility(type) switch
+            {
+                Accessibility.Internal => SyntaxFactory.Token(SyntaxKind.InternalKeyword).Text,
+                Accessibility.Public => SyntaxFactory.Token(SyntaxKind.PublicKeyword).Text,
+                // These only apply to nested types which are currently not supported
+                Accessibility.Private => null,
+                Accessibility.ProtectedAndInternal => null,
+                Accessibility.Protected => null,
+                Accessibility.ProtectedOrInternal => null,
+                Accessibility.NotApplicable => null,
                 _ => null,
             };
 

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -385,7 +385,7 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
     }
 
     {{~ ## DISCRIMINATOR COVERTER ## ~}}
-    internal readonly ref struct {{ Variant.Name }}_N
+    {{ Variant.Accessibility }} readonly ref struct {{ Variant.Name }}_N
     {
         public readonly uint N;
         public {{ Variant.Name }}_N(uint n) => N = n;
@@ -417,7 +417,7 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
     {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
     {{~ for $p in Params ~}}
     [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct {{ Variant.Name }}_{{ $p.Index }}
+    {{ Variant.Accessibility }} readonly struct {{ Variant.Name }}_{{ $p.Index }}
     {
         public readonly {{ value_type $p }} Value;
         {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}

--- a/src/dotVariant.Test/Variants.cs
+++ b/src/dotVariant.Test/Variants.cs
@@ -77,6 +77,18 @@ namespace dotVariant.Test.Variants
         }
     }
 
+    [Variant]
+    internal sealed partial class InternalVariant
+    {
+        static partial void VariantOf(int a, string b);
+    }
+
+    [Variant]
+    public sealed partial class PublicVariant
+    {
+        static partial void VariantOf(int a, string b);
+    }
+
     public static class TypeLoadTest
     {
         [Test]


### PR DESCRIPTION
Everything except extension methods was declared internal, which breaks
with public variants. Now they work too.