### PR TITLE
Correctly generate default cases in switch statements

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -566,8 +566,10 @@ namespace Foo
                 case 3:
                     s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -595,8 +597,10 @@ namespace Foo
                 case 3:
                     s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -621,8 +625,9 @@ namespace Foo
                     return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
                 case 3:
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -647,8 +652,9 @@ namespace Foo
                     return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
                 case 3:
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -752,8 +758,9 @@ namespace dotVariant._G.Foo
                         return "float";
                     case 3:
                         return "string";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -771,8 +778,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -790,8 +798,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
+                    default:
+                        return ThrowInternalError<object>();
                 }
-                return ThrowInternalError<object>();
             }
         }
 
@@ -811,8 +820,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -829,8 +839,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -866,8 +877,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     s(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
@@ -886,8 +899,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     s(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
@@ -902,8 +917,9 @@ namespace dotVariant._G.Foo
                     return f(_x._2.Value);
                 case 3:
                     return s(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
@@ -918,8 +934,9 @@ namespace dotVariant._G.Foo
                     return f(_x._2.Value);
                 case 3:
                     return s(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -733,8 +733,10 @@ namespace Foo
                 case 4:
                     a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -766,8 +768,10 @@ namespace Foo
                 case 4:
                     a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -795,8 +799,9 @@ namespace Foo
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
                 case 4:
                     return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -824,8 +829,9 @@ namespace Foo
                     return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
                 case 4:
                     return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -938,8 +944,9 @@ namespace dotVariant._G.Foo
                         return "string";
                     case 4:
                         return "System.Array?";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -959,8 +966,9 @@ namespace dotVariant._G.Foo
                         return _x._3.Value.ToString();
                     case 4:
                         return _x._4.Value?.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -980,8 +988,9 @@ namespace dotVariant._G.Foo
                         return _x._3.Value;
                     case 4:
                         return _x._4.Value;
+                    default:
+                        return ThrowInternalError<object?>();
                 }
-                return ThrowInternalError<object?>();
             }
         }
 
@@ -1003,8 +1012,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
                 case 4:
                     return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -1023,8 +1033,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._3.Value);
                     case 4:
                         return global::System.HashCode.Combine(_x._4.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -1068,8 +1079,10 @@ namespace dotVariant._G.Foo
                 case 4:
                     a(_x._4.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
@@ -1091,8 +1104,10 @@ namespace dotVariant._G.Foo
                 case 4:
                     a(_x._4.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
@@ -1109,8 +1124,9 @@ namespace dotVariant._G.Foo
                     return s(_x._3.Value);
                 case 4:
                     return a(_x._4.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
@@ -1127,8 +1143,9 @@ namespace dotVariant._G.Foo
                     return s(_x._3.Value);
                 case 4:
                     return a(_x._4.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -406,8 +406,10 @@ namespace Foo
                 case 2:
                     stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
         }
 
         /// <summary>
@@ -431,8 +433,10 @@ namespace Foo
                 case 2:
                     stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -454,8 +458,9 @@ namespace Foo
                     return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                 case 2:
                     return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -477,8 +482,9 @@ namespace Foo
                     return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
                 case 2:
                     return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -528,8 +534,10 @@ namespace dotVariant._G.Foo
                 case 2:
                     _x._2.Value?.Dispose();
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public static explicit operator Variant_disposable_N(Variant_disposable v) => new Variant_disposable_N(v._n);
@@ -588,8 +596,9 @@ namespace dotVariant._G.Foo
                         return "int";
                     case 2:
                         return "System.IO.Stream";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -605,8 +614,9 @@ namespace dotVariant._G.Foo
                         return _x._1.Value.ToString();
                     case 2:
                         return _x._2.Value?.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -622,8 +632,9 @@ namespace dotVariant._G.Foo
                         return _x._1.Value;
                     case 2:
                         return _x._2.Value;
+                    default:
+                        return ThrowInternalError<object>();
                 }
-                return ThrowInternalError<object>();
             }
         }
 
@@ -641,8 +652,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                 case 2:
                     return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -657,8 +669,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._1.Value);
                     case 2:
                         return global::System.HashCode.Combine(_x._2.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -686,8 +699,10 @@ namespace dotVariant._G.Foo
                 case 2:
                     stream(_x._2.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
@@ -703,8 +718,10 @@ namespace dotVariant._G.Foo
                 case 2:
                     stream(_x._2.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
@@ -717,8 +734,9 @@ namespace dotVariant._G.Foo
                     return i(_x._1.Value);
                 case 2:
                     return stream(_x._2.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
@@ -731,8 +749,9 @@ namespace dotVariant._G.Foo
                     return i(_x._1.Value);
                 case 2:
                     return stream(_x._2.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -399,8 +399,10 @@ namespace Foo
                 case 2:
                     s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
         }
 
         /// <summary>
@@ -424,8 +426,10 @@ namespace Foo
                 case 2:
                     s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -447,8 +451,9 @@ namespace Foo
                     return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 case 2:
                     return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -470,8 +475,9 @@ namespace Foo
                     return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
                 case 2:
                     return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -566,8 +572,9 @@ namespace dotVariant._G.Foo
                         return "int";
                     case 2:
                         return "string";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -583,8 +590,9 @@ namespace dotVariant._G.Foo
                         return _x._1.Value.ToString();
                     case 2:
                         return _x._2.Value?.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -600,8 +608,9 @@ namespace dotVariant._G.Foo
                         return _x._1.Value;
                     case 2:
                         return _x._2.Value;
+                    default:
+                        return ThrowInternalError<object>();
                 }
-                return ThrowInternalError<object>();
             }
         }
 
@@ -619,8 +628,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                 case 2:
                     return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2.Value, other._x._2.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -635,8 +645,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._1.Value);
                     case 2:
                         return global::System.HashCode.Combine(_x._2.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -664,8 +675,10 @@ namespace dotVariant._G.Foo
                 case 2:
                     s(_x._2.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<int> i, global::System.Action<string> s)
@@ -681,8 +694,10 @@ namespace dotVariant._G.Foo
                 case 2:
                     s(_x._2.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
@@ -695,8 +710,9 @@ namespace dotVariant._G.Foo
                     return i(_x._1.Value);
                 case 2:
                     return s(_x._2.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
@@ -709,8 +725,9 @@ namespace dotVariant._G.Foo
                     return i(_x._1.Value);
                 case 2:
                     return s(_x._2.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -565,8 +565,10 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
         }
 
         /// <summary>
@@ -594,8 +596,10 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -620,8 +624,9 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -646,8 +651,9 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -751,8 +757,9 @@ namespace dotVariant._G.Foo
                         return "double";
                     case 3:
                         return "object";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -770,8 +777,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -789,8 +797,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
+                    default:
+                        return ThrowInternalError<object>();
                 }
-                return ThrowInternalError<object>();
             }
         }
 
@@ -810,8 +819,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -828,8 +838,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -865,8 +876,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
@@ -885,8 +898,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
@@ -901,8 +916,9 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
@@ -917,8 +933,9 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -565,8 +565,10 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
                     break;
+                default:
+                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                    break;
             }
-            global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
         }
 
         /// <summary>
@@ -594,8 +596,10 @@ namespace Foo
                 case 3:
                     o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
                     break;
-                }
-            global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                default:
+                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                    break;
+            }
         }
 
         /// <summary>
@@ -620,8 +624,9 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
         }
 
         /// <summary>
@@ -646,8 +651,9 @@ namespace Foo
                     return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
                 case 3:
                     return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                default:
+                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
             }
-            return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy
@@ -751,8 +757,9 @@ namespace dotVariant._G.Foo
                         return "double";
                     case 3:
                         return "object";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -770,8 +777,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value.ToString();
                     case 3:
                         return _x._3.Value.ToString() ?? "null";
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -789,8 +797,9 @@ namespace dotVariant._G.Foo
                         return _x._2.Value;
                     case 3:
                         return _x._3.Value;
+                    default:
+                        return ThrowInternalError<object?>();
                 }
-                return ThrowInternalError<object?>();
             }
         }
 
@@ -810,8 +819,9 @@ namespace dotVariant._G.Foo
                     return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                 case 3:
                     return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         public override int GetHashCode()
@@ -828,8 +838,9 @@ namespace dotVariant._G.Foo
                         return global::System.HashCode.Combine(_x._2.Value);
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -865,8 +876,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
@@ -885,8 +898,10 @@ namespace dotVariant._G.Foo
                 case 3:
                     o(_x._3.Value);
                     break;
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
@@ -901,8 +916,9 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
@@ -917,8 +933,9 @@ namespace dotVariant._G.Foo
                     return d(_x._2.Value);
                 case 3:
                     return o(_x._3.Value);
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -153,8 +153,10 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     {{~ end ~}}
                     break;
                 {{~ end ~}}
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
         {{~ end ~}}
 
@@ -226,8 +228,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return "{{ $p.DiagName }}";
                     {{~ end ~}}
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -244,8 +247,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return {{ coalesce_ToString $p ($storage $p) }};
                     {{~ end ~}}
+                    default:
+                        return ThrowInternalError<string>();
                 }
-                return ThrowInternalError<string>();
             }
         }
 
@@ -262,8 +266,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     case {{ $p.Index }}:
                         return {{ $storage $p }};
                     {{~ end ~}}
+                    default:
+                        return ThrowInternalError<object{{ global_nullable }}>();
                 }
-                return ThrowInternalError<object{{ global_nullable }}>();
             }
         }
 
@@ -283,8 +288,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                 case {{ $i }}:
                     return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
                 {{~ end ~}}
+                default:
+                    return ThrowInternalError<bool>();
             }
-            return ThrowInternalError<bool>();
         }
 
         {{~ ## UNION GetHashCode ## ~}}
@@ -305,8 +311,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                         return {{ coalesce $p ($storage $p) ".GetHashCode()" "0"}};
                         {{~ end ~}}
                     {{~ end ~}}
+                    default:
+                        return ThrowInternalError<int>();
                 }
-                return ThrowInternalError<int>();
             }
         }
 
@@ -332,8 +339,10 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     {{ $p.Hint }}({{ $storage $p }});
                     break;
                 {{~ end ~}}
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         {{~ ## UNION Visit(Action) ## ~}}
@@ -349,8 +358,10 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                     {{ $p.Hint }}({{ $storage $p }});
                     break;
                     {{~ end ~}}
+                default:
+                    ThrowInternalError();
+                    break;
             }
-            ThrowInternalError();
         }
 
         {{~ ## UNION Visit(Func) ## ~}}
@@ -364,8 +375,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ $storage $p }});
                 {{~ end ~}}
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
 
         {{~ ## UNION Visit(Func) ## ~}}
@@ -379,8 +391,9 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ $storage $p }});
                 {{~ end ~}}
+                default:
+                    return ThrowInternalError<TResult>();
             }
-            return ThrowInternalError<TResult>();
         }
     }
 

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -422,8 +422,10 @@ namespace {{ Variant.Namespace }}
                     {{ $p.Hint }}({{ get_value $p }});
                     break;
                 {{~ end ~}}
+                default:
+                    {{ storage_type }}.ThrowInternalError();
+                    break;
             }
-            {{ storage_type }}.ThrowInternalError();
         }
 
         {{~ ## VARIANT Visit(Action<A>, Action<B>, ..., empty) ## ~}}
@@ -448,8 +450,10 @@ namespace {{ Variant.Namespace }}
                     {{ $p.Hint }}({{ get_value $p }});
                     break;
                 {{~ end ~}}
-                }
-            {{ storage_type }}.ThrowInternalError();
+                default:
+                    {{ storage_type }}.ThrowInternalError();
+                    break;
+            }
         }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ...) ## ~}}
@@ -473,8 +477,9 @@ namespace {{ Variant.Namespace }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ get_value $p }});
                 {{~ end ~}}
+                default:
+                    return {{ storage_type }}.ThrowInternalError<TResult>();
             }
-            return {{ storage_type }}.ThrowInternalError<TResult>();
         }
 
         {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ..., empty) ## ~}}
@@ -498,8 +503,9 @@ namespace {{ Variant.Namespace }}
                 case {{ $p.Index }}:
                     return {{ $p.Hint }}({{ get_value $p }});
                 {{~ end ~}}
+                default:
+                    return {{ storage_type }}.ThrowInternalError<TResult>();
             }
-            return {{ storage_type }}.ThrowInternalError<TResult>();
         }
 
         private sealed class _VariantTypeProxy

--- a/src/dotVariant.Test/Variant+Dispose.cs
+++ b/src/dotVariant.Test/Variant+Dispose.cs
@@ -16,9 +16,10 @@ namespace dotVariant.Test
             [Test]
             public static void If_active_member_is_disposable_its_Dispose_is_called()
             {
-                var a = new DisposableVariant(new Disposable(() => Assert.Pass()));
+                var disposed = false;
+                var a = new DisposableVariant(new Disposable(() => disposed = true));
                 a.Dispose();
-                Assert.Fail("Dispose() not called");
+                Assert.That(disposed, Is.True, "Dispose() not called");
             }
         }
     }

--- a/src/dotVariant.Test/Variant+Match-Action.cs
+++ b/src/dotVariant.Test/Variant+Match-Action.cs
@@ -17,24 +17,27 @@ namespace dotVariant.Test
             public static void Match_succeeds_on_active_value_1()
             {
                 var v = new Class_int_float_string(1);
-                v.Match((int x) => { Assert.That(x, Is.EqualTo(1)); Assert.Pass(); });
-                Assert.Fail("delegate not called");
+                var called = false;
+                v.Match((int x) => { Assert.That(x, Is.EqualTo(1)); called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_succeeds_on_active_value_2()
             {
                 var v = new Class_int_float_string(1f);
-                v.Match((float x) => { Assert.That(x, Is.EqualTo(1f)); Assert.Pass(); });
-                Assert.Fail("delegate not called");
+                var called = false;
+                v.Match((float x) => { Assert.That(x, Is.EqualTo(1f)); called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_succeeds_on_active_value_3()
             {
                 var v = new Class_int_float_string("s");
-                v.Match((string x) => { Assert.That(x, Is.EqualTo("s")); Assert.Pass(); });
-                Assert.Fail("delegate not called");
+                var called = false;
+                v.Match((string x) => { Assert.That(x, Is.EqualTo("s")); called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
@@ -74,72 +77,81 @@ namespace dotVariant.Test
             public static void Match_calls_alternative_on_inactive_value_1_1()
             {
                 var v = new Class_int_float_string(1);
-                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_inactive_value_1_2()
             {
                 var v = new Class_int_float_string(1);
-                v.Match((string _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((string _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_inactive_value_2_1()
             {
                 var v = new Class_int_float_string(1f);
-                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_inactive_value_2_2()
             {
                 var v = new Class_int_float_string(1f);
-                v.Match((string _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((string _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_inactive_value_3_1()
             {
                 var v = new Class_int_float_string("s");
-                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_inactive_value_3_2()
             {
                 var v = new Class_int_float_string("s");
-                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_empty_value_1()
             {
                 var v = new Class_with_default_ctor();
-                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((int _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_empty_value_2()
             {
                 var v = new Class_with_default_ctor();
-                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((float _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
 
             [Test]
             public static void Match_calls_alternative_on_empty_value_3()
             {
                 var v = new Class_with_default_ctor();
-                v.Match((Helper _) => { Assert.Fail("wrong delegate called"); }, () => { Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                var called = false;
+                v.Match((Helper _) => { Assert.Fail("wrong delegate called"); }, () => { called = true; });
+                Assert.That(called, Is.True, "delegate not called");
             }
         }
     }

--- a/src/dotVariant.Test/Variant+Visit.cs
+++ b/src/dotVariant.Test/Variant+Visit.cs
@@ -17,33 +17,36 @@ namespace dotVariant.Test
             public static void Visit_calls_corresponding_action_1()
             {
                 var v = new Class_int_float_string(1);
+                var called = false;
                 v.Visit(
-                    x => { Assert.That(x, Is.EqualTo(1)); Assert.Pass(); },
+                    x => { Assert.That(x, Is.EqualTo(1)); called = true; },
                     _ => { Assert.Fail("wrong delegate called"); },
                     _ => { Assert.Fail("wrong delegate called"); });
-                Assert.Fail("no delegate called");
+                Assert.That(called, Is.True, "no delegate called");
             }
 
             [Test]
             public static void Visit_calls_corresponding_action_2()
             {
                 var v = new Class_int_float_string(1f);
+                var called = false;
                 v.Visit(
                     _ => { Assert.Fail("wrong delegate called"); },
-                    x => { Assert.That(x, Is.EqualTo(1f)); Assert.Pass(); },
+                    x => { Assert.That(x, Is.EqualTo(1f)); called = true; },
                     _ => { Assert.Fail("wrong delegate called"); });
-                Assert.Fail("no delegate called");
+                Assert.That(called, Is.True, "no delegate called");
             }
 
             [Test]
             public static void Visit_calls_corresponding_action_3()
             {
                 var v = new Class_int_float_string("s");
+                var called = false;
                 v.Visit(
                     _ => { Assert.Fail("wrong delegate called"); },
                     _ => { Assert.Fail("wrong delegate called"); },
-                    x => { Assert.That(x, Is.EqualTo("s")); Assert.Pass(); });
-                Assert.Fail("no delegate called");
+                    x => { Assert.That(x, Is.EqualTo("s")); called = true; });
+                Assert.That(called, Is.True, "no delegate called");
             }
 
             [Test]

--- a/src/dotVariant.Test/Variants.cs
+++ b/src/dotVariant.Test/Variants.cs
@@ -108,6 +108,8 @@ namespace dotVariant.Test.Variants
                     new Class_int(1),
                     new DisposableVariant(new Disposable(() => { })),
                     new DisposableVariantWithImpl(new Disposable(() => { })),
+                    new InternalVariant(1),
+                    new PublicVariant(1),
                 },
                 Throws.Nothing);
         }


### PR DESCRIPTION
Methods with switch statements were generated with a call to
`ThrowInternalError()` following the switch. If the switch cases used
`break` instead of `return` then even correct variant states would
result in `InvalidOperationException`.

Now the `ThrowInternalError()` call is moved to a `default` case.

This affected both `Dispose()` and `Visit()`.

fixes #18