### PR TITLE
Ensure IObservable extensions classes work in the global namespace

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -1340,9 +1340,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_class_nullable_disable_Ex
     {
         /// <summary>
@@ -1358,9 +1355,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<int, TResult> i)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
-                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1),
+                _variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1375,9 +1372,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<float, TResult> f)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
-                .Select(_variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2),
+                _variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1392,9 +1389,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<string, TResult> s)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
-                .Select(_variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3),
+                _variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value));
         }
 
         /// <summary>
@@ -1412,7 +1409,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
                 {
@@ -1439,7 +1436,7 @@ namespace Foo
                 global::System.Func<float, TResult> f,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
                 {
@@ -1466,7 +1463,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
                 {
@@ -1494,7 +1491,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
                 {
@@ -1521,7 +1518,7 @@ namespace Foo
                 global::System.Func<float, TResult> f,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
                 {
@@ -1548,7 +1545,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
                 {
@@ -1576,7 +1573,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
                 {
@@ -1611,7 +1608,7 @@ namespace Foo
                 global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
                 {
@@ -1656,7 +1653,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3) =>
             {
-                return Observable.Merge(i(_1), f(_2), s(_3));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), f(_2), s(_3));
             });
         }
 
@@ -1688,7 +1685,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3, _0) =>
             {
-                return Observable.Merge(i(_1), f(_2), s(_3), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), f(_2), s(_3), _(_0));
             });
         }
 
@@ -1715,14 +1712,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<float>, global::System.IObservable<string>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -1748,14 +1743,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_disable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<float>, global::System.IObservable<string>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -1657,9 +1657,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_class_nullable_enable_Ex
     {
         /// <summary>
@@ -1675,9 +1672,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<int, TResult> i)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
-                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1),
+                _variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1692,9 +1689,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<float, TResult> f)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
-                .Select(_variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2),
+                _variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1709,9 +1706,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<string, TResult> s)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
-                .Select(_variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3),
+                _variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.Array"/> element of an observable sequence
@@ -1726,9 +1723,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<global::System.Array?, TResult> a)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
-                .Select(_variant => a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4),
+                _variant => a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value));
         }
 
         /// <summary>
@@ -1746,7 +1743,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
                 {
@@ -1773,7 +1770,7 @@ namespace Foo
                 global::System.Func<float, TResult> f,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
                 {
@@ -1800,7 +1797,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
                 {
@@ -1827,7 +1824,7 @@ namespace Foo
                 global::System.Func<global::System.Array?, TResult> a,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
                 {
@@ -1855,7 +1852,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
                 {
@@ -1882,7 +1879,7 @@ namespace Foo
                 global::System.Func<float, TResult> f,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
                 {
@@ -1909,7 +1906,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
                 {
@@ -1936,7 +1933,7 @@ namespace Foo
                 global::System.Func<global::System.Array?, TResult> a,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
                 {
@@ -1965,7 +1962,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
                 {
@@ -2003,7 +2000,7 @@ namespace Foo
                 global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
                 {
@@ -2051,7 +2048,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3, _4) =>
             {
-                return Observable.Merge(i(_1), f(_2), s(_3), a(_4));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), f(_2), s(_3), a(_4));
             });
         }
 
@@ -2084,7 +2081,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3, _4, _0) =>
             {
-                return Observable.Merge(i(_1), f(_2), s(_3), a(_4), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), f(_2), s(_3), a(_4), _(_0));
             });
         }
 
@@ -2111,14 +2108,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<float>, global::System.IObservable<string>, global::System.IObservable<global::System.Array?>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject4)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject4).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -2144,14 +2139,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_class_nullable_enable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<float>, global::System.IObservable<string>, global::System.IObservable<global::System.Array?>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject4, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject4, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -1047,9 +1047,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_disposable_Ex
     {
         /// <summary>
@@ -1065,9 +1062,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_disposable> source,
                 global::System.Func<int, TResult> i)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
-                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1),
+                _variant => i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
@@ -1082,9 +1079,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_disposable> source,
                 global::System.Func<global::System.IO.Stream, TResult> stream)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
-                .Select(_variant => stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2),
+                _variant => stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value));
         }
 
         /// <summary>
@@ -1102,7 +1099,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
                 {
@@ -1129,7 +1126,7 @@ namespace Foo
                 global::System.Func<global::System.IO.Stream, TResult> stream,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
                 {
@@ -1157,7 +1154,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
                 {
@@ -1184,7 +1181,7 @@ namespace Foo
                 global::System.Func<global::System.IO.Stream, TResult> stream,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
                 {
@@ -1211,7 +1208,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_disposable> source,
                 global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
                 {
@@ -1243,7 +1240,7 @@ namespace Foo
                 global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
                 {
@@ -1285,7 +1282,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2) =>
             {
-                return Observable.Merge(i(_1), stream(_2));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), stream(_2));
             });
         }
 
@@ -1316,7 +1313,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _0) =>
             {
-                return Observable.Merge(i(_1), stream(_2), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), stream(_2), _(_0));
             });
         }
 
@@ -1343,14 +1340,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_disposable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -1376,14 +1371,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_disposable> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<global::System.IO.Stream>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -1023,9 +1023,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_public_Ex
     {
         /// <summary>
@@ -1041,9 +1038,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
-                .Select(_variant => i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1),
+                _variant => i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1058,9 +1055,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<string, TResult> s)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
-                .Select(_variant => s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2),
+                _variant => s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value));
         }
 
         /// <summary>
@@ -1078,7 +1075,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
                 {
@@ -1105,7 +1102,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
                 {
@@ -1133,7 +1130,7 @@ namespace Foo
                 global::System.Func<int, TResult> i,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
                 {
@@ -1160,7 +1157,7 @@ namespace Foo
                 global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
                 {
@@ -1187,7 +1184,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
                 {
@@ -1219,7 +1216,7 @@ namespace Foo
                 global::System.Func<int, TResult> i, global::System.Func<string, TResult> s,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
                 {
@@ -1261,7 +1258,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2) =>
             {
-                return Observable.Merge(i(_1), s(_2));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), s(_2));
             });
         }
 
@@ -1292,7 +1289,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _0) =>
             {
-                return Observable.Merge(i(_1), s(_2), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), s(_2), _(_0));
             });
         }
 
@@ -1319,14 +1316,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -1352,14 +1347,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_public> source,
                 global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -1339,9 +1339,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_struct_nullable_disable_Ex
     {
         /// <summary>
@@ -1357,9 +1354,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<long, TResult> l)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
-                .Select(_variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1),
+                _variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1374,9 +1371,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<double, TResult> d)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
-                .Select(_variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2),
+                _variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1391,9 +1388,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<object, TResult> o)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
-                .Select(_variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3),
+                _variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value));
         }
 
         /// <summary>
@@ -1411,7 +1408,7 @@ namespace Foo
                 global::System.Func<long, TResult> l,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
                 {
@@ -1438,7 +1435,7 @@ namespace Foo
                 global::System.Func<double, TResult> d,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
                 {
@@ -1465,7 +1462,7 @@ namespace Foo
                 global::System.Func<object, TResult> o,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
                 {
@@ -1493,7 +1490,7 @@ namespace Foo
                 global::System.Func<long, TResult> l,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
                 {
@@ -1520,7 +1517,7 @@ namespace Foo
                 global::System.Func<double, TResult> d,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
                 {
@@ -1547,7 +1544,7 @@ namespace Foo
                 global::System.Func<object, TResult> o,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
                 {
@@ -1575,7 +1572,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
                 {
@@ -1610,7 +1607,7 @@ namespace Foo
                 global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
                 {
@@ -1655,7 +1652,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3) =>
             {
-                return Observable.Merge(l(_1), d(_2), o(_3));
+                return global::System.Reactive.Linq.Observable.Merge(l(_1), d(_2), o(_3));
             });
         }
 
@@ -1687,7 +1684,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3, _0) =>
             {
-                return Observable.Merge(l(_1), d(_2), o(_3), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(l(_1), d(_2), o(_3), _(_0));
             });
         }
 
@@ -1714,14 +1711,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<global::System.IObservable<long>, global::System.IObservable<double>, global::System.IObservable<object>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -1747,14 +1742,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_disable> source,
                 global::System.Func<global::System.IObservable<long>, global::System.IObservable<double>, global::System.IObservable<object>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -1339,9 +1339,6 @@ namespace Foo
 }
 namespace Foo
 {
-    using System;
-    using System.Reactive.Linq;
-
     public static partial class _Variant_struct_nullable_enable_Ex
     {
         /// <summary>
@@ -1357,9 +1354,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<long, TResult> l)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
-                .Select(_variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1),
+                _variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1374,9 +1371,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<double, TResult> d)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
-                .Select(_variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2),
+                _variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1391,9 +1388,9 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<object, TResult> o)
         {
-            return source
-                .Where(_variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
-                .Select(_variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3),
+                _variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value));
         }
 
         /// <summary>
@@ -1411,7 +1408,7 @@ namespace Foo
                 global::System.Func<long, TResult> l,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
                 {
@@ -1438,7 +1435,7 @@ namespace Foo
                 global::System.Func<double, TResult> d,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
                 {
@@ -1465,7 +1462,7 @@ namespace Foo
                 global::System.Func<object, TResult> o,
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
                 {
@@ -1493,7 +1490,7 @@ namespace Foo
                 global::System.Func<long, TResult> l,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
                 {
@@ -1520,7 +1517,7 @@ namespace Foo
                 global::System.Func<double, TResult> d,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
                 {
@@ -1547,7 +1544,7 @@ namespace Foo
                 global::System.Func<object, TResult> o,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
                 {
@@ -1575,7 +1572,7 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
                 {
@@ -1610,7 +1607,7 @@ namespace Foo
                 global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o,
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
                 {
@@ -1655,7 +1652,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3) =>
             {
-                return Observable.Merge(l(_1), d(_2), o(_3));
+                return global::System.Reactive.Linq.Observable.Merge(l(_1), d(_2), o(_3));
             });
         }
 
@@ -1687,7 +1684,7 @@ namespace Foo
         {
             return VisitMany(source, (_1, _2, _3, _0) =>
             {
-                return Observable.Merge(l(_1), d(_2), o(_3), _(_0));
+                return global::System.Reactive.Linq.Observable.Merge(l(_1), d(_2), o(_3), _(_0));
             });
         }
 
@@ -1714,14 +1711,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<global::System.IObservable<long>, global::System.IObservable<double>, global::System.IObservable<object>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -1747,14 +1742,12 @@ namespace Foo
                 this global::System.IObservable<global::Foo.Variant_struct_nullable_enable> source,
                 global::System.Func<global::System.IObservable<long>, global::System.IObservable<double>, global::System.IObservable<object>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector(_mo.Subject1, _mo.Subject2, _mo.Subject3, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Generator/templates/IObservable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IObservable.scriban-cs
@@ -7,10 +7,6 @@
 namespace {{ Options.ExtensionClassNamespace }}
 {
 {{~ end ~}}
-    {{~ ## These are for extension methods only. All types must still be fully qualidfied. ## ~}}
-    using System;
-    using System.Reactive.Linq;
-
     {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
     {
         {{~ ## Match(IObservable<V>, Func<A, R>) ## ~}}
@@ -28,9 +24,9 @@ namespace {{ Options.ExtensionClassNamespace }}
                 this global::System.IObservable<{{ Variant.FullName }}> source,
                 {{ func_type $p }} {{ $p.Hint }})
         {
-            return source
-                .Where(_variant => {{ get_n }} == {{ $p.Index }})
-                .Select(_variant => {{ $p.Hint }}({{ get_value $p }}));
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(source, _variant => {{ get_n }} == {{ $p.Index }}),
+                _variant => {{ $p.Hint }}({{ get_value $p }}));
         }
         {{~ end ~}}
 
@@ -51,7 +47,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 {{ func_type $p }} {{ $p.Hint }},
                 TResult _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if ({{ get_n }} == {{ $p.Index }})
                 {
@@ -82,7 +78,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 {{ func_type $p }} {{ $p.Hint }},
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if ({{ get_n }} == {{ $p.Index }})
                 {
@@ -112,7 +108,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 this global::System.IObservable<{{ Variant.FullName }}> source,
                 {{ func_params }})
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch ({{ get_n }})
                 {
@@ -146,7 +142,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 {{ func_params }},
                 global::System.Func<TResult> _)
         {
-            return source.Select(_variant =>
+            return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 switch ({{ get_n }})
                 {
@@ -191,7 +187,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}) =>
             {
-                return Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }});
+                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }});
             });
         }
         {{~ end ~}}
@@ -225,7 +221,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}, _0) =>
             {
-                return Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }}, _(_0));
+                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }}, _(_0));
             });
         }
 
@@ -253,14 +249,12 @@ namespace {{ Options.ExtensionClassNamespace }}
                 this global::System.IObservable<{{ Variant.FullName }}> source,
                 global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(false);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector({{ Params | array.each @(do; ret "_mo.Subject" + $0.Index + ""; end) | array.join ", " }})
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector({{ Params | array.each @(do; ret "_mo.Subject" + $0.Index + ""; end) | array.join ", " }}).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }
@@ -287,14 +281,12 @@ namespace {{ Options.ExtensionClassNamespace }}
                 this global::System.IObservable<{{ Variant.FullName }}> source,
                 global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
-            return Observable.Create<TResult>(_o =>
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
                 var _mo = new VisitManyObserver(true);
                 return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
-                    selector({{ Params | array.each @(do; ret "_mo.Subject" + $0.Index + ""; end) | array.join ", " }}, _mo.Subject0)
-                        .Subscribe(_o),
-                    source
-                        .SubscribeSafe(_mo),
+                    selector({{ Params | array.each @(do; ret "_mo.Subject" + $0.Index + ""; end) | array.join ", " }}, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(source, _mo),
                     _mo);
             });
         }

--- a/src/dotVariant.Test/Variants.cs
+++ b/src/dotVariant.Test/Variants.cs
@@ -108,10 +108,17 @@ namespace dotVariant.Test.Variants
                     new Class_int(1),
                     new DisposableVariant(new Disposable(() => { })),
                     new DisposableVariantWithImpl(new Disposable(() => { })),
+                    new GlobalVariant(1),
                     new InternalVariant(1),
                     new PublicVariant(1),
                 },
                 Throws.Nothing);
         }
     }
+}
+
+[dotVariant.Variant]
+internal partial class GlobalVariant
+{
+    static partial void VariantOf(int a, string b);
 }


### PR DESCRIPTION
Extension classes were defined in their own namespace section containing
custom `using` directives to find IObservable extension methods.

However if a variant was declared in the global namespace then this
class would also be generated in the global namesapce and the orphaned
`using` directives would then break the build as they were no longer at
the top of the file.

To solve this replace all uses of extension method syntax with fully
qualified calls to the System.Reactive extension classes and ditch the
`using`s.