### PR TITLE
Refactor internal access to unions to prepare for generics

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -106,9 +106,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
             }
             else
             {
@@ -123,9 +123,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
         public void Match(out float f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value;
+                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
             }
             else
             {
@@ -140,9 +140,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
         public void Match(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
             }
             else
             {
@@ -157,9 +157,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
                 return true;
             }
             else
@@ -175,9 +175,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch(out float f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value;
+                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
                 return true;
             }
             else
@@ -193,9 +193,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s = ((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
                 return true;
             }
             else
@@ -213,9 +213,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 return true;
             }
             else
@@ -231,9 +231,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<float> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 return true;
             }
             else
@@ -249,9 +249,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 return true;
             }
             else
@@ -269,9 +269,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -287,9 +287,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public void Match(global::System.Action<float> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -305,9 +305,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public void Match(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -324,9 +324,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -342,9 +342,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<float> f, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -360,9 +360,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -380,9 +380,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -399,9 +399,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -418,9 +418,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -438,9 +438,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -457,9 +457,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -476,9 +476,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -495,9 +495,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -513,9 +513,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -531,9 +531,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -552,19 +552,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     break;
                 case 3:
-                    s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
@@ -583,19 +583,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     break;
                 case 3:
-                    s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
@@ -615,16 +615,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 case 3:
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
             }
@@ -642,16 +642,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 case 3:
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
             }
@@ -667,10 +667,14 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_N(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_1(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_2(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_2)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_disable_3(Variant_class_nullable_disable v) => (global::dotVariant._G.Foo.Variant_class_nullable_disable_3)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_disable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<float>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_2<float>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_3<string>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_3<string>)v._variant;
     }
 }
 
@@ -679,30 +683,99 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_class_nullable_disable
     {
-        private readonly Variant_class_nullable_disable_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_3 _3;
+
+            public Union(int value)
+            {
+                _2 = default;
+                _3 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(float value)
+            {
+                _1 = default;
+                _3 = default;
+                _2 = new Value_2(value);
+            }
+            public Union(string value)
+            {
+                _1 = default;
+                _2 = default;
+                _3 = new Value_3(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly int Value;
+            public readonly object _dummy1;
+
+            public Value_1(int value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly float Value;
+            public readonly object _dummy1;
+
+            public Value_2(float value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_3
+        {
+            public readonly string Value;
+
+            public Value_3(string value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_class_nullable_disable(int i)
         {
             _n = 1;
-            _x = new Variant_class_nullable_disable_Union(i);
+            _x = new Union(i);
         }
         public Variant_class_nullable_disable(float f)
         {
             _n = 2;
-            _x = new Variant_class_nullable_disable_Union(f);
+            _x = new Union(f);
         }
         public Variant_class_nullable_disable(string s)
         {
             _n = 3;
-            _x = new Variant_class_nullable_disable_Union(s);
+            _x = new Union(s);
         }
 
 
-        public static explicit operator Variant_class_nullable_disable_N(Variant_class_nullable_disable v) => new Variant_class_nullable_disable_N(v._n);
-        public static explicit operator Variant_class_nullable_disable_1(Variant_class_nullable_disable v) => v._x._1;
-        public static explicit operator Variant_class_nullable_disable_2(Variant_class_nullable_disable v) => v._x._2;
-        public static explicit operator Variant_class_nullable_disable_3(Variant_class_nullable_disable v) => v._x._3;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_disable v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_class_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<float>(in Variant_class_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_2<float>(v._x._2.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_3<string>(in Variant_class_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_3<string>(v._x._3.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -939,78 +1012,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_class_nullable_disable_N
-    {
-        public readonly uint N;
-        public Variant_class_nullable_disable_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_disable_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_disable_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_disable_2 _2;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_disable_3 _3;
-
-        public Variant_class_nullable_disable_Union(int value)
-        {
-            _2 = default;
-            _3 = default;
-            _1 = new Variant_class_nullable_disable_1(value);
-        }
-        public Variant_class_nullable_disable_Union(float value)
-        {
-            _1 = default;
-            _3 = default;
-            _2 = new Variant_class_nullable_disable_2(value);
-        }
-        public Variant_class_nullable_disable_Union(string value)
-        {
-            _1 = default;
-            _2 = default;
-            _3 = new Variant_class_nullable_disable_3(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_disable_1
-    {
-        public readonly int Value;
-        public readonly object _dummy1;
-
-        public Variant_class_nullable_disable_1(int value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_disable_2
-    {
-        public readonly float Value;
-        public readonly object _dummy1;
-
-        public Variant_class_nullable_disable_2(float value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_disable_3
-    {
-        public readonly string Value;
-
-        public Variant_class_nullable_disable_3(string value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -1034,9 +1035,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -1056,9 +1057,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
             }
         }
@@ -1078,9 +1079,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
             }
         }
@@ -1103,9 +1104,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1131,9 +1132,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1159,9 +1160,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1188,9 +1189,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1216,9 +1217,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1244,9 +1245,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1275,19 +1276,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
@@ -1316,19 +1317,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)variant).Value);
+                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
@@ -1356,8 +1357,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1),
-                _variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1373,8 +1374,8 @@ namespace Foo
                 global::System.Func<float, TResult> f)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2),
-                _variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1390,8 +1391,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3),
-                _variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
+                _variant => s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value));
         }
 
         /// <summary>
@@ -1411,9 +1412,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1438,9 +1439,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1465,9 +1466,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1493,9 +1494,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1520,9 +1521,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1547,9 +1548,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1575,16 +1576,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
                 }
@@ -1610,16 +1611,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
                 }
@@ -1776,7 +1777,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_class_nullable_disable _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1789,13 +1790,13 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_disable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_disable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_disable_3)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_class_nullable_disable.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -124,9 +124,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
             }
             else
             {
@@ -141,9 +141,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
         public void Match(out float f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value;
+                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
             }
             else
             {
@@ -158,9 +158,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
         public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out string? s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
             }
             else
             {
@@ -175,9 +175,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
         public void Match(out global::System.Array? a)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                a = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value;
+                a = ((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value;
             }
             else
             {
@@ -192,9 +192,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
                 return true;
             }
             else
@@ -210,9 +210,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch(out float f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value;
+                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
                 return true;
             }
             else
@@ -228,9 +228,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
                 return true;
             }
             else
@@ -246,9 +246,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
         public bool TryMatch(out global::System.Array? a)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                a = ((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value;
+                a = ((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value;
                 return true;
             }
             else
@@ -266,9 +266,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 return true;
             }
             else
@@ -284,9 +284,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<float> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 return true;
             }
             else
@@ -302,9 +302,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 return true;
             }
             else
@@ -320,9 +320,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<global::System.Array?> a)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                 return true;
             }
             else
@@ -340,9 +340,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -358,9 +358,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public void Match(global::System.Action<float> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -376,9 +376,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public void Match(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -394,9 +394,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.Array?> a)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
             }
             else
             {
@@ -413,9 +413,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -431,9 +431,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<float> f, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -449,9 +449,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -467,9 +467,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
             }
             else
             {
@@ -487,9 +487,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -506,9 +506,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -525,9 +525,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -544,9 +544,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
             }
             else
             {
@@ -564,9 +564,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -583,9 +583,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -602,9 +602,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -621,9 +621,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
             }
             else
             {
@@ -640,9 +640,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -658,9 +658,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
             }
             else
             {
@@ -676,9 +676,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
             }
             else
             {
@@ -694,9 +694,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
             {
-                return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
             }
             else
             {
@@ -716,22 +716,22 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     break;
                 case 3:
-                    s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     break;
                 case 4:
-                    a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
@@ -751,22 +751,22 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     break;
                 case 3:
-                    s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     break;
                 case 4:
-                    a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
@@ -787,18 +787,18 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 case 3:
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 case 4:
-                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
             }
@@ -817,18 +817,18 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 case 3:
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 case 4:
-                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
             }
@@ -844,11 +844,16 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_N(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_1(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_2(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_2)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_3(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_3)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_class_nullable_enable_4(Variant_class_nullable_enable v) => (global::dotVariant._G.Foo.Variant_class_nullable_enable_4)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_enable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<float>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_2<float>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_3<string>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_3<string>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_4<global::System.Array?>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_4<global::System.Array?>)v._variant;
     }
 }
 
@@ -857,36 +862,128 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_class_nullable_enable
     {
-        private readonly Variant_class_nullable_enable_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_3 _3;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_4 _4;
+
+            public Union(int value)
+            {
+                _2 = default;
+                _3 = default;
+                _4 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(float value)
+            {
+                _1 = default;
+                _3 = default;
+                _4 = default;
+                _2 = new Value_2(value);
+            }
+            public Union(string value)
+            {
+                _1 = default;
+                _2 = default;
+                _4 = default;
+                _3 = new Value_3(value);
+            }
+            public Union(global::System.Array? value)
+            {
+                _1 = default;
+                _2 = default;
+                _3 = default;
+                _4 = new Value_4(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly int Value;
+            public readonly object _dummy1;
+
+            public Value_1(int value)
+            {
+                _dummy1 = null!;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly float Value;
+            public readonly object _dummy1;
+
+            public Value_2(float value)
+            {
+                _dummy1 = null!;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_3
+        {
+            public readonly string Value;
+
+            public Value_3(string value)
+            {
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_4
+        {
+            public readonly global::System.Array? Value;
+
+            public Value_4(global::System.Array? value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_class_nullable_enable(int i)
         {
             _n = 1;
-            _x = new Variant_class_nullable_enable_Union(i);
+            _x = new Union(i);
         }
         public Variant_class_nullable_enable(float f)
         {
             _n = 2;
-            _x = new Variant_class_nullable_enable_Union(f);
+            _x = new Union(f);
         }
         public Variant_class_nullable_enable(string s)
         {
             _n = 3;
-            _x = new Variant_class_nullable_enable_Union(s);
+            _x = new Union(s);
         }
         public Variant_class_nullable_enable(global::System.Array? a)
         {
             _n = 4;
-            _x = new Variant_class_nullable_enable_Union(a);
+            _x = new Union(a);
         }
 
 
-        public static explicit operator Variant_class_nullable_enable_N(Variant_class_nullable_enable v) => new Variant_class_nullable_enable_N(v._n);
-        public static explicit operator Variant_class_nullable_enable_1(Variant_class_nullable_enable v) => v._x._1;
-        public static explicit operator Variant_class_nullable_enable_2(Variant_class_nullable_enable v) => v._x._2;
-        public static explicit operator Variant_class_nullable_enable_3(Variant_class_nullable_enable v) => v._x._3;
-        public static explicit operator Variant_class_nullable_enable_4(Variant_class_nullable_enable v) => v._x._4;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_enable v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_class_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<float>(in Variant_class_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_2<float>(v._x._2.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_3<string>(in Variant_class_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_3<string>(v._x._3.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_4<global::System.Array?>(in Variant_class_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_4<global::System.Array?>(v._x._4.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -1148,100 +1245,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_class_nullable_enable_N
-    {
-        public readonly uint N;
-        public Variant_class_nullable_enable_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_enable_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_enable_2 _2;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_enable_3 _3;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_class_nullable_enable_4 _4;
-
-        public Variant_class_nullable_enable_Union(int value)
-        {
-            _2 = default;
-            _3 = default;
-            _4 = default;
-            _1 = new Variant_class_nullable_enable_1(value);
-        }
-        public Variant_class_nullable_enable_Union(float value)
-        {
-            _1 = default;
-            _3 = default;
-            _4 = default;
-            _2 = new Variant_class_nullable_enable_2(value);
-        }
-        public Variant_class_nullable_enable_Union(string value)
-        {
-            _1 = default;
-            _2 = default;
-            _4 = default;
-            _3 = new Variant_class_nullable_enable_3(value);
-        }
-        public Variant_class_nullable_enable_Union(global::System.Array? value)
-        {
-            _1 = default;
-            _2 = default;
-            _3 = default;
-            _4 = new Variant_class_nullable_enable_4(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_enable_1
-    {
-        public readonly int Value;
-        public readonly object _dummy1;
-
-        public Variant_class_nullable_enable_1(int value)
-        {
-            _dummy1 = null!;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_enable_2
-    {
-        public readonly float Value;
-        public readonly object _dummy1;
-
-        public Variant_class_nullable_enable_2(float value)
-        {
-            _dummy1 = null!;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_enable_3
-    {
-        public readonly string Value;
-
-        public Variant_class_nullable_enable_3(string value)
-        {
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_class_nullable_enable_4
-    {
-        public readonly global::System.Array? Value;
-
-        public Variant_class_nullable_enable_4(global::System.Array? value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -1265,9 +1268,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -1287,9 +1290,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
             }
         }
@@ -1309,9 +1312,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
             }
         }
@@ -1331,9 +1334,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
                 }
             }
         }
@@ -1356,9 +1359,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1384,9 +1387,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1412,9 +1415,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1440,9 +1443,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
                 }
                 else
                 {
@@ -1469,9 +1472,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1497,9 +1500,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1525,9 +1528,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1553,9 +1556,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N == 4)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
                 }
                 else
                 {
@@ -1585,22 +1588,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                         break;
                     case 4:
-                        yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                        yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
@@ -1630,22 +1633,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)variant).Value);
+                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
                         break;
                     case 4:
-                        yield return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)variant).Value);
+                        yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
@@ -1673,8 +1676,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1),
-                _variant => i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1690,8 +1693,8 @@ namespace Foo
                 global::System.Func<float, TResult> f)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2),
-                _variant => f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1707,8 +1710,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3),
-                _variant => s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
+                _variant => s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.Array"/> element of an observable sequence
@@ -1724,8 +1727,8 @@ namespace Foo
                 global::System.Func<global::System.Array?, TResult> a)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4),
-                _variant => a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 4),
+                _variant => a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value));
         }
 
         /// <summary>
@@ -1745,9 +1748,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1772,9 +1775,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1799,9 +1802,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1826,9 +1829,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
                 {
-                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                 }
                 else
                 {
@@ -1854,9 +1857,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1881,9 +1884,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1908,9 +1911,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1935,9 +1938,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N == 4)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
                 {
-                    return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                 }
                 else
                 {
@@ -1964,18 +1967,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     case 4:
-                        return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                        return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
                 }
@@ -2002,18 +2005,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                     case 4:
-                        return a(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                        return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
                 }
@@ -2174,7 +2177,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_class_nullable_enable _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_class_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -2187,16 +2190,16 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_enable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_enable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_enable_3)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
                         break;
                     case 4:
-                        Subject4.OnNext(((global::dotVariant._G.Foo.Variant_class_nullable_enable_4)_variant).Value);
+                        Subject4.OnNext(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_class_nullable_enable.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -95,9 +95,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
             }
             else
             {
@@ -112,9 +112,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
         public void Match(out global::System.IO.Stream stream)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+                stream = ((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value;
             }
             else
             {
@@ -129,9 +129,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
                 return true;
             }
             else
@@ -147,9 +147,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
         public bool TryMatch(out global::System.IO.Stream stream)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                stream = ((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value;
+                stream = ((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value;
                 return true;
             }
             else
@@ -167,9 +167,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 return true;
             }
             else
@@ -185,9 +185,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 return true;
             }
             else
@@ -205,9 +205,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -223,9 +223,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.IO.Stream> stream)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
             }
             else
             {
@@ -242,9 +242,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -260,9 +260,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
             }
             else
             {
@@ -280,9 +280,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -299,9 +299,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
             }
             else
             {
@@ -319,9 +319,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -338,9 +338,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
             }
             else
             {
@@ -357,9 +357,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -375,9 +375,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
             }
             else
             {
@@ -395,16 +395,16 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
@@ -422,16 +422,16 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
@@ -450,14 +450,14 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
             }
@@ -474,14 +474,14 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
             }
@@ -497,9 +497,12 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_N(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_1(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_disposable_2(Variant_disposable v) => (global::dotVariant._G.Foo.Variant_disposable_2)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_disposable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_disposable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(Variant_disposable v) => (global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)v._variant;
     }
 }
 
@@ -509,18 +512,61 @@ namespace dotVariant._G.Foo
     internal readonly struct Variant_disposable
         : global::System.IDisposable
     {
-        private readonly Variant_disposable_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+
+            public Union(int value)
+            {
+                _2 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(global::System.IO.Stream value)
+            {
+                _1 = default;
+                _2 = new Value_2(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly int Value;
+            public readonly object _dummy1;
+
+            public Value_1(int value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly global::System.IO.Stream Value;
+
+            public Value_2(global::System.IO.Stream value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_disposable(int i)
         {
             _n = 1;
-            _x = new Variant_disposable_Union(i);
+            _x = new Union(i);
         }
         public Variant_disposable(global::System.IO.Stream stream)
         {
             _n = 2;
-            _x = new Variant_disposable_Union(stream);
+            _x = new Union(stream);
         }
 
         public void Dispose()
@@ -540,9 +586,12 @@ namespace dotVariant._G.Foo
             }
         }
 
-        public static explicit operator Variant_disposable_N(Variant_disposable v) => new Variant_disposable_N(v._n);
-        public static explicit operator Variant_disposable_1(Variant_disposable v) => v._x._1;
-        public static explicit operator Variant_disposable_2(Variant_disposable v) => v._x._2;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_disposable v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_disposable v)
+            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(in Variant_disposable v)
+            => new global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(v._x._2.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -754,56 +803,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_disposable_N
-    {
-        public readonly uint N;
-        public Variant_disposable_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_disposable_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_disposable_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_disposable_2 _2;
-
-        public Variant_disposable_Union(int value)
-        {
-            _2 = default;
-            _1 = new Variant_disposable_1(value);
-        }
-        public Variant_disposable_Union(global::System.IO.Stream value)
-        {
-            _1 = default;
-            _2 = new Variant_disposable_2(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_disposable_1
-    {
-        public readonly int Value;
-        public readonly object _dummy1;
-
-        public Variant_disposable_1(int value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_disposable_2
-    {
-        public readonly global::System.IO.Stream Value;
-
-        public Variant_disposable_2(global::System.IO.Stream value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -827,9 +826,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -849,9 +848,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
             }
         }
@@ -874,9 +873,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -902,9 +901,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
                 else
                 {
@@ -931,9 +930,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -959,9 +958,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
                 else
                 {
@@ -989,16 +988,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
@@ -1026,16 +1025,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_disposable_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._G.Foo.Variant_disposable_2)variant).Value);
+                        yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
@@ -1063,8 +1062,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1),
-                _variant => i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
@@ -1080,8 +1079,8 @@ namespace Foo
                 global::System.Func<global::System.IO.Stream, TResult> stream)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2),
-                _variant => stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value));
         }
 
         /// <summary>
@@ -1101,9 +1100,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1128,9 +1127,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 }
                 else
                 {
@@ -1156,9 +1155,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1183,9 +1182,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 }
                 else
                 {
@@ -1210,14 +1209,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
                 }
@@ -1242,14 +1241,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
                 }
@@ -1402,7 +1401,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_disposable _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_disposable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1415,10 +1414,10 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_disposable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_disposable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_disposable.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
@@ -70,9 +70,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
         public void Match(out int? i)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int?>)_variant).Value;
             }
             else
             {
@@ -87,9 +87,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
         public bool TryMatch(out int? i)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int?>)_variant).Value;
                 return true;
             }
             else
@@ -107,9 +107,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int?> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                 return true;
             }
             else
@@ -127,9 +127,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int?> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
             }
             else
             {
@@ -146,9 +146,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int?> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
             }
             else
             {
@@ -166,9 +166,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int?, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
             }
             else
             {
@@ -186,9 +186,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
             }
             else
             {
@@ -205,9 +205,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
             }
             else
             {
@@ -224,13 +224,13 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int?> i)
         {
-            switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
@@ -247,13 +247,13 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int?> i, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
@@ -271,12 +271,12 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int?, TResult> i)
         {
-            switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
             }
@@ -292,12 +292,12 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
             }
@@ -313,8 +313,10 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_nullable_value_type_N(Variant_nullable_value_type v) => (global::dotVariant._G.Foo.Variant_nullable_value_type_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_nullable_value_type_1(Variant_nullable_value_type v) => (global::dotVariant._G.Foo.Variant_nullable_value_type_1)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_nullable_value_type v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<int?>(Variant_nullable_value_type v) => (global::dotVariant._Private.Accessor_1<int?>)v._variant;
     }
 }
 
@@ -323,18 +325,43 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_nullable_value_type
     {
-        private readonly Variant_nullable_value_type_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+
+            public Union(int? value)
+            {
+                _1 = new Value_1(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly int? Value;
+
+            public Value_1(int? value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_nullable_value_type(int? i)
         {
             _n = 1;
-            _x = new Variant_nullable_value_type_Union(i);
+            _x = new Union(i);
         }
 
 
-        public static explicit operator Variant_nullable_value_type_N(Variant_nullable_value_type v) => new Variant_nullable_value_type_N(v._n);
-        public static explicit operator Variant_nullable_value_type_1(Variant_nullable_value_type v) => v._x._1;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_nullable_value_type v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<int?>(in Variant_nullable_value_type v)
+            => new global::dotVariant._Private.Accessor_1<int?>(v._x._1.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -521,36 +548,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_nullable_value_type_N
-    {
-        public readonly uint N;
-        public Variant_nullable_value_type_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_nullable_value_type_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_nullable_value_type_1 _1;
-
-        public Variant_nullable_value_type_Union(int? value)
-        {
-            _1 = new Variant_nullable_value_type_1(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_nullable_value_type_1
-    {
-        public readonly int? Value;
-
-        public Variant_nullable_value_type_1(int? value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -574,9 +571,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
                 }
             }
         }
@@ -599,9 +596,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
                 }
                 else
                 {
@@ -628,9 +625,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
                 }
                 else
                 {
@@ -657,13 +654,13 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
@@ -690,13 +687,13 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
@@ -724,8 +721,8 @@ namespace Foo
                 global::System.Func<int?, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1),
-                _variant => i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value));
         }
 
         /// <summary>
@@ -745,9 +742,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                 }
                 else
                 {
@@ -773,9 +770,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                 }
                 else
                 {
@@ -799,12 +796,12 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
                 }
@@ -828,12 +825,12 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
                 }
@@ -954,7 +951,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_nullable_value_type _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_nullable_value_type_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -967,7 +964,7 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_nullable_value_type_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_nullable_value_type.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -88,9 +88,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
         public void Match(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_public_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
             }
             else
             {
@@ -105,9 +105,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
         public void Match(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                s = ((global::dotVariant._G.Foo.Variant_public_2)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_2<string>)_variant).Value;
             }
             else
             {
@@ -122,9 +122,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i = ((global::dotVariant._G.Foo.Variant_public_1)_variant).Value;
+                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
                 return true;
             }
             else
@@ -140,9 +140,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch(out string s)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                s = ((global::dotVariant._G.Foo.Variant_public_2)_variant).Value;
+                s = ((global::dotVariant._Private.Accessor_2<string>)_variant).Value;
                 return true;
             }
             else
@@ -160,9 +160,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 return true;
             }
             else
@@ -178,9 +178,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public bool TryMatch(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                 return true;
             }
             else
@@ -198,9 +198,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public void Match(global::System.Action<int> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -216,9 +216,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public void Match(global::System.Action<string> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
             }
             else
             {
@@ -235,9 +235,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<int> i, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -253,9 +253,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public void Match(global::System.Action<string> s, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
             }
             else
             {
@@ -273,9 +273,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -292,9 +292,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
             }
             else
             {
@@ -312,9 +312,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -331,9 +331,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
             }
             else
             {
@@ -350,9 +350,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
             }
             else
             {
@@ -368,9 +368,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
             }
             else
             {
@@ -388,16 +388,16 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<string> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
@@ -415,16 +415,16 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     break;
                 case 2:
-                    s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
@@ -443,14 +443,14 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
         {
-            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
             }
@@ -467,14 +467,14 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 case 2:
-                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
             }
@@ -490,9 +490,12 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_public_N(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_public_1(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_public_2(Variant_public v) => (global::dotVariant._G.Foo.Variant_public_2)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_public v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_public v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<string>(Variant_public v) => (global::dotVariant._Private.Accessor_2<string>)v._variant;
     }
 }
 
@@ -501,24 +504,70 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_public
     {
-        private readonly Variant_public_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+
+            public Union(int value)
+            {
+                _2 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(string value)
+            {
+                _1 = default;
+                _2 = new Value_2(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly int Value;
+            public readonly object _dummy1;
+
+            public Value_1(int value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly string Value;
+
+            public Value_2(string value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_public(int i)
         {
             _n = 1;
-            _x = new Variant_public_Union(i);
+            _x = new Union(i);
         }
         public Variant_public(string s)
         {
             _n = 2;
-            _x = new Variant_public_Union(s);
+            _x = new Union(s);
         }
 
 
-        public static explicit operator Variant_public_N(Variant_public v) => new Variant_public_N(v._n);
-        public static explicit operator Variant_public_1(Variant_public v) => v._x._1;
-        public static explicit operator Variant_public_2(Variant_public v) => v._x._2;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_public v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_public v)
+            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<string>(in Variant_public v)
+            => new global::dotVariant._Private.Accessor_2<string>(v._x._2.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -730,56 +779,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_public_N
-    {
-        public readonly uint N;
-        public Variant_public_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_public_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_public_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_public_2 _2;
-
-        public Variant_public_Union(int value)
-        {
-            _2 = default;
-            _1 = new Variant_public_1(value);
-        }
-        public Variant_public_Union(string value)
-        {
-            _1 = default;
-            _2 = new Variant_public_2(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_public_1
-    {
-        public readonly int Value;
-        public readonly object _dummy1;
-
-        public Variant_public_1(int value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_public_2
-    {
-        public readonly string Value;
-
-        public Variant_public_2(string value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -803,9 +802,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -825,9 +824,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
                 }
             }
         }
@@ -850,9 +849,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -878,9 +877,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
                 }
                 else
                 {
@@ -907,9 +906,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
+                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -935,9 +934,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
+                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
                 }
                 else
                 {
@@ -965,16 +964,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_public_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
@@ -1002,16 +1001,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_public_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._G.Foo.Variant_public_1)variant).Value);
+                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return s(((global::dotVariant._G.Foo.Variant_public_2)variant).Value);
+                        yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
@@ -1039,8 +1038,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1),
-                _variant => i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1056,8 +1055,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2),
-                _variant => s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value));
         }
 
         /// <summary>
@@ -1077,9 +1076,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1104,9 +1103,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                 }
                 else
                 {
@@ -1132,9 +1131,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1159,9 +1158,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_public_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                 }
                 else
                 {
@@ -1186,14 +1185,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
                 }
@@ -1218,14 +1217,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return s(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                        return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
                 }
@@ -1378,7 +1377,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_public _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_public_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1391,10 +1390,10 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_public_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_public_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_public.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -105,9 +105,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
         public readonly void Match(out long l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value;
+                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
             }
             else
             {
@@ -122,9 +122,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
         public readonly void Match(out double d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value;
+                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
             }
             else
             {
@@ -139,9 +139,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
         public readonly void Match(out object o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value;
+                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
             }
             else
             {
@@ -156,9 +156,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
         public readonly bool TryMatch(out long l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value;
+                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
                 return true;
             }
             else
@@ -174,9 +174,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
         public readonly bool TryMatch(out double d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value;
+                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
                 return true;
             }
             else
@@ -192,9 +192,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
         public readonly bool TryMatch(out object o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value;
+                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
                 return true;
             }
             else
@@ -212,9 +212,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<long> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 return true;
             }
             else
@@ -230,9 +230,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<double> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 return true;
             }
             else
@@ -248,9 +248,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<object> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 return true;
             }
             else
@@ -268,9 +268,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -286,9 +286,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -304,9 +304,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -323,9 +323,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -341,9 +341,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -359,9 +359,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -379,9 +379,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -398,9 +398,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -417,9 +417,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -437,9 +437,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -456,9 +456,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -475,9 +475,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -494,9 +494,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -512,9 +512,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -530,9 +530,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -551,19 +551,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
                     break;
                 case 1:
-                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     break;
                 case 2:
-                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     break;
                 case 3:
-                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
@@ -582,19 +582,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     break;
                 case 2:
-                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     break;
                 case 3:
-                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
@@ -614,16 +614,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError<TResult>();
                 case 1:
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 case 2:
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 case 3:
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
             }
@@ -641,16 +641,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 case 2:
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 case 3:
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
             }
@@ -666,10 +666,14 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_N(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_1(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_2(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_disable_3(Variant_struct_nullable_disable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<long>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_1<long>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<double>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_2<double>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_3<object>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_3<object>)v._variant;
     }
 }
 
@@ -678,30 +682,99 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_struct_nullable_disable
     {
-        private readonly Variant_struct_nullable_disable_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_3 _3;
+
+            public Union(long value)
+            {
+                _2 = default;
+                _3 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(double value)
+            {
+                _1 = default;
+                _3 = default;
+                _2 = new Value_2(value);
+            }
+            public Union(object value)
+            {
+                _1 = default;
+                _2 = default;
+                _3 = new Value_3(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly long Value;
+            public readonly object _dummy1;
+
+            public Value_1(long value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly double Value;
+            public readonly object _dummy1;
+
+            public Value_2(double value)
+            {
+                _dummy1 = null;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_3
+        {
+            public readonly object Value;
+
+            public Value_3(object value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_struct_nullable_disable(long l)
         {
             _n = 1;
-            _x = new Variant_struct_nullable_disable_Union(l);
+            _x = new Union(l);
         }
         public Variant_struct_nullable_disable(double d)
         {
             _n = 2;
-            _x = new Variant_struct_nullable_disable_Union(d);
+            _x = new Union(d);
         }
         public Variant_struct_nullable_disable(object o)
         {
             _n = 3;
-            _x = new Variant_struct_nullable_disable_Union(o);
+            _x = new Union(o);
         }
 
 
-        public static explicit operator Variant_struct_nullable_disable_N(Variant_struct_nullable_disable v) => new Variant_struct_nullable_disable_N(v._n);
-        public static explicit operator Variant_struct_nullable_disable_1(Variant_struct_nullable_disable v) => v._x._1;
-        public static explicit operator Variant_struct_nullable_disable_2(Variant_struct_nullable_disable v) => v._x._2;
-        public static explicit operator Variant_struct_nullable_disable_3(Variant_struct_nullable_disable v) => v._x._3;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_disable v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<long>(in Variant_struct_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_1<long>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<double>(in Variant_struct_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_2<double>(v._x._2.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_3<object>(in Variant_struct_nullable_disable v)
+            => new global::dotVariant._Private.Accessor_3<object>(v._x._3.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -938,78 +1011,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_struct_nullable_disable_N
-    {
-        public readonly uint N;
-        public Variant_struct_nullable_disable_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_disable_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_disable_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_disable_2 _2;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_disable_3 _3;
-
-        public Variant_struct_nullable_disable_Union(long value)
-        {
-            _2 = default;
-            _3 = default;
-            _1 = new Variant_struct_nullable_disable_1(value);
-        }
-        public Variant_struct_nullable_disable_Union(double value)
-        {
-            _1 = default;
-            _3 = default;
-            _2 = new Variant_struct_nullable_disable_2(value);
-        }
-        public Variant_struct_nullable_disable_Union(object value)
-        {
-            _1 = default;
-            _2 = default;
-            _3 = new Variant_struct_nullable_disable_3(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_disable_1
-    {
-        public readonly long Value;
-        public readonly object _dummy1;
-
-        public Variant_struct_nullable_disable_1(long value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_disable_2
-    {
-        public readonly double Value;
-        public readonly object _dummy1;
-
-        public Variant_struct_nullable_disable_2(double value)
-        {
-            _dummy1 = null;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_disable_3
-    {
-        public readonly object Value;
-
-        public Variant_struct_nullable_disable_3(object value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -1033,9 +1034,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
             }
         }
@@ -1055,9 +1056,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
             }
         }
@@ -1077,9 +1078,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
             }
         }
@@ -1102,9 +1103,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1130,9 +1131,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1158,9 +1159,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1187,9 +1188,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1215,9 +1216,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1243,9 +1244,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1274,19 +1275,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
@@ -1315,19 +1316,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)variant).Value);
+                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)variant).Value);
+                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)variant).Value);
+                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
@@ -1355,8 +1356,8 @@ namespace Foo
                 global::System.Func<long, TResult> l)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1),
-                _variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1372,8 +1373,8 @@ namespace Foo
                 global::System.Func<double, TResult> d)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2),
-                _variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1389,8 +1390,8 @@ namespace Foo
                 global::System.Func<object, TResult> o)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3),
-                _variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
+                _variant => o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value));
         }
 
         /// <summary>
@@ -1410,9 +1411,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1437,9 +1438,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1464,9 +1465,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1492,9 +1493,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1519,9 +1520,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1546,9 +1547,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1574,16 +1575,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError<TResult>();
                     case 1:
-                        return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
                 }
@@ -1609,16 +1610,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return l(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
                 }
@@ -1775,7 +1776,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_struct_nullable_disable _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_disable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1788,13 +1789,13 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_disable_3)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_struct_nullable_disable.MakeInternalError());

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -105,9 +105,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
         public readonly void Match(out long l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value;
+                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
             }
             else
             {
@@ -122,9 +122,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
         public readonly void Match(out double d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value;
+                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
             }
             else
             {
@@ -139,9 +139,9 @@ namespace Foo
         /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
         public readonly void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out object? o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value;
+                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
             }
             else
             {
@@ -156,9 +156,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
         public readonly bool TryMatch(out long l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value;
+                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
                 return true;
             }
             else
@@ -174,9 +174,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
         public readonly bool TryMatch(out double d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value;
+                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
                 return true;
             }
             else
@@ -192,9 +192,9 @@ namespace Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
         public readonly bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o = ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value;
+                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
                 return true;
             }
             else
@@ -212,9 +212,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<long> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 return true;
             }
             else
@@ -230,9 +230,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<double> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 return true;
             }
             else
@@ -248,9 +248,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly bool TryMatch(global::System.Action<object> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 return true;
             }
             else
@@ -268,9 +268,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -286,9 +286,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -304,9 +304,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -323,9 +323,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -341,9 +341,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<double> d, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -359,9 +359,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly void Match(global::System.Action<object> o, global::System.Action _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -379,9 +379,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -398,9 +398,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -417,9 +417,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -437,9 +437,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -456,9 +456,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -475,9 +475,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -494,9 +494,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
             {
-                return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
             }
             else
             {
@@ -512,9 +512,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
             {
-                return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
             }
             else
             {
@@ -530,9 +530,9 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
             {
-                return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
             }
             else
             {
@@ -551,19 +551,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
                     break;
                 case 1:
-                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     break;
                 case 2:
-                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     break;
                 case 3:
-                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
@@ -582,19 +582,19 @@ namespace Foo
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     _();
                     break;
                 case 1:
-                    l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     break;
                 case 2:
-                    d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     break;
                 case 3:
-                    o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     break;
                 default:
                     global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
@@ -614,16 +614,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError<TResult>();
                 case 1:
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 case 2:
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 case 3:
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
             }
@@ -641,16 +641,16 @@ namespace Foo
         /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
             {
                 case 0:
                     return _();
                 case 1:
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 case 2:
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 case 3:
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 default:
                     return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
             }
@@ -666,10 +666,14 @@ namespace Foo
             }
         }
 
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_N(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_1(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_2(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)v._variant;
-        public static explicit operator global::dotVariant._G.Foo.Variant_struct_nullable_enable_3(Variant_struct_nullable_enable v) => (global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_1<long>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_1<long>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_2<double>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_2<double>)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_3<object>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_3<object>)v._variant;
     }
 }
 
@@ -678,30 +682,99 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerNonUserCode]
     internal readonly struct Variant_struct_nullable_enable
     {
-        private readonly Variant_struct_nullable_enable_Union _x;
-        private readonly uint _n;
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_1 _1;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_2 _2;
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_3 _3;
+
+            public Union(long value)
+            {
+                _2 = default;
+                _3 = default;
+                _1 = new Value_1(value);
+            }
+            public Union(double value)
+            {
+                _1 = default;
+                _3 = default;
+                _2 = new Value_2(value);
+            }
+            public Union(object value)
+            {
+                _1 = default;
+                _2 = default;
+                _3 = new Value_3(value);
+            }
+        }
+
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_1
+        {
+            public readonly long Value;
+            public readonly object _dummy1;
+
+            public Value_1(long value)
+            {
+                _dummy1 = null!;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_2
+        {
+            public readonly double Value;
+            public readonly object _dummy1;
+
+            public Value_2(double value)
+            {
+                _dummy1 = null!;
+                Value = value;
+            }
+        }
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_3
+        {
+            public readonly object Value;
+
+            public Value_3(object value)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         public Variant_struct_nullable_enable(long l)
         {
             _n = 1;
-            _x = new Variant_struct_nullable_enable_Union(l);
+            _x = new Union(l);
         }
         public Variant_struct_nullable_enable(double d)
         {
             _n = 2;
-            _x = new Variant_struct_nullable_enable_Union(d);
+            _x = new Union(d);
         }
         public Variant_struct_nullable_enable(object o)
         {
             _n = 3;
-            _x = new Variant_struct_nullable_enable_Union(o);
+            _x = new Union(o);
         }
 
 
-        public static explicit operator Variant_struct_nullable_enable_N(Variant_struct_nullable_enable v) => new Variant_struct_nullable_enable_N(v._n);
-        public static explicit operator Variant_struct_nullable_enable_1(Variant_struct_nullable_enable v) => v._x._1;
-        public static explicit operator Variant_struct_nullable_enable_2(Variant_struct_nullable_enable v) => v._x._2;
-        public static explicit operator Variant_struct_nullable_enable_3(Variant_struct_nullable_enable v) => v._x._3;
+        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_enable v)
+            => (global::dotVariant._Private.Discriminator)v._n;
+        public static explicit operator global::dotVariant._Private.Accessor_1<long>(in Variant_struct_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_1<long>(v._x._1.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_2<double>(in Variant_struct_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_2<double>(v._x._2.Value);
+        public static explicit operator global::dotVariant._Private.Accessor_3<object>(in Variant_struct_nullable_enable v)
+            => new global::dotVariant._Private.Accessor_3<object>(v._x._3.Value);
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
         [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
@@ -938,78 +1011,6 @@ namespace dotVariant._G.Foo
             }
         }
     }
-
-    public readonly ref struct Variant_struct_nullable_enable_N
-    {
-        public readonly uint N;
-        public Variant_struct_nullable_enable_N(uint n) => N = n;
-    }
-
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_enable_Union
-    {
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_enable_1 _1;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_enable_2 _2;
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly Variant_struct_nullable_enable_3 _3;
-
-        public Variant_struct_nullable_enable_Union(long value)
-        {
-            _2 = default;
-            _3 = default;
-            _1 = new Variant_struct_nullable_enable_1(value);
-        }
-        public Variant_struct_nullable_enable_Union(double value)
-        {
-            _1 = default;
-            _3 = default;
-            _2 = new Variant_struct_nullable_enable_2(value);
-        }
-        public Variant_struct_nullable_enable_Union(object value)
-        {
-            _1 = default;
-            _2 = default;
-            _3 = new Variant_struct_nullable_enable_3(value);
-        }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_enable_1
-    {
-        public readonly long Value;
-        public readonly object _dummy1;
-
-        public Variant_struct_nullable_enable_1(long value)
-        {
-            _dummy1 = null!;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_enable_2
-    {
-        public readonly double Value;
-        public readonly object _dummy1;
-
-        public Variant_struct_nullable_enable_2(double value)
-        {
-            _dummy1 = null!;
-            Value = value;
-        }
-    }
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    public readonly struct Variant_struct_nullable_enable_3
-    {
-        public readonly object Value;
-
-        public Variant_struct_nullable_enable_3(object value)
-        {
-            Value = value;
-        }
-    }
 }
 
 
@@ -1033,9 +1034,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
             }
         }
@@ -1055,9 +1056,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
             }
         }
@@ -1077,9 +1078,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
             }
         }
@@ -1102,9 +1103,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1130,9 +1131,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1158,9 +1159,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1187,9 +1188,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1215,9 +1216,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1243,9 +1244,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1274,19 +1275,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
                         yield break;
                     case 1:
-                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
@@ -1315,19 +1316,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)variant).Value);
+                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)variant).Value);
+                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)variant).Value);
+                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
                         break;
                     default:
                         global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
@@ -1355,8 +1356,8 @@ namespace Foo
                 global::System.Func<long, TResult> l)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1),
-                _variant => l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
+                _variant => l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1372,8 +1373,8 @@ namespace Foo
                 global::System.Func<double, TResult> d)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2),
-                _variant => d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
+                _variant => d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1389,8 +1390,8 @@ namespace Foo
                 global::System.Func<object, TResult> o)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3),
-                _variant => o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
+                _variant => o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value));
         }
 
         /// <summary>
@@ -1410,9 +1411,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1437,9 +1438,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1464,9 +1465,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1492,9 +1493,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 1)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1519,9 +1520,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 2)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1546,9 +1547,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N == 3)
+                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1574,16 +1575,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError<TResult>();
                     case 1:
-                        return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
                 }
@@ -1609,16 +1610,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return l(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                     default:
                         return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
                 }
@@ -1775,7 +1776,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_struct_nullable_enable _variant)
             {
-                switch (((global::dotVariant._G.Foo.Variant_struct_nullable_enable_N)_variant).N)
+                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1788,13 +1789,13 @@ namespace Foo
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_1)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_2)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._G.Foo.Variant_struct_nullable_enable_3)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
                         break;
                     default:
                         OnError(global::dotVariant._G.Foo.Variant_struct_nullable_enable.MakeInternalError());

--- a/src/dotVariant.Generator/Diagnose.cs
+++ b/src/dotVariant.Generator/Diagnose.cs
@@ -48,6 +48,7 @@ namespace dotVariant.Generator
                 new Func<ITypeSymbol, MethodDeclarationSyntax, IMethodSymbol, ImmutableArray<IParameterSymbol>, CancellationToken, IEnumerable<Diagnostic>>[]
                 {
                     CheckThat.HasAtLeastOneOption,
+                    CheckThat.NotTooManyOptions,
                     CheckThat.HasNoDuplicateOptions,
                     CheckThat.HasNoReservedName,
                     CheckThat.NoImplicitConversionForBaseClasses,
@@ -145,6 +146,23 @@ namespace dotVariant.Generator
                         nameof(HasAtLeastOneOption),
                         "'VariantOf()' must have at least one parameter.",
                         $"Variant types must have at least one parameter in their 'VariantOf()' method.",
+                        LocationOfFirstToken(syntax, SyntaxKind.IdentifierToken));
+                }
+            }
+
+            public static IEnumerable<Diagnostic> NotTooManyOptions(
+                ITypeSymbol type,
+                MethodDeclarationSyntax syntax,
+                IMethodSymbol variantOf,
+                ImmutableArray<IParameterSymbol> options,
+                CancellationToken token)
+            {
+                if (options.Count() > byte.MaxValue)
+                {
+                    yield return MakeError(
+                        nameof(NotTooManyOptions),
+                        $"'VariantOf()' must not have more than {byte.MaxValue} parameters.",
+                        $"Variant types must not have more than {byte.MaxValue} parameters in their 'VariantOf()' method.",
                         LocationOfFirstToken(syntax, SyntaxKind.IdentifierToken));
                 }
             }

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -127,15 +127,57 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
         : global::System.IDisposable
     {{~ end ~}}
     {
-        private readonly {{ Variant.Name }}_Union _x;
-        private readonly uint _n;
+        {{~ ## UNION TYPE ## ~}}
+        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+        private readonly struct Union
+        {
+            {{~ ## UNION MEMBERS ## ~}}
+            {{~ for $p in Params ~}}
+            [global::System.Runtime.InteropServices.FieldOffset(0)]
+            public readonly Value_{{ $p.Index }} _{{ $p.Index }};
+            {{~ end ~}}
+
+            {{~ ## UNION CONSTRUCTORS ## ~}}
+            {{~ for $p in Params ~}}
+            public Union({{ value_type $p }} value)
+            {
+                {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
+                _{{ $other.Index }} = default;
+                {{~ end ~}}
+                _{{ $p.Index }} = new Value_{{ $p.Index }}(value);
+            }
+            {{~ end ~}}
+        }
+
+        {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
+        {{~ for $p in Params ~}}
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        private readonly struct Value_{{ $p.Index }}
+        {
+            public readonly {{ value_type $p }} Value;
+            {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+            public readonly object _dummy{{ $dummy }};
+            {{~ end ~}}
+
+            public Value_{{ $p.Index }}({{ value_type $p }} value)
+            {
+                {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+                _dummy{{ $dummy }} = null{{ global_forgive }};
+                {{~ end ~}}
+                Value = value;
+            }
+        }
+        {{~ end ~}}
+
+        private readonly Union _x;
+        private readonly byte _n;
 
         {{~ ## STORAGE CONSTRUCTORS ## ~}}
         {{~ for $p in Params ~}}
         public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
         {
             _n = {{ $p.Index }};
-            _x = new {{ Variant.Name }}_Union({{ $p.Hint }});
+            _x = new Union({{ $p.Hint }});
         }
         {{~ end ~}}
 
@@ -161,9 +203,11 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
         {{~ end ~}}
 
         {{~ ## INTERNAL ACCESS ## ~}}
-        public static explicit operator {{ Variant.Name }}_N({{ Variant.Name }} v) => new {{ Variant.Name }}_N(v._n);
+        public static explicit operator global::dotVariant._Private.Discriminator({{ Variant.Name }} v)
+            => (global::dotVariant._Private.Discriminator)v._n;
         {{~ for $p in Params ~}}
-        public static explicit operator {{ Variant.Name }}_{{ $p.Index }}({{ Variant.Name }} v) => v._x._{{ $p.Index }};
+        public static explicit operator global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>(in {{ Variant.Name }} v)
+            => new global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>(v._x._{{ $p.Index }}.Value);
         {{~ end ~}}
 
         [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
@@ -396,54 +440,4 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
             }
         }
     }
-
-    {{~ ## DISCRIMINATOR COVERTER ## ~}}
-    {{ Variant.Accessibility }} readonly ref struct {{ Variant.Name }}_N
-    {
-        public readonly uint N;
-        public {{ Variant.Name }}_N(uint n) => N = n;
-    }
-
-    {{~ ## UNION TYPE ## ~}}
-    [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct {{ Variant.Name }}_Union
-    {
-        {{~ ## UNION MEMBERS ## ~}}
-        {{~ for $p in Params ~}}
-        [global::System.Runtime.InteropServices.FieldOffset(0)]
-        public readonly {{ Variant.Name }}_{{ $p.Index }} _{{ $p.Index }};
-        {{~ end ~}}
-
-        {{~ ## UNION CONSTRUCTORS ## ~}}
-        {{~ for $p in Params ~}}
-        public {{ Variant.Name }}_Union({{ value_type $p }} value)
-        {
-            {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
-            _{{ $other.Index }} = default;
-            {{~ end ~}}
-            _{{ $p.Index }} = new {{ Variant.Name }}_{{ $p.Index }}(value);
-        }
-        {{~ end ~}}
-    }
-
-    {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
-    {{~ for $p in Params ~}}
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    {{ Variant.Accessibility }} readonly struct {{ Variant.Name }}_{{ $p.Index }}
-    {
-        public readonly {{ value_type $p }} Value;
-        {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-        public readonly object _dummy{{ $dummy }};
-        {{~ end ~}}
-
-        public {{ Variant.Name }}_{{ $p.Index }}({{ value_type $p }} value)
-        {
-            {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-            _dummy{{ $dummy }} = null{{ global_forgive }};
-            {{~ end ~}}
-            Value = value;
-        }
-    }
-    {{~ end ~}}
 }

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -103,11 +103,11 @@ end
 
 storage_type = "global::dotVariant._G." + (Variant.Namespace ? (Variant.Namespace + ".") : "") + Variant.Name
 func get_value(param, expression = "_variant")
-    ret "((" + storage_type + "_" + param.Index + ")" + expression + ").Value"
+    ret "((global::dotVariant._Private.Accessor_" + param.Index + "<" + value_type param + ">)" + expression + ").Value"
 end
 
 func get_n(expression = "_variant")
-    ret "((" + storage_type + "_N)" + expression + ").N"
+    ret "((int)(global::dotVariant._Private.Discriminator)" + expression + ")"
 end
 
 func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Hint; end) | array.join ", "
@@ -120,6 +120,7 @@ needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.s
 
 readonly storage_type
 readonly get_value
+readonly get_n
 readonly func_params
 readonly action_params
 readonly method_modifiers
@@ -520,9 +521,11 @@ namespace {{ Variant.Namespace }}
         }
 
         {{~ ## INTERNAL ACCESS ## ~}}
-        public static explicit operator {{ storage_type }}_N({{ Variant.Name }} v) => ({{ storage_type }}_N)v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Discriminator({{ Variant.Name }} v) => (global::dotVariant._Private.Discriminator)v._variant;
         {{~ for $p in Params ~}}
-        public static explicit operator {{ storage_type }}_{{ $p.Index }}({{ Variant.Name }} v) => ({{ storage_type }}_{{ $p.Index }})v._variant;
+        [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+        public static explicit operator global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>({{ Variant.Name }} v) => (global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>)v._variant;
         {{~ end ~}}
     }
 {{~ if Variant.Namespace ~}}

--- a/src/dotVariant.Runtime/_Private/Accessor.cs
+++ b/src/dotVariant.Runtime/_Private/Accessor.cs
@@ -1,0 +1,519 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+namespace dotVariant._Private
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_1<T> { public readonly T Value; public Accessor_1(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_2<T> { public readonly T Value; public Accessor_2(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_3<T> { public readonly T Value; public Accessor_3(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_4<T> { public readonly T Value; public Accessor_4(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_5<T> { public readonly T Value; public Accessor_5(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_6<T> { public readonly T Value; public Accessor_6(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_7<T> { public readonly T Value; public Accessor_7(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_8<T> { public readonly T Value; public Accessor_8(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_9<T> { public readonly T Value; public Accessor_9(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_10<T> { public readonly T Value; public Accessor_10(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_11<T> { public readonly T Value; public Accessor_11(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_12<T> { public readonly T Value; public Accessor_12(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_13<T> { public readonly T Value; public Accessor_13(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_14<T> { public readonly T Value; public Accessor_14(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_15<T> { public readonly T Value; public Accessor_15(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_16<T> { public readonly T Value; public Accessor_16(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_17<T> { public readonly T Value; public Accessor_17(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_18<T> { public readonly T Value; public Accessor_18(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_19<T> { public readonly T Value; public Accessor_19(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_20<T> { public readonly T Value; public Accessor_20(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_21<T> { public readonly T Value; public Accessor_21(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_22<T> { public readonly T Value; public Accessor_22(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_23<T> { public readonly T Value; public Accessor_23(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_24<T> { public readonly T Value; public Accessor_24(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_25<T> { public readonly T Value; public Accessor_25(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_26<T> { public readonly T Value; public Accessor_26(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_27<T> { public readonly T Value; public Accessor_27(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_28<T> { public readonly T Value; public Accessor_28(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_29<T> { public readonly T Value; public Accessor_29(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_30<T> { public readonly T Value; public Accessor_30(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_31<T> { public readonly T Value; public Accessor_31(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_32<T> { public readonly T Value; public Accessor_32(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_33<T> { public readonly T Value; public Accessor_33(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_34<T> { public readonly T Value; public Accessor_34(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_35<T> { public readonly T Value; public Accessor_35(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_36<T> { public readonly T Value; public Accessor_36(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_37<T> { public readonly T Value; public Accessor_37(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_38<T> { public readonly T Value; public Accessor_38(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_39<T> { public readonly T Value; public Accessor_39(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_40<T> { public readonly T Value; public Accessor_40(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_41<T> { public readonly T Value; public Accessor_41(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_42<T> { public readonly T Value; public Accessor_42(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_43<T> { public readonly T Value; public Accessor_43(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_44<T> { public readonly T Value; public Accessor_44(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_45<T> { public readonly T Value; public Accessor_45(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_46<T> { public readonly T Value; public Accessor_46(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_47<T> { public readonly T Value; public Accessor_47(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_48<T> { public readonly T Value; public Accessor_48(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_49<T> { public readonly T Value; public Accessor_49(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_50<T> { public readonly T Value; public Accessor_50(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_51<T> { public readonly T Value; public Accessor_51(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_52<T> { public readonly T Value; public Accessor_52(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_53<T> { public readonly T Value; public Accessor_53(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_54<T> { public readonly T Value; public Accessor_54(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_55<T> { public readonly T Value; public Accessor_55(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_56<T> { public readonly T Value; public Accessor_56(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_57<T> { public readonly T Value; public Accessor_57(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_58<T> { public readonly T Value; public Accessor_58(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_59<T> { public readonly T Value; public Accessor_59(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_60<T> { public readonly T Value; public Accessor_60(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_61<T> { public readonly T Value; public Accessor_61(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_62<T> { public readonly T Value; public Accessor_62(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_63<T> { public readonly T Value; public Accessor_63(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_64<T> { public readonly T Value; public Accessor_64(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_65<T> { public readonly T Value; public Accessor_65(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_66<T> { public readonly T Value; public Accessor_66(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_67<T> { public readonly T Value; public Accessor_67(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_68<T> { public readonly T Value; public Accessor_68(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_69<T> { public readonly T Value; public Accessor_69(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_70<T> { public readonly T Value; public Accessor_70(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_71<T> { public readonly T Value; public Accessor_71(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_72<T> { public readonly T Value; public Accessor_72(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_73<T> { public readonly T Value; public Accessor_73(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_74<T> { public readonly T Value; public Accessor_74(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_75<T> { public readonly T Value; public Accessor_75(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_76<T> { public readonly T Value; public Accessor_76(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_77<T> { public readonly T Value; public Accessor_77(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_78<T> { public readonly T Value; public Accessor_78(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_79<T> { public readonly T Value; public Accessor_79(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_80<T> { public readonly T Value; public Accessor_80(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_81<T> { public readonly T Value; public Accessor_81(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_82<T> { public readonly T Value; public Accessor_82(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_83<T> { public readonly T Value; public Accessor_83(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_84<T> { public readonly T Value; public Accessor_84(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_85<T> { public readonly T Value; public Accessor_85(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_86<T> { public readonly T Value; public Accessor_86(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_87<T> { public readonly T Value; public Accessor_87(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_88<T> { public readonly T Value; public Accessor_88(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_89<T> { public readonly T Value; public Accessor_89(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_90<T> { public readonly T Value; public Accessor_90(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_91<T> { public readonly T Value; public Accessor_91(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_92<T> { public readonly T Value; public Accessor_92(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_93<T> { public readonly T Value; public Accessor_93(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_94<T> { public readonly T Value; public Accessor_94(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_95<T> { public readonly T Value; public Accessor_95(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_96<T> { public readonly T Value; public Accessor_96(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_97<T> { public readonly T Value; public Accessor_97(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_98<T> { public readonly T Value; public Accessor_98(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_99<T> { public readonly T Value; public Accessor_99(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_100<T> { public readonly T Value; public Accessor_100(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_101<T> { public readonly T Value; public Accessor_101(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_102<T> { public readonly T Value; public Accessor_102(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_103<T> { public readonly T Value; public Accessor_103(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_104<T> { public readonly T Value; public Accessor_104(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_105<T> { public readonly T Value; public Accessor_105(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_106<T> { public readonly T Value; public Accessor_106(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_107<T> { public readonly T Value; public Accessor_107(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_108<T> { public readonly T Value; public Accessor_108(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_109<T> { public readonly T Value; public Accessor_109(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_110<T> { public readonly T Value; public Accessor_110(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_111<T> { public readonly T Value; public Accessor_111(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_112<T> { public readonly T Value; public Accessor_112(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_113<T> { public readonly T Value; public Accessor_113(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_114<T> { public readonly T Value; public Accessor_114(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_115<T> { public readonly T Value; public Accessor_115(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_116<T> { public readonly T Value; public Accessor_116(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_117<T> { public readonly T Value; public Accessor_117(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_118<T> { public readonly T Value; public Accessor_118(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_119<T> { public readonly T Value; public Accessor_119(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_120<T> { public readonly T Value; public Accessor_120(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_121<T> { public readonly T Value; public Accessor_121(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_122<T> { public readonly T Value; public Accessor_122(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_123<T> { public readonly T Value; public Accessor_123(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_124<T> { public readonly T Value; public Accessor_124(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_125<T> { public readonly T Value; public Accessor_125(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_126<T> { public readonly T Value; public Accessor_126(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_127<T> { public readonly T Value; public Accessor_127(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_128<T> { public readonly T Value; public Accessor_128(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_129<T> { public readonly T Value; public Accessor_129(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_130<T> { public readonly T Value; public Accessor_130(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_131<T> { public readonly T Value; public Accessor_131(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_132<T> { public readonly T Value; public Accessor_132(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_133<T> { public readonly T Value; public Accessor_133(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_134<T> { public readonly T Value; public Accessor_134(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_135<T> { public readonly T Value; public Accessor_135(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_136<T> { public readonly T Value; public Accessor_136(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_137<T> { public readonly T Value; public Accessor_137(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_138<T> { public readonly T Value; public Accessor_138(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_139<T> { public readonly T Value; public Accessor_139(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_140<T> { public readonly T Value; public Accessor_140(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_141<T> { public readonly T Value; public Accessor_141(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_142<T> { public readonly T Value; public Accessor_142(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_143<T> { public readonly T Value; public Accessor_143(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_144<T> { public readonly T Value; public Accessor_144(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_145<T> { public readonly T Value; public Accessor_145(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_146<T> { public readonly T Value; public Accessor_146(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_147<T> { public readonly T Value; public Accessor_147(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_148<T> { public readonly T Value; public Accessor_148(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_149<T> { public readonly T Value; public Accessor_149(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_150<T> { public readonly T Value; public Accessor_150(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_151<T> { public readonly T Value; public Accessor_151(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_152<T> { public readonly T Value; public Accessor_152(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_153<T> { public readonly T Value; public Accessor_153(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_154<T> { public readonly T Value; public Accessor_154(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_155<T> { public readonly T Value; public Accessor_155(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_156<T> { public readonly T Value; public Accessor_156(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_157<T> { public readonly T Value; public Accessor_157(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_158<T> { public readonly T Value; public Accessor_158(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_159<T> { public readonly T Value; public Accessor_159(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_160<T> { public readonly T Value; public Accessor_160(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_161<T> { public readonly T Value; public Accessor_161(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_162<T> { public readonly T Value; public Accessor_162(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_163<T> { public readonly T Value; public Accessor_163(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_164<T> { public readonly T Value; public Accessor_164(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_165<T> { public readonly T Value; public Accessor_165(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_166<T> { public readonly T Value; public Accessor_166(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_167<T> { public readonly T Value; public Accessor_167(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_168<T> { public readonly T Value; public Accessor_168(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_169<T> { public readonly T Value; public Accessor_169(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_170<T> { public readonly T Value; public Accessor_170(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_171<T> { public readonly T Value; public Accessor_171(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_172<T> { public readonly T Value; public Accessor_172(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_173<T> { public readonly T Value; public Accessor_173(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_174<T> { public readonly T Value; public Accessor_174(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_175<T> { public readonly T Value; public Accessor_175(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_176<T> { public readonly T Value; public Accessor_176(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_177<T> { public readonly T Value; public Accessor_177(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_178<T> { public readonly T Value; public Accessor_178(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_179<T> { public readonly T Value; public Accessor_179(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_180<T> { public readonly T Value; public Accessor_180(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_181<T> { public readonly T Value; public Accessor_181(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_182<T> { public readonly T Value; public Accessor_182(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_183<T> { public readonly T Value; public Accessor_183(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_184<T> { public readonly T Value; public Accessor_184(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_185<T> { public readonly T Value; public Accessor_185(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_186<T> { public readonly T Value; public Accessor_186(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_187<T> { public readonly T Value; public Accessor_187(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_188<T> { public readonly T Value; public Accessor_188(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_189<T> { public readonly T Value; public Accessor_189(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_190<T> { public readonly T Value; public Accessor_190(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_191<T> { public readonly T Value; public Accessor_191(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_192<T> { public readonly T Value; public Accessor_192(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_193<T> { public readonly T Value; public Accessor_193(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_194<T> { public readonly T Value; public Accessor_194(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_195<T> { public readonly T Value; public Accessor_195(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_196<T> { public readonly T Value; public Accessor_196(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_197<T> { public readonly T Value; public Accessor_197(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_198<T> { public readonly T Value; public Accessor_198(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_199<T> { public readonly T Value; public Accessor_199(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_200<T> { public readonly T Value; public Accessor_200(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_201<T> { public readonly T Value; public Accessor_201(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_202<T> { public readonly T Value; public Accessor_202(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_203<T> { public readonly T Value; public Accessor_203(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_204<T> { public readonly T Value; public Accessor_204(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_205<T> { public readonly T Value; public Accessor_205(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_206<T> { public readonly T Value; public Accessor_206(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_207<T> { public readonly T Value; public Accessor_207(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_208<T> { public readonly T Value; public Accessor_208(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_209<T> { public readonly T Value; public Accessor_209(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_210<T> { public readonly T Value; public Accessor_210(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_211<T> { public readonly T Value; public Accessor_211(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_212<T> { public readonly T Value; public Accessor_212(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_213<T> { public readonly T Value; public Accessor_213(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_214<T> { public readonly T Value; public Accessor_214(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_215<T> { public readonly T Value; public Accessor_215(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_216<T> { public readonly T Value; public Accessor_216(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_217<T> { public readonly T Value; public Accessor_217(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_218<T> { public readonly T Value; public Accessor_218(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_219<T> { public readonly T Value; public Accessor_219(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_220<T> { public readonly T Value; public Accessor_220(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_221<T> { public readonly T Value; public Accessor_221(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_222<T> { public readonly T Value; public Accessor_222(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_223<T> { public readonly T Value; public Accessor_223(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_224<T> { public readonly T Value; public Accessor_224(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_225<T> { public readonly T Value; public Accessor_225(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_226<T> { public readonly T Value; public Accessor_226(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_227<T> { public readonly T Value; public Accessor_227(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_228<T> { public readonly T Value; public Accessor_228(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_229<T> { public readonly T Value; public Accessor_229(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_230<T> { public readonly T Value; public Accessor_230(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_231<T> { public readonly T Value; public Accessor_231(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_232<T> { public readonly T Value; public Accessor_232(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_233<T> { public readonly T Value; public Accessor_233(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_234<T> { public readonly T Value; public Accessor_234(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_235<T> { public readonly T Value; public Accessor_235(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_236<T> { public readonly T Value; public Accessor_236(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_237<T> { public readonly T Value; public Accessor_237(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_238<T> { public readonly T Value; public Accessor_238(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_239<T> { public readonly T Value; public Accessor_239(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_240<T> { public readonly T Value; public Accessor_240(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_241<T> { public readonly T Value; public Accessor_241(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_242<T> { public readonly T Value; public Accessor_242(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_243<T> { public readonly T Value; public Accessor_243(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_244<T> { public readonly T Value; public Accessor_244(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_245<T> { public readonly T Value; public Accessor_245(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_246<T> { public readonly T Value; public Accessor_246(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_247<T> { public readonly T Value; public Accessor_247(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_248<T> { public readonly T Value; public Accessor_248(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_249<T> { public readonly T Value; public Accessor_249(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_250<T> { public readonly T Value; public Accessor_250(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_251<T> { public readonly T Value; public Accessor_251(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_252<T> { public readonly T Value; public Accessor_252(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_253<T> { public readonly T Value; public Accessor_253(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_254<T> { public readonly T Value; public Accessor_254(T value) => Value = value; }
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public readonly struct Accessor_255<T> { public readonly T Value; public Accessor_255(T value) => Value = value; }
+}

--- a/src/dotVariant.Runtime/_Private/Discriminator.cs
+++ b/src/dotVariant.Runtime/_Private/Discriminator.cs
@@ -1,0 +1,11 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+namespace dotVariant._Private
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public enum Discriminator : byte { }
+}


### PR DESCRIPTION
For generic variants there can be multiple types with the same name but
different number of generic arguments, for example

`Foo<T1>`
`Foo<T1, T2>`

As such we can no longer rely on the uniqueness of the name when
generating new types. To circumvent this have pre-defined types in the
runtime support library so they can be used as the access key. That now
means we can keep the union types private to the variant implementation,
which has the same generic parameters as the primary type and is thus
unique again.