### PR TITLE
Some improvements to test setup

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,6 +13,7 @@
 
     <EnableNETAnalyzer>true</EnableNETAnalyzer>
     <PackageSelfTest Condition="'$(PackageSelfTest)' == ''">false</PackageSelfTest>
+    <DefineConstants Condition="'$(CI)' != ''">$(DefineConstants);CI</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -158,13 +158,8 @@ namespace dotVariant.Generator.Test
                 .Select(name =>
                 {
                     var match = testPattern.Match(name[prefix.Length..]);
-                    return (Name: match.Groups[1].Value, Input: Load());
-
-                    string Load()
-                    {
-                        using var stream = assembly.GetManifestResourceStream(name);
-                        return new StreamReader(stream!).ReadToEnd();
-                    }
+                    using var reader = new StreamReader(assembly.GetManifestResourceStream(name)!);
+                    return (Name: match.Groups[1].Value, Input: reader.ReadToEnd());
                 })
                 .Select(test =>
                     new TestCaseData(test.Input)

--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -31,7 +31,7 @@ namespace dotVariant.Generator.Test
                     $"{typeof(SourceGenerator).FullName}",
                     $"{typeName}.cs");
             var output = outputs[file];
-            output = GetCopyrightHeader(input).ToString() + output;
+            output = _copyrightHeader + output;
             if (output != expected)
             {
                 // TODO: create diff
@@ -57,29 +57,7 @@ namespace dotVariant.Generator.Test
                         LoadSample($"{test.FileName}.out.cs"))
                     .SetName($"{nameof(Translation)}({test.FileName})"));
 
-        private static ReadOnlySpan<char> GetCopyrightHeader(ReadOnlySpan<char> input)
-        {
-            // The test file saved on disk contains a copyright header that is not
-            // produced by the generator. Extract it from the input so we can
-            // prepend it to the output for test comparison.
-
-            var start = input;
-            var header = 0;
-            var eol = 0;
-            do
-            {
-                eol = input.IndexOf(Environment.NewLine.AsSpan());
-                if (eol > 0 && input[0] != '/')
-                {
-                    break;
-                }
-                var line = eol + Environment.NewLine.Length;
-                header += line;
-                input = input[line..];
-            }
-            while (eol != -1);
-            return start.Slice(0, header);
-        }
+        private static readonly string _copyrightHeader = LoadSample("copyright.cs");
 
         [TestCaseSource(nameof(DiagnosticsCases))]
         public static void Diagnostics(string input)

--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -35,6 +35,10 @@
       <Link>samples/%(RecursiveDir)%(Filename)%(Extension)</Link>
       <LogicalName>dotVariant.Generator.Test.samples.%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="SamplesDir" Value="$(MSBuildThisFileDirectory)samples" />
   </ItemGroup>
 
 </Project>

--- a/src/dotVariant.Generator.Test/samples/copyright.cs
+++ b/src/dotVariant.Generator.Test/samples/copyright.cs
@@ -1,0 +1,6 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+


### PR DESCRIPTION
- Allow directly saving transformed samples when running these tests
- Fix missing dispose
- Use an empty file with copyright header to compare transformation results