### PR TITLE
Refactor internals of variant's union storage type

### DIFF
--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -9,48 +9,52 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial class Variant_class_nullable_disable
         : global::System.IEquatable<Variant_class_nullable_disable>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_class_nullable_disable _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_disable(int i)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(i);
+            => _variant = new __VariantImpl(i);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_disable(float f)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(f);
+            => _variant = new __VariantImpl(f);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_disable(string s)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_disable(s);
+            => _variant = new __VariantImpl(s);
 
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_disable(int i)
             => new Variant_class_nullable_disable(i);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_disable(float f)
             => new Variant_class_nullable_disable(f);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_disable(string s)
             => new Variant_class_nullable_disable(s);
 
@@ -58,604 +62,196 @@ namespace Foo
         /// Create a Variant_class_nullable_disable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_disable Create(int i)
             => new Variant_class_nullable_disable(i);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_disable Create(float f)
             => new Variant_class_nullable_disable(f);
         /// <summary>
         /// Create a Variant_class_nullable_disable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_disable Create(string s)
             => new Variant_class_nullable_disable(s);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_class_nullable_disable was constructed without a value.
-        /// </summary>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override bool Equals(object other)
             => other is Variant_class_nullable_disable v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool Equals(Variant_class_nullable_disable other)
             => !(other is null) && _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_class_nullable_disable lhs, Variant_class_nullable_disable rhs)
-            => lhs?.Equals(rhs) ?? (rhs is null);
+        => lhs?.Equals(rhs) ?? (rhs is null);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_class_nullable_disable lhs, Variant_class_nullable_disable rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
-        public void Match(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
-        public void Match(out float f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
-        public void Match(out string s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                i = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
-        /// </summary>
-        /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
-        public bool TryMatch(out float f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                f = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
-        public bool TryMatch(out string s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                s = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<float> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public void Match(global::System.Action<float> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<float> f, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="f"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<float, TResult> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_disable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="f"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out float)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out float f)
+            => _variant.TryMatch(out f);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{float})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<float> f)
+            => _variant.TryMatch(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out float)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out float f)
+            => _variant.Match(out f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{float})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<float> f)
+            => _variant.Match(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{float}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<float> f, global::System.Action _)
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<float, TResult> f)
+            => _variant.Match(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out string s)
+            => _variant.TryMatch(out s);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<string> s)
+            => _variant.TryMatch(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out string s)
+            => _variant.Match(out s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s, global::System.Action _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(s, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_disable,
-        /// and throw an exception if Variant_class_nullable_disable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{float}, global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                    break;
-                case 3:
-                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, f, s);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable,
-        /// and invoke a special delegate if Variant_class_nullable_disable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_class_nullable_disable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{float}, global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                    break;
-                case 3:
-                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, f, s, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_disable and return the result,
-        /// and throw an exception if Variant_class_nullable_disable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{float, TResult}, global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError<TResult>();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                case 3:
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, f, s);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable and return the result,
-        /// and invoke a special delegate if Variant_class_nullable_disable is empty and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_class_nullable_disable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{float, TResult}, global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                case 3:
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, f, s, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -668,178 +264,158 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_disable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_class_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(Variant_class_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<int>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<float>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_2<float>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(Variant_class_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<float>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_3<string>(Variant_class_nullable_disable v) => (global::dotVariant._Private.Accessor_3<string>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(Variant_class_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_3<string>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_disable
+    partial class Variant_class_nullable_disable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
-            public Union(int value)
-            {
-                _2 = default;
-                _3 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(float value)
-            {
-                _1 = default;
-                _3 = default;
-                _2 = new Value_2(value);
-            }
-            public Union(string value)
-            {
-                _1 = default;
-                _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly float Value;
-            public readonly object _dummy1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_3 _3;
 
-            public Value_2(float value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly string Value;
-
-            public Value_3(string value)
-            {
-                Value = value;
-            }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_class_nullable_disable(int i)
-        {
-            _n = 1;
-            _x = new Union(i);
-        }
-        public Variant_class_nullable_disable(float f)
-        {
-            _n = 2;
-            _x = new Union(f);
-        }
-        public Variant_class_nullable_disable(string s)
-        {
-            _n = 3;
-            _x = new Union(s);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_disable v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_class_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<float>(in Variant_class_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_2<float>(v._x._2.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_3<string>(in Variant_class_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_3<string>(v._x._3.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_class_nullable_disable is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_class_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(int value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "int";
-                    case 2:
-                        return "float";
-                    case 3:
-                        return "string";
-                    default:
-                        return ThrowInternalError<string>();
+                    _2 = default;
+                    _3 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(float value)
+                {
+                    _1 = default;
+                    _3 = default;
+                    _2 = new Value_2(value);
+                }
+                public Union(string value)
+                {
+                    _1 = default;
+                    _2 = default;
+                    _3 = new Value_3(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly int Value;
+                public readonly object _dummy1;
+
+                public Value_1(int value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
+            {
+                public readonly float Value;
+                public readonly object _dummy1;
+
+                public Value_2(float value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_3
+            {
+                public readonly string Value;
+
+                public Value_3(string value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(int i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+            public __VariantImpl(float f)
+            {
+                _n = 2;
+                _x = new Union(f);
+            }
+            public __VariantImpl(string s)
+            {
+                _n = 3;
+                _x = new Union(s);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_class_nullable_disable was constructed without a value.
+            /// </summary>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int";
+                        case 2:
+                            return "float";
+                        case 3:
+                            return "string";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_disable");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -852,55 +428,55 @@ namespace dotVariant._G.Foo
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_disable");
                 }
             }
-        }
 
-        public object AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        case 3:
+                            return _x._3.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_class_nullable_disable");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
                     case 3:
-                        return _x._3.Value;
+                        return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
                     default:
-                        return ThrowInternalError<object>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_class_nullable_disable");
                 }
             }
-        }
 
-        public bool Equals(in Variant_class_nullable_disable other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
-                case 3:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -913,102 +489,485 @@ namespace dotVariant._G.Foo
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_class_nullable_disable");
                 }
             }
-        }
 
-        public bool TryMatch(out int i)
-        {
-            i = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out float f)
-        {
-            f = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-        public bool TryMatch(out string s)
-        {
-            s = _n == 3 ? _x._3.Value : default;
-            return _n == 3;
-        }
-
-        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
+            public bool TryMatch(out int i)
             {
-                case 0:
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
+            public void Match(out int i)
+            {
+                if (_n == 1)
+                {
+                    i = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    f(_x._2.Value);
-                    break;
-                case 3:
-                    s(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    f(_x._2.Value);
-                    break;
-                case 3:
-                    s(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return i(_x._1.Value);
-                case 2:
-                    return f(_x._2.Value);
-                case 3:
-                    return s(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "int", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return i(_x._1.Value);
-                case 2:
+                return _n == 1 ? i(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="int"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? i(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
+            /// </summary>
+            /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
+            public bool TryMatch(out float f)
+            {
+                f = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<float> f)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
+            public void Match(out float f)
+            {
+                if (_n == 2)
+                {
+                    f = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public void Match(global::System.Action<float> f)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<float> f, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="f"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="float"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f)
+            {
+                if (_n == 2)
+                {
                     return f(_x._2.Value);
-                case 3:
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="f"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
+            {
+                return _n == 2 ? f(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? f(_x._2.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
+            public bool TryMatch(out string s)
+            {
+                s = _n == 3 ? _x._3.Value : default;
+                return _n == 3;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<string> s)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
+            public void Match(out string s)
+            {
+                if (_n == 3)
+                {
+                    s = _x._3.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s, global::System.Action _)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            {
+                if (_n == 3)
+                {
                     return s(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            {
+                return _n == 3 ? s(_x._3.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            {
+                return _n == 3 ? s(_x._3.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable,
+            /// and invoke a special delegate if Variant_class_nullable_disable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_class_nullable_disable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        f(_x._2.Value);
+                        break;
+                    case 3:
+                        s(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_disable,
+            /// and throw an exception if Variant_class_nullable_disable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_disable");
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        f(_x._2.Value);
+                        break;
+                    case 3:
+                        s(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_disable and return the result,
+            /// and invoke a special delegate if Variant_class_nullable_disable is empty and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_class_nullable_disable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return f(_x._2.Value);
+                    case 3:
+                        return s(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_disable and return the result,
+            /// and throw an exception if Variant_class_nullable_disable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_disable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_disable");
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return f(_x._2.Value);
+                    case 3:
+                        return s(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
+                }
             }
         }
     }
@@ -1035,9 +994,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -1057,9 +1016,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
             }
         }
@@ -1079,9 +1038,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
             }
         }
@@ -1104,9 +1063,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1132,9 +1091,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1160,9 +1119,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1189,9 +1148,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1217,9 +1176,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1245,9 +1204,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1276,22 +1235,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_disable");
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                        yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
                         yield break;
                 }
             }
@@ -1317,22 +1276,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                        yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
                         yield break;
                 }
             }
@@ -1357,8 +1316,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1374,8 +1333,8 @@ namespace Foo
                 global::System.Func<float, TResult> f)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1391,8 +1350,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
-                _variant => s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3),
+                _variant => s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value));
         }
 
         /// <summary>
@@ -1412,9 +1371,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1439,9 +1398,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                    return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1466,9 +1425,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1494,9 +1453,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1521,9 +1480,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                    return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1548,9 +1507,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1576,18 +1535,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_disable");
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
                 }
             });
         }
@@ -1611,18 +1570,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_disable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
                 }
             });
         }
@@ -1777,7 +1736,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_class_nullable_disable _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1786,20 +1745,20 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_class_nullable_disable.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_class_nullable_disable"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_class_nullable_disable.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_class_nullable_disable"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -9,60 +9,66 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial class Variant_class_nullable_enable
         : global::System.IEquatable<Variant_class_nullable_enable>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_class_nullable_enable _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_enable(int i)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(i);
+            => _variant = new __VariantImpl(i);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_enable(float f)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(f);
+            => _variant = new __VariantImpl(f);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_enable(string s)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(s);
+            => _variant = new __VariantImpl(s);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_class_nullable_enable(global::System.Array? a)
-            => _variant = new global::dotVariant._G.Foo.Variant_class_nullable_enable(a);
+            => _variant = new __VariantImpl(a);
 
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_enable(int i)
             => new Variant_class_nullable_enable(i);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_enable(float f)
             => new Variant_class_nullable_enable(f);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_enable(string s)
             => new Variant_class_nullable_enable(s);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_class_nullable_enable(global::System.Array? a)
             => new Variant_class_nullable_enable(a);
 
@@ -70,769 +76,243 @@ namespace Foo
         /// Create a Variant_class_nullable_enable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_enable Create(int i)
             => new Variant_class_nullable_enable(i);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="float"/>.
         /// </summary>
         /// <param name="f">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_enable Create(float f)
             => new Variant_class_nullable_enable(f);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_enable Create(string s)
             => new Variant_class_nullable_enable(s);
         /// <summary>
         /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_class_nullable_enable Create(global::System.Array? a)
             => new Variant_class_nullable_enable(a);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_class_nullable_enable was constructed without a value.
-        /// </summary>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override bool Equals(object? other)
             => other is Variant_class_nullable_enable v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool Equals(Variant_class_nullable_enable? other)
             => !(other is null) && _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_class_nullable_enable? lhs, Variant_class_nullable_enable? rhs)
-            => lhs?.Equals(rhs) ?? (rhs is null);
+        => lhs?.Equals(rhs) ?? (rhs is null);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_class_nullable_enable? lhs, Variant_class_nullable_enable? rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
-        public void Match(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
-        public void Match(out float f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
-        public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out string? s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
-        public void Match(out global::System.Array? a)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                a = ((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'System.Array?', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                i = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
-        /// </summary>
-        /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
-        public bool TryMatch(out float f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f = ((global::dotVariant._Private.Accessor_2<float>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                f = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
-        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s = ((global::dotVariant._Private.Accessor_3<string>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                s = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
-        /// </summary>
-        /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
-        public bool TryMatch(out global::System.Array? a)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                a = ((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                a = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<float> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<global::System.Array?> a)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public void Match(global::System.Action<float> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.Array?> a)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'System.Array?', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<float> f, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="f"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<float, TResult> f)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'float', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="a"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_class_nullable_enable' (expected 'System.Array?', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="f"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="a"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out float)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out float f)
+            => _variant.TryMatch(out f);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{float})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<float> f)
+            => _variant.TryMatch(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out float)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out float f)
+            => _variant.Match(out f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{float})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<float> f)
+            => _variant.Match(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{float}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<float> f, global::System.Action _)
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<float, TResult> f)
+            => _variant.Match(f);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{float, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(f, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out string?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
+            => _variant.TryMatch(out s);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<string> s)
+            => _variant.TryMatch(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out string?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out string? s)
+            => _variant.Match(out s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s, global::System.Action _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Array?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out global::System.Array? a)
+            => _variant.TryMatch(out a);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{global::System.Array?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<global::System.Array?> a)
+            => _variant.TryMatch(a);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out global::System.Array?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out global::System.Array? a)
+            => _variant.Match(out a);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{global::System.Array?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<global::System.Array?> a)
+            => _variant.Match(a);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{global::System.Array?}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
+            => _variant.Match(a, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.Array?, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
+            => _variant.Match(a);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.Array?, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
+            => _variant.Match(a, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.Array?, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
-            {
-                return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(a, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_enable,
-        /// and throw an exception if Variant_class_nullable_enable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{float}, global::System.Action{string}, global::System.Action{global::System.Array?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                    break;
-                case 3:
-                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                    break;
-                case 4:
-                    a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, f, s, a);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable,
-        /// and invoke a special delegate if Variant_class_nullable_enable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{float}, global::System.Action{string}, global::System.Action{global::System.Array?}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                    break;
-                case 3:
-                    s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                    break;
-                case 4:
-                    a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, f, s, a, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_enable and return the result,
-        /// and throw an exception if Variant_class_nullable_enable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{float, TResult}, global::System.Func{string, TResult}, global::System.Func{global::System.Array?, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError<TResult>();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                case 3:
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                case 4:
-                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, f, s, a);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable and return the result,
-        /// and invoke a special delegate if Variant_class_nullable_enable is empty and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{float, TResult}, global::System.Func{string, TResult}, global::System.Func{global::System.Array?, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
-                case 3:
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
-                case 4:
-                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, f, s, a, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -845,211 +325,193 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_enable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_class_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(Variant_class_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<int>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<float>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_2<float>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(Variant_class_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<float>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_3<string>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_3<string>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(Variant_class_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_3<string>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_4<global::System.Array?>(Variant_class_nullable_enable v) => (global::dotVariant._Private.Accessor_4<global::System.Array?>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(Variant_class_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_class_nullable_enable
+    partial class Variant_class_nullable_enable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_4 _4;
-
-            public Union(int value)
-            {
-                _2 = default;
-                _3 = default;
-                _4 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(float value)
-            {
-                _1 = default;
-                _3 = default;
-                _4 = default;
-                _2 = new Value_2(value);
-            }
-            public Union(string value)
-            {
-                _1 = default;
-                _2 = default;
-                _4 = default;
-                _3 = new Value_3(value);
-            }
-            public Union(global::System.Array? value)
-            {
-                _1 = default;
-                _2 = default;
-                _3 = default;
-                _4 = new Value_4(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly float Value;
-            public readonly object _dummy1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_3 _3;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_4 _4;
 
-            public Value_2(float value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly string Value;
-
-            public Value_3(string value)
-            {
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_4
-        {
-            public readonly global::System.Array? Value;
-
-            public Value_4(global::System.Array? value)
-            {
-                Value = value;
-            }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_class_nullable_enable(int i)
-        {
-            _n = 1;
-            _x = new Union(i);
-        }
-        public Variant_class_nullable_enable(float f)
-        {
-            _n = 2;
-            _x = new Union(f);
-        }
-        public Variant_class_nullable_enable(string s)
-        {
-            _n = 3;
-            _x = new Union(s);
-        }
-        public Variant_class_nullable_enable(global::System.Array? a)
-        {
-            _n = 4;
-            _x = new Union(a);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_class_nullable_enable v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_class_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<float>(in Variant_class_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_2<float>(v._x._2.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_3<string>(in Variant_class_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_3<string>(v._x._3.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_4<global::System.Array?>(in Variant_class_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_4<global::System.Array?>(v._x._4.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_class_nullable_enable is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_class_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(int value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "int";
-                    case 2:
-                        return "float";
-                    case 3:
-                        return "string";
-                    case 4:
-                        return "System.Array?";
-                    default:
-                        return ThrowInternalError<string>();
+                    _2 = default;
+                    _3 = default;
+                    _4 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(float value)
+                {
+                    _1 = default;
+                    _3 = default;
+                    _4 = default;
+                    _2 = new Value_2(value);
+                }
+                public Union(string value)
+                {
+                    _1 = default;
+                    _2 = default;
+                    _4 = default;
+                    _3 = new Value_3(value);
+                }
+                public Union(global::System.Array? value)
+                {
+                    _1 = default;
+                    _2 = default;
+                    _3 = default;
+                    _4 = new Value_4(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly int Value;
+                public readonly object _dummy1;
+
+                public Value_1(int value)
+                {
+                    _dummy1 = null!;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
+            {
+                public readonly float Value;
+                public readonly object _dummy1;
+
+                public Value_2(float value)
+                {
+                    _dummy1 = null!;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_3
+            {
+                public readonly string Value;
+
+                public Value_3(string value)
+                {
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_4
+            {
+                public readonly global::System.Array? Value;
+
+                public Value_4(global::System.Array? value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(int i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+            public __VariantImpl(float f)
+            {
+                _n = 2;
+                _x = new Union(f);
+            }
+            public __VariantImpl(string s)
+            {
+                _n = 3;
+                _x = new Union(s);
+            }
+            public __VariantImpl(global::System.Array? a)
+            {
+                _n = 4;
+                _x = new Union(a);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(v._x._4.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_class_nullable_enable was constructed without a value.
+            /// </summary>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int";
+                        case 2:
+                            return "float";
+                        case 3:
+                            return "string";
+                        case 4:
+                            return "System.Array?";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_enable");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -1064,59 +526,59 @@ namespace dotVariant._G.Foo
                     case 4:
                         return _x._4.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_enable");
                 }
             }
-        }
 
-        public object? AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object? AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        case 3:
+                            return _x._3.Value;
+                        case 4:
+                            return _x._4.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant_class_nullable_enable");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
                     case 3:
-                        return _x._3.Value;
+                        return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
                     case 4:
-                        return _x._4.Value;
+                        return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
                     default:
-                        return ThrowInternalError<object?>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_class_nullable_enable");
                 }
             }
-        }
 
-        public bool Equals(in Variant_class_nullable_enable other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
-                case 3:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
-                case 4:
-                    return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -1131,117 +593,619 @@ namespace dotVariant._G.Foo
                     case 4:
                         return global::System.HashCode.Combine(_x._4.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_class_nullable_enable");
                 }
             }
-        }
 
-        public bool TryMatch(out int i)
-        {
-            i = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out float f)
-        {
-            f = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
-        {
-            s = _n == 3 ? _x._3.Value : default;
-            return _n == 3;
-        }
-        public bool TryMatch(out global::System.Array? a)
-        {
-            a = _n == 4 ? _x._4.Value : default;
-            return _n == 4;
-        }
-
-        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
+            public bool TryMatch(out int i)
             {
-                case 0:
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
+            public void Match(out int i)
+            {
+                if (_n == 1)
+                {
+                    i = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    f(_x._2.Value);
-                    break;
-                case 3:
-                    s(_x._3.Value);
-                    break;
-                case 4:
-                    a(_x._4.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    f(_x._2.Value);
-                    break;
-                case 3:
-                    s(_x._3.Value);
-                    break;
-                case 4:
-                    a(_x._4.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return i(_x._1.Value);
-                case 2:
-                    return f(_x._2.Value);
-                case 3:
-                    return s(_x._3.Value);
-                case 4:
-                    return a(_x._4.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "int", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return i(_x._1.Value);
-                case 2:
+                return _n == 1 ? i(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="int"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? i(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
+            /// </summary>
+            /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
+            public bool TryMatch(out float f)
+            {
+                f = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<float> f)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">Receives the stored value if it is of type <see cref="float"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
+            public void Match(out float f)
+            {
+                if (_n == 2)
+                {
+                    f = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public void Match(global::System.Action<float> f)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<float> f, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    f(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="f"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="float"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f)
+            {
+                if (_n == 2)
+                {
                     return f(_x._2.Value);
-                case 3:
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "float", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="f"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
+            {
+                return _n == 2 ? f(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="f">The delegate to invoke with the stored value if it is of type <see cref="float"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? f(_x._2.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
+            public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
+            {
+                s = _n == 3 ? _x._3.Value : default;
+                return _n == 3;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<string> s)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
+            public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out string? s)
+            {
+                if (_n == 3)
+                {
+                    s = _x._3.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s, global::System.Action _)
+            {
+                if (_n == 3)
+                {
+                    s(_x._3.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            {
+                if (_n == 3)
+                {
                     return s(_x._3.Value);
-                case 4:
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            {
+                return _n == 3 ? s(_x._3.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            {
+                return _n == 3 ? s(_x._3.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
+            /// </summary>
+            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
+            public bool TryMatch(out global::System.Array? a)
+            {
+                a = _n == 4 ? _x._4.Value : default;
+                return _n == 4;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<global::System.Array?> a)
+            {
+                if (_n == 4)
+                {
+                    a(_x._4.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
+            public void Match(out global::System.Array? a)
+            {
+                if (_n == 4)
+                {
+                    a = _x._4.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
+            public void Match(global::System.Action<global::System.Array?> a)
+            {
+                if (_n == 4)
+                {
+                    a(_x._4.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
+            {
+                if (_n == 4)
+                {
+                    a(_x._4.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="a"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
+            {
+                if (_n == 4)
+                {
                     return a(_x._4.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="a"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
+            {
+                return _n == 4 ? a(_x._4.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
+            {
+                return _n == 4 ? a(_x._4.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable,
+            /// and invoke a special delegate if Variant_class_nullable_enable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        f(_x._2.Value);
+                        break;
+                    case 3:
+                        s(_x._3.Value);
+                        break;
+                    case 4:
+                        a(_x._4.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_enable,
+            /// and throw an exception if Variant_class_nullable_enable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_enable");
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        f(_x._2.Value);
+                        break;
+                    case 3:
+                        s(_x._3.Value);
+                        break;
+                    case 4:
+                        a(_x._4.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_class_nullable_enable and return the result,
+            /// and invoke a special delegate if Variant_class_nullable_enable is empty and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return f(_x._2.Value);
+                    case 3:
+                        return s(_x._3.Value);
+                    case 4:
+                        return a(_x._4.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_class_nullable_enable and return the result,
+            /// and throw an exception if Variant_class_nullable_enable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<float, TResult> f, global::System.Func<string, TResult> s, global::System.Func<global::System.Array?, TResult> a)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_enable");
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return f(_x._2.Value);
+                    case 3:
+                        return s(_x._3.Value);
+                    case 4:
+                        return a(_x._4.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
+                }
             }
         }
     }
@@ -1268,9 +1232,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -1290,9 +1254,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
             }
         }
@@ -1312,9 +1276,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
             }
         }
@@ -1334,9 +1298,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
+                    yield return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)variant).Value);
                 }
             }
         }
@@ -1359,9 +1323,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1387,9 +1351,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1415,9 +1379,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1443,9 +1407,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
+                    yield return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)variant).Value);
                 }
                 else
                 {
@@ -1472,9 +1436,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -1500,9 +1464,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                    yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                 }
                 else
                 {
@@ -1528,9 +1492,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                 }
                 else
                 {
@@ -1556,9 +1520,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 4)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 4)
                 {
-                    yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
+                    yield return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)variant).Value);
                 }
                 else
                 {
@@ -1588,25 +1552,25 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_enable");
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                        yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                         break;
                     case 4:
-                        yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
+                        yield return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
                         yield break;
                 }
             }
@@ -1633,25 +1597,25 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return f(((global::dotVariant._Private.Accessor_2<float>)variant).Value);
+                        yield return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)variant).Value);
                         break;
                     case 3:
-                        yield return s(((global::dotVariant._Private.Accessor_3<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)variant).Value);
                         break;
                     case 4:
-                        yield return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)variant).Value);
+                        yield return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
                         yield break;
                 }
             }
@@ -1676,8 +1640,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="float"/> element of an observable sequence
@@ -1693,8 +1657,8 @@ namespace Foo
                 global::System.Func<float, TResult> f)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1710,8 +1674,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
-                _variant => s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3),
+                _variant => s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.Array"/> element of an observable sequence
@@ -1727,8 +1691,8 @@ namespace Foo
                 global::System.Func<global::System.Array?, TResult> a)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 4),
-                _variant => a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 4),
+                _variant => a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value));
         }
 
         /// <summary>
@@ -1748,9 +1712,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1775,9 +1739,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                    return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1802,9 +1766,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1829,9 +1793,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 4)
                 {
-                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
+                    return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value);
                 }
                 else
                 {
@@ -1857,9 +1821,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1884,9 +1848,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                    return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                 }
                 else
                 {
@@ -1911,9 +1875,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                 }
                 else
                 {
@@ -1938,9 +1902,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 4)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 4)
                 {
-                    return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
+                    return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value);
                 }
                 else
                 {
@@ -1967,20 +1931,20 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_enable");
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                     case 4:
-                        return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
+                        return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
                 }
             });
         }
@@ -2005,20 +1969,20 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return f(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        return f(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                     case 3:
-                        return s(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                     case 4:
-                        return a(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
+                        return a(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_class_nullable_enable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
                 }
             });
         }
@@ -2177,7 +2141,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_class_nullable_enable _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -2186,23 +2150,23 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_class_nullable_enable.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_class_nullable_enable"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<float>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<float>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<string>)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value);
                         break;
                     case 4:
-                        Subject4.OnNext(((global::dotVariant._Private.Accessor_4<global::System.Array?>)_variant).Value);
+                        Subject4.OnNext(((global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_class_nullable_enable.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_class_nullable_enable"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -9,37 +9,39 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial class Variant_disposable
         : global::System.IEquatable<Variant_disposable>
         , global::System.IDisposable
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_disposable _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_disposable(int i)
-            => _variant = new global::dotVariant._G.Foo.Variant_disposable(i);
+            => _variant = new __VariantImpl(i);
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
         /// </summary>
         /// <param name="stream">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_disposable(global::System.IO.Stream stream)
-            => _variant = new global::dotVariant._G.Foo.Variant_disposable(stream);
+            => _variant = new __VariantImpl(stream);
 
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_disposable(int i)
             => new Variant_disposable(i);
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
         /// </summary>
         /// <param name="stream">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_disposable(global::System.IO.Stream stream)
             => new Variant_disposable(stream);
 
@@ -47,445 +49,156 @@ namespace Foo
         /// Create a Variant_disposable with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_disposable Create(int i)
             => new Variant_disposable(i);
         /// <summary>
         /// Create a Variant_disposable with a value of type <see cref="global::System.IO.Stream"/>.
         /// </summary>
         /// <param name="stream">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_disposable Create(global::System.IO.Stream stream)
             => new Variant_disposable(stream);
 
 
         /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Dispose()
         {
             _variant.Dispose();
         }
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_disposable was constructed without a value.
-        /// </summary>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override bool Equals(object other)
             => other is Variant_disposable v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool Equals(Variant_disposable other)
             => !(other is null) && _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_disposable lhs, Variant_disposable rhs)
-            => lhs?.Equals(rhs) ?? (rhs is null);
+        => lhs?.Equals(rhs) ?? (rhs is null);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_disposable lhs, Variant_disposable rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
-        public void Match(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        public void Match(out global::System.IO.Stream stream)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                stream = ((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                i = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
-        /// </summary>
-        /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
-        public bool TryMatch(out global::System.IO.Stream stream)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                stream = ((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                stream = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.IO.Stream> stream)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="stream"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_disposable' (expected 'System.IO.Stream', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="stream"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.IO.Stream)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out global::System.IO.Stream stream)
+            => _variant.TryMatch(out stream);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{global::System.IO.Stream})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
+            => _variant.TryMatch(stream);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out global::System.IO.Stream)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out global::System.IO.Stream stream)
+            => _variant.Match(out stream);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{global::System.IO.Stream})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<global::System.IO.Stream> stream)
+            => _variant.Match(stream);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{global::System.IO.Stream}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+            => _variant.Match(stream, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.IO.Stream, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
+            => _variant.Match(stream);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.IO.Stream, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
+            => _variant.Match(stream, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{global::System.IO.Stream, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(stream, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable,
-        /// and throw an exception if Variant_disposable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{global::System.IO.Stream})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, stream);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable,
-        /// and invoke a special delegate if Variant_disposable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{global::System.IO.Stream}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, stream, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable and return the result,
-        /// and throw an exception if Variant_disposable is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{global::System.IO.Stream, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, stream);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable and return the result,
-        /// and invoke a special delegate if Variant_disposable is empty and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{global::System.IO.Stream, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, stream, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -498,162 +211,140 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_disposable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_disposable v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_disposable v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(Variant_disposable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<int>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(Variant_disposable v) => (global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(Variant_disposable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_disposable
-        : global::System.IDisposable
+    partial class Variant_disposable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-
-            public Union(int value)
-            {
-                _2 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(global::System.IO.Stream value)
-            {
-                _1 = default;
-                _2 = new Value_2(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
+            : global::System.IDisposable
         {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly global::System.IO.Stream Value;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
 
-            public Value_2(global::System.IO.Stream value)
+                public Union(int value)
+                {
+                    _2 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(global::System.IO.Stream value)
+                {
+                    _1 = default;
+                    _2 = new Value_2(value);
+                }
+            }
+
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
             {
-                Value = value;
+                public readonly int Value;
+                public readonly object _dummy1;
+
+                public Value_1(int value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
             }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_disposable(int i)
-        {
-            _n = 1;
-            _x = new Union(i);
-        }
-        public Variant_disposable(global::System.IO.Stream stream)
-        {
-            _n = 2;
-            _x = new Union(stream);
-        }
-
-        public void Dispose()
-        {
-            switch (_n)
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
             {
-                case 0:
-                    break;
-                case 1:
-                    break;
-                case 2:
-                    _x._2.Value?.Dispose();
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                public readonly global::System.IO.Stream Value;
+
+                public Value_2(global::System.IO.Stream value)
+                {
+                    Value = value;
+                }
             }
-        }
 
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_disposable v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_disposable v)
-            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(in Variant_disposable v)
-            => new global::dotVariant._Private.Accessor_2<global::System.IO.Stream>(v._x._2.Value);
+            private readonly Union _x;
+            private readonly byte _n;
 
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
+            public __VariantImpl(int i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+            public __VariantImpl(global::System.IO.Stream stream)
+            {
+                _n = 2;
+                _x = new Union(stream);
+            }
 
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_disposable is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_disposable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
+            public void Dispose()
             {
                 switch (_n)
                 {
                     case 0:
-                        return "<empty>";
+                        break;
                     case 1:
-                        return "int";
+                        break;
                     case 2:
-                        return "System.IO.Stream";
+                        _x._2.Value?.Dispose();
+                        break;
                     default:
-                        return ThrowInternalError<string>();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
+                        break;
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(v._x._2.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_disposable was constructed without a value.
+            /// </summary>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int";
+                        case 2:
+                            return "System.IO.Stream";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_disposable");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -664,51 +355,51 @@ namespace dotVariant._G.Foo
                     case 2:
                         return _x._2.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_disposable");
                 }
             }
-        }
 
-        public object AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_disposable");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
                     default:
-                        return ThrowInternalError<object>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_disposable");
                 }
             }
-        }
 
-        public bool Equals(in Variant_disposable other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -719,87 +410,351 @@ namespace dotVariant._G.Foo
                     case 2:
                         return global::System.HashCode.Combine(_x._2.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_disposable");
                 }
             }
-        }
 
-        public bool TryMatch(out int i)
-        {
-            i = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out global::System.IO.Stream stream)
-        {
-            stream = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+            public bool TryMatch(out int i)
             {
-                case 0:
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_disposable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+            public void Match(out int i)
+            {
+                if (_n == 1)
+                {
+                    i = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_disposable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_disposable", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    stream(_x._2.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    stream(_x._2.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return i(_x._1.Value);
-                case 2:
-                    return stream(_x._2.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_disposable", "int", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return i(_x._1.Value);
-                case 2:
+                return _n == 1 ? i(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="int"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? i(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+            /// </summary>
+            /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
+            public bool TryMatch(out global::System.IO.Stream stream)
+            {
+                stream = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<global::System.IO.Stream> stream)
+            {
+                if (_n == 2)
+                {
+                    stream(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="stream">Receives the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+            public void Match(out global::System.IO.Stream stream)
+            {
+                if (_n == 2)
+                {
+                    stream = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_disposable", "System.IO.Stream", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+            public void Match(global::System.Action<global::System.IO.Stream> stream)
+            {
+                if (_n == 2)
+                {
+                    stream(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_disposable", "System.IO.Stream", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    stream(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="stream"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable does not contain a value of type <see cref="global::System.IO.Stream"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream)
+            {
+                if (_n == 2)
+                {
                     return stream(_x._2.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_disposable", "System.IO.Stream", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="stream"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
+            {
+                return _n == 2 ? stream(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="stream">The delegate to invoke with the stored value if it is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? stream(_x._2.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable,
+            /// and invoke a special delegate if Variant_disposable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        stream(_x._2.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable,
+            /// and throw an exception if Variant_disposable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<global::System.IO.Stream> stream)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_disposable");
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        stream(_x._2.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_disposable and return the result,
+            /// and invoke a special delegate if Variant_disposable is empty and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_disposable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return stream(_x._2.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_disposable and return the result,
+            /// and throw an exception if Variant_disposable is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="stream">The delegate to invoke if the stored value is of type <see cref="global::System.IO.Stream"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_disposable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<global::System.IO.Stream, TResult> stream)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_disposable");
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return stream(_x._2.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
+                }
             }
         }
     }
@@ -826,9 +781,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -848,9 +803,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
+                    yield return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
             }
         }
@@ -873,9 +828,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -901,9 +856,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
+                    yield return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
                 else
                 {
@@ -930,9 +885,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -958,9 +913,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
+                    yield return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)variant).Value);
                 }
                 else
                 {
@@ -988,19 +943,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_disposable");
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
+                        yield return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
                         yield break;
                 }
             }
@@ -1025,19 +980,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)variant).Value);
+                        yield return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
                         yield break;
                 }
             }
@@ -1062,8 +1017,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="global::System.IO.Stream"/> element of an observable sequence
@@ -1079,8 +1034,8 @@ namespace Foo
                 global::System.Func<global::System.IO.Stream, TResult> stream)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value));
         }
 
         /// <summary>
@@ -1100,9 +1055,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1127,9 +1082,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
+                    return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 }
                 else
                 {
@@ -1155,9 +1110,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1182,9 +1137,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
+                    return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value);
                 }
                 else
                 {
@@ -1209,16 +1164,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_disposable");
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
+                        return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
                 }
             });
         }
@@ -1241,16 +1196,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return stream(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
+                        return stream(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_disposable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
                 }
             });
         }
@@ -1401,7 +1356,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_disposable _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1410,17 +1365,17 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_disposable.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_disposable"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<global::System.IO.Stream>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_disposable.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_disposable"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
@@ -9,24 +9,24 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial class Variant_nullable_value_type
         : global::System.IEquatable<Variant_nullable_value_type>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_nullable_value_type _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_nullable_value_type with a value of type <see cref="int?"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_nullable_value_type(int? i)
-            => _variant = new global::dotVariant._G.Foo.Variant_nullable_value_type(i);
+            => _variant = new __VariantImpl(i);
 
         /// <summary>
         /// Create a Variant_nullable_value_type with a value of type <see cref="int?"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_nullable_value_type(int? i)
             => new Variant_nullable_value_type(i);
 
@@ -34,274 +34,102 @@ namespace Foo
         /// Create a Variant_nullable_value_type with a value of type <see cref="int?"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_nullable_value_type Create(int? i)
             => new Variant_nullable_value_type(i);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_nullable_value_type was constructed without a value.
-        /// </summary>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override bool Equals(object other)
             => other is Variant_nullable_value_type v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool Equals(Variant_nullable_value_type other)
             => !(other is null) && _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_nullable_value_type lhs, Variant_nullable_value_type rhs)
-            => lhs?.Equals(rhs) ?? (rhs is null);
+        => lhs?.Equals(rhs) ?? (rhs is null);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_nullable_value_type lhs, Variant_nullable_value_type rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int?"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
-        public void Match(out int? i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int?>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_nullable_value_type' (expected 'int?', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int?"/>.</param>
-        /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out int?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(out int? i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int?>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                i = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{int?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(global::System.Action<int?> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out int?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int? i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int?> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_nullable_value_type' (expected 'int?', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int?}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int?> i, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int?, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int?, TResult> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_nullable_value_type' (expected 'int?', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int?, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int?, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_nullable_value_type,
-        /// and throw an exception if Variant_nullable_value_type is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int?})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int?> i)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_nullable_value_type,
-        /// and invoke a special delegate if Variant_nullable_value_type is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_nullable_value_type is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int?}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int?> i, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_nullable_value_type and return the result,
-        /// and throw an exception if Variant_nullable_value_type is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int?, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int?, TResult> i)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError<TResult>();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_nullable_value_type and return the result,
-        /// and invoke a special delegate if Variant_nullable_value_type is empty and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_nullable_value_type is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int?, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -314,114 +142,90 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_nullable_value_type v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_nullable_value_type v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<int?>(Variant_nullable_value_type v) => (global::dotVariant._Private.Accessor_1<int?>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int?>(Variant_nullable_value_type v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<int?>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_nullable_value_type
+    partial class Variant_nullable_value_type
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-
-            public Union(int? value)
-            {
-                _1 = new Value_1(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly int? Value;
-
-            public Value_1(int? value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                Value = value;
-            }
-        }
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
 
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_nullable_value_type(int? i)
-        {
-            _n = 1;
-            _x = new Union(i);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_nullable_value_type v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<int?>(in Variant_nullable_value_type v)
-            => new global::dotVariant._Private.Accessor_1<int?>(v._x._1.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_nullable_value_type is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_nullable_value_type has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(int? value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "int?";
-                    default:
-                        return ThrowInternalError<string>();
+                    _1 = new Value_1(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly int? Value;
+
+                public Value_1(int? value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(int? i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int?>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<int?>(v._x._1.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_nullable_value_type was constructed without a value.
+            /// </summary>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int?";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_nullable_value_type");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -430,47 +234,47 @@ namespace dotVariant._G.Foo
                     case 1:
                         return _x._1.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_nullable_value_type");
                 }
             }
-        }
 
-        public object AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_nullable_value_type");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<int?>.Default.Equals(_x._1.Value, other._x._1.Value);
                     default:
-                        return ThrowInternalError<object>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_nullable_value_type");
                 }
             }
-        }
 
-        public bool Equals(in Variant_nullable_value_type other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int?>.Default.Equals(_x._1.Value, other._x._1.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -479,72 +283,217 @@ namespace dotVariant._G.Foo
                     case 1:
                         return global::System.HashCode.Combine(_x._1.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_nullable_value_type");
                 }
             }
-        }
 
-        public bool TryMatch(out int? i)
-        {
-            i = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-
-        public void Visit(global::System.Action<int?> i, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int?"/>.</param>
+            /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
+            public bool TryMatch(out int? i)
             {
-                case 0:
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<int?> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
+            public void Match(out int? i)
+            {
+                if (_n == 1)
+                {
+                    i = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_nullable_value_type", "int?", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public void Match(global::System.Action<int?> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_nullable_value_type", "int?", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<int?> i, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<int?> i)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type does not contain a value of type <see cref="int?"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int?, TResult> i)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return i(_x._1.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_nullable_value_type", "int?", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<int?, TResult> i)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int?, TResult> i, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return i(_x._1.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                return _n == 1 ? i(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_nullable_value_type if it is of type <see cref="int?"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int?"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? i(_x._1.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_nullable_value_type,
+            /// and invoke a special delegate if Variant_nullable_value_type is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_nullable_value_type is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int?> i, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_nullable_value_type,
+            /// and throw an exception if Variant_nullable_value_type is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int?> i)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_nullable_value_type");
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_nullable_value_type and return the result,
+            /// and invoke a special delegate if Variant_nullable_value_type is empty and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_nullable_value_type is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_nullable_value_type and return the result,
+            /// and throw an exception if Variant_nullable_value_type is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_nullable_value_type is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int?, TResult> i)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_nullable_value_type");
+                    case 1:
+                        return i(_x._1.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
+                }
             }
         }
     }
@@ -571,9 +520,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)variant).Value);
                 }
             }
         }
@@ -596,9 +545,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)variant).Value);
                 }
                 else
                 {
@@ -625,9 +574,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)variant).Value);
                 }
                 else
                 {
@@ -654,16 +603,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_nullable_value_type");
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
                         yield break;
                 }
             }
@@ -687,16 +636,16 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int?>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
                         yield break;
                 }
             }
@@ -721,8 +670,8 @@ namespace Foo
                 global::System.Func<int?, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value));
         }
 
         /// <summary>
@@ -742,9 +691,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value);
                 }
                 else
                 {
@@ -770,9 +719,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value);
                 }
                 else
                 {
@@ -796,14 +745,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_nullable_value_type");
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
                 }
             });
         }
@@ -825,14 +774,14 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_nullable_value_type.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
                 }
             });
         }
@@ -951,7 +900,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_nullable_value_type _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -960,14 +909,14 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_nullable_value_type.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_nullable_value_type"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int?>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<int?>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_nullable_value_type.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_nullable_value_type"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -9,36 +9,38 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial class Variant_public
         : global::System.IEquatable<Variant_public>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_public _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_public with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_public(int i)
-            => _variant = new global::dotVariant._G.Foo.Variant_public(i);
+            => _variant = new __VariantImpl(i);
         /// <summary>
         /// Create a Variant_public with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_public(string s)
-            => _variant = new global::dotVariant._G.Foo.Variant_public(s);
+            => _variant = new __VariantImpl(s);
 
         /// <summary>
         /// Create a Variant_public with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_public(int i)
             => new Variant_public(i);
         /// <summary>
         /// Create a Variant_public with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_public(string s)
             => new Variant_public(s);
 
@@ -46,439 +48,149 @@ namespace Foo
         /// Create a Variant_public with a value of type <see cref="int"/>.
         /// </summary>
         /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_public Create(int i)
             => new Variant_public(i);
         /// <summary>
         /// Create a Variant_public with a value of type <see cref="string"/>.
         /// </summary>
         /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_public Create(string s)
             => new Variant_public(s);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_public was constructed without a value.
-        /// </summary>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override bool Equals(object other)
             => other is Variant_public v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool Equals(Variant_public other)
             => !(other is null) && _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_public lhs, Variant_public rhs)
-            => lhs?.Equals(rhs) ?? (rhs is null);
+        => lhs?.Equals(rhs) ?? (rhs is null);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_public lhs, Variant_public rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
-        public void Match(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
-        public void Match(out string s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                s = ((global::dotVariant._Private.Accessor_2<string>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(out int i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i = ((global::dotVariant._Private.Accessor_1<int>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                i = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
-        public bool TryMatch(out string s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                s = ((global::dotVariant._Private.Accessor_2<string>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                s = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public bool TryMatch(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public bool TryMatch(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{int}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Match(global::System.Action<int> i, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
-        public void Match(global::System.Action<string> s, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'int', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_public' (expected 'string', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(i);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
-        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(i, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{int, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out string s)
+            => _variant.TryMatch(out s);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<string> s)
+            => _variant.TryMatch(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out string s)
+            => _variant.Match(out s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s, global::System.Action _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(s, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public,
-        /// and throw an exception if Variant_public is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<string> s)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, s);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public,
-        /// and invoke a special delegate if Variant_public is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{int}, global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                    break;
-                case 2:
-                    s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(i, s, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public and return the result,
-        /// and throw an exception if Variant_public is empty.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, s);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public and return the result,
-        /// and invoke a special delegate if Variant_public is empty and return its result.
-        /// </summary>
-        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
-        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
-                case 2:
-                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(i, s, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -491,145 +203,123 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_public v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_public v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(Variant_public v) => (global::dotVariant._Private.Accessor_1<int>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(Variant_public v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<int>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<string>(Variant_public v) => (global::dotVariant._Private.Accessor_2<string>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<string>(Variant_public v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<string>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_public
+    partial class Variant_public
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-
-            public Union(int value)
-            {
-                _2 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(string value)
-            {
-                _1 = default;
-                _2 = new Value_2(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly string Value;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
 
-            public Value_2(string value)
-            {
-                Value = value;
-            }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_public(int i)
-        {
-            _n = 1;
-            _x = new Union(i);
-        }
-        public Variant_public(string s)
-        {
-            _n = 2;
-            _x = new Union(s);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_public v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<int>(in Variant_public v)
-            => new global::dotVariant._Private.Accessor_1<int>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<string>(in Variant_public v)
-            => new global::dotVariant._Private.Accessor_2<string>(v._x._2.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_public is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_public has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(int value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "int";
-                    case 2:
-                        return "string";
-                    default:
-                        return ThrowInternalError<string>();
+                    _2 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(string value)
+                {
+                    _1 = default;
+                    _2 = new Value_2(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly int Value;
+                public readonly object _dummy1;
+
+                public Value_1(int value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
+            {
+                public readonly string Value;
+
+                public Value_2(string value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(int i)
+            {
+                _n = 1;
+                _x = new Union(i);
+            }
+            public __VariantImpl(string s)
+            {
+                _n = 2;
+                _x = new Union(s);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<string>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<string>(v._x._2.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_public was constructed without a value.
+            /// </summary>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "int";
+                        case 2:
+                            return "string";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_public");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -640,51 +330,51 @@ namespace dotVariant._G.Foo
                     case 2:
                         return _x._2.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_public");
                 }
             }
-        }
 
-        public object AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_public");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2.Value, other._x._2.Value);
                     default:
-                        return ThrowInternalError<object>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_public");
                 }
             }
-        }
 
-        public bool Equals(in Variant_public other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2.Value, other._x._2.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -695,87 +385,351 @@ namespace dotVariant._G.Foo
                     case 2:
                         return global::System.HashCode.Combine(_x._2.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_public");
                 }
             }
-        }
 
-        public bool TryMatch(out int i)
-        {
-            i = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out string s)
-        {
-            s = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-
-        public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
+            public bool TryMatch(out int i)
             {
-                case 0:
+                i = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_public if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
+            public void Match(out int i)
+            {
+                if (_n == 1)
+                {
+                    i = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_public", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_public", "int", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<int> i, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    i(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    s(_x._2.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<int> i, global::System.Action<string> s)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="int"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    i(_x._1.Value);
-                    break;
-                case 2:
-                    s(_x._2.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return i(_x._1.Value);
-                case 2:
-                    return s(_x._2.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_public", "int", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return i(_x._1.Value);
-                case 2:
+                return _n == 1 ? i(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="int"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? i(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
+            public bool TryMatch(out string s)
+            {
+                s = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<string> s)
+            {
+                if (_n == 2)
+                {
+                    s(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+            public void Match(out string s)
+            {
+                if (_n == 2)
+                {
+                    s = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_public", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s)
+            {
+                if (_n == 2)
+                {
+                    s(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_public", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<string> s, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    s(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public does not contain a value of type <see cref="string"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            {
+                if (_n == 2)
+                {
                     return s(_x._2.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_public", "string", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            {
+                return _n == 2 ? s(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_public if it is of type <see cref="string"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? s(_x._2.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public,
+            /// and invoke a special delegate if Variant_public is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        s(_x._2.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public,
+            /// and throw an exception if Variant_public is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<int> i, global::System.Action<string> s)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_public");
+                        break;
+                    case 1:
+                        i(_x._1.Value);
+                        break;
+                    case 2:
+                        s(_x._2.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_public and return the result,
+            /// and invoke a special delegate if Variant_public is empty and return its result.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_public is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return s(_x._2.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_public and return the result,
+            /// and throw an exception if Variant_public is empty.
+            /// </summary>
+            /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+            /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_public is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_public");
+                    case 1:
+                        return i(_x._1.Value);
+                    case 2:
+                        return s(_x._2.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
+                }
             }
         }
     }
@@ -802,9 +756,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
             }
         }
@@ -824,9 +778,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)variant).Value);
                 }
             }
         }
@@ -849,9 +803,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -877,9 +831,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)variant).Value);
                 }
                 else
                 {
@@ -906,9 +860,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                    yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                 }
                 else
                 {
@@ -934,9 +888,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
+                    yield return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)variant).Value);
                 }
                 else
                 {
@@ -964,19 +918,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_public.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_public");
                         yield break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
                         yield break;
                 }
             }
@@ -1001,19 +955,19 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return i(((global::dotVariant._Private.Accessor_1<int>)variant).Value);
+                        yield return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)variant).Value);
                         break;
                     case 2:
-                        yield return s(((global::dotVariant._Private.Accessor_2<string>)variant).Value);
+                        yield return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_public.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
                         yield break;
                 }
             }
@@ -1038,8 +992,8 @@ namespace Foo
                 global::System.Func<int, TResult> i)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="string"/> element of an observable sequence
@@ -1055,8 +1009,8 @@ namespace Foo
                 global::System.Func<string, TResult> s)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value));
         }
 
         /// <summary>
@@ -1076,9 +1030,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1103,9 +1057,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value);
                 }
                 else
                 {
@@ -1131,9 +1085,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                    return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                 }
                 else
                 {
@@ -1158,9 +1112,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
+                    return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value);
                 }
                 else
                 {
@@ -1185,16 +1139,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_public.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_public");
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
                 }
             });
         }
@@ -1217,16 +1171,16 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return i(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        return i(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                     case 2:
-                        return s(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
+                        return s(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_public.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
                 }
             });
         }
@@ -1377,7 +1331,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_public _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1386,17 +1340,17 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_public.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_public"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<int>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<int>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<string>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<string>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_public.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_public"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -9,42 +9,45 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial struct Variant_struct_nullable_disable
         : global::System.IEquatable<Variant_struct_nullable_disable>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_struct_nullable_disable _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_disable(long l)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(l);
+            => _variant = new __VariantImpl(l);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_disable(double d)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(d);
+            => _variant = new __VariantImpl(d);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_disable(object o)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_disable(o);
+            => _variant = new __VariantImpl(o);
 
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_struct_nullable_disable(long l)
             => new Variant_struct_nullable_disable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_struct_nullable_disable(double d)
             => new Variant_struct_nullable_disable(d);
 
@@ -52,609 +55,196 @@ namespace Foo
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_disable Create(long l)
             => new Variant_struct_nullable_disable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_disable Create(double d)
             => new Variant_struct_nullable_disable(d);
         /// <summary>
         /// Create a Variant_struct_nullable_disable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_disable Create(object o)
             => new Variant_struct_nullable_disable(o);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_struct_nullable_disable was constructed without a value.
-        /// </summary>
-        /// <remarks>
-        /// Because Variant_struct_nullable_disable is a value type, its default constructor cannot be disabled.
-        /// A default-constructed Variant_struct_nullable_disable will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
-        /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
-        /// </remarks>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override bool Equals(object other)
             => other is Variant_struct_nullable_disable v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool Equals(Variant_struct_nullable_disable other)
             => _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_struct_nullable_disable lhs, Variant_struct_nullable_disable rhs)
-            => lhs.Equals(rhs);
+        => lhs.Equals(rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_struct_nullable_disable lhs, Variant_struct_nullable_disable rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
-        public readonly void Match(out long l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
-        public readonly void Match(out double d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
-        public readonly void Match(out object o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>.
-        /// </summary>
-        /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out long)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool TryMatch(out long l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                l = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
-        /// </summary>
-        /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
-        public readonly bool TryMatch(out double d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                d = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
-        /// </summary>
-        /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
-        public readonly bool TryMatch(out object o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                o = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{long})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool TryMatch(global::System.Action<long> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly bool TryMatch(global::System.Action<double> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly bool TryMatch(global::System.Action<object> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out long)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(out long l)
+            => _variant.Match(out l);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{long})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Match(global::System.Action<long> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<double> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<object> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{long}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<double> d, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<object> o, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(l, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="l"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="d"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="o"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_disable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="l"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="d"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="o"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(l, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(l, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out double)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(out double d)
+            => _variant.TryMatch(out d);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{double})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(global::System.Action<double> d)
+            => _variant.TryMatch(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out double)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(out double d)
+            => _variant.Match(out d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{double})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<double> d)
+            => _variant.Match(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{double}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<double> d, global::System.Action _)
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
+            => _variant.Match(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out object)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(out object o)
+            => _variant.TryMatch(out o);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(global::System.Action<object> o)
+            => _variant.TryMatch(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out object)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(out object o)
+            => _variant.Match(out o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<object> o)
+            => _variant.Match(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{object}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<object> o, global::System.Action _)
+            => _variant.Match(o, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
+            => _variant.Match(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
+            => _variant.Match(o, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(o, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_disable,
-        /// and throw an exception if Variant_struct_nullable_disable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{long}, global::System.Action{double}, global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
-                    break;
-                case 1:
-                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                    break;
-                case 2:
-                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                    break;
-                case 3:
-                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(l, d, o);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable,
-        /// and invoke a special delegate if Variant_struct_nullable_disable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_struct_nullable_disable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{long}, global::System.Action{double}, global::System.Action{object}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                    break;
-                case 2:
-                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                    break;
-                case 3:
-                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(l, d, o, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_disable and return the result,
-        /// and throw an exception if Variant_struct_nullable_disable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{long, TResult}, global::System.Func{double, TResult}, global::System.Func{object, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError<TResult>();
-                case 1:
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                case 2:
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                case 3:
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(l, d, o);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable and return the result,
-        /// and invoke a special delegate if Variant_struct_nullable_disable is empty and return its result.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_struct_nullable_disable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{long, TResult}, global::System.Func{double, TResult}, global::System.Func{object, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                case 2:
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                case 3:
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(l, d, o, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -667,178 +257,163 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_struct_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<long>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_1<long>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(Variant_struct_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<long>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<double>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_2<double>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(Variant_struct_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<double>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_3<object>(Variant_struct_nullable_disable v) => (global::dotVariant._Private.Accessor_3<object>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(Variant_struct_nullable_disable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_3<object>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_disable
+    partial struct Variant_struct_nullable_disable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
-            public Union(long value)
-            {
-                _2 = default;
-                _3 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(double value)
-            {
-                _1 = default;
-                _3 = default;
-                _2 = new Value_2(value);
-            }
-            public Union(object value)
-            {
-                _1 = default;
-                _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly long Value;
-            public readonly object _dummy1;
-
-            public Value_1(long value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly double Value;
-            public readonly object _dummy1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_3 _3;
 
-            public Value_2(double value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly object Value;
-
-            public Value_3(object value)
-            {
-                Value = value;
-            }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_struct_nullable_disable(long l)
-        {
-            _n = 1;
-            _x = new Union(l);
-        }
-        public Variant_struct_nullable_disable(double d)
-        {
-            _n = 2;
-            _x = new Union(d);
-        }
-        public Variant_struct_nullable_disable(object o)
-        {
-            _n = 3;
-            _x = new Union(o);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_disable v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<long>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_1<long>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<double>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_2<double>(v._x._2.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_3<object>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant._Private.Accessor_3<object>(v._x._3.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_struct_nullable_disable is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_struct_nullable_disable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(long value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "long";
-                    case 2:
-                        return "double";
-                    case 3:
-                        return "object";
-                    default:
-                        return ThrowInternalError<string>();
+                    _2 = default;
+                    _3 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(double value)
+                {
+                    _1 = default;
+                    _3 = default;
+                    _2 = new Value_2(value);
+                }
+                public Union(object value)
+                {
+                    _1 = default;
+                    _2 = default;
+                    _3 = new Value_3(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly long Value;
+                public readonly object _dummy1;
+
+                public Value_1(long value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
+            {
+                public readonly double Value;
+                public readonly object _dummy1;
+
+                public Value_2(double value)
+                {
+                    _dummy1 = null;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_3
+            {
+                public readonly object Value;
+
+                public Value_3(object value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(long l)
+            {
+                _n = 1;
+                _x = new Union(l);
+            }
+            public __VariantImpl(double d)
+            {
+                _n = 2;
+                _x = new Union(d);
+            }
+            public __VariantImpl(object o)
+            {
+                _n = 3;
+                _x = new Union(o);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_struct_nullable_disable was constructed without a value.
+            /// </summary>
+            /// <remarks>
+            /// Because Variant_struct_nullable_disable is a value type, its default constructor cannot be disabled.
+            /// A default-constructed Variant_struct_nullable_disable will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
+            /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
+            /// </remarks>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "long";
+                        case 2:
+                            return "double";
+                        case 3:
+                            return "object";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_disable");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -851,55 +426,55 @@ namespace dotVariant._G.Foo
                     case 3:
                         return _x._3.Value?.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_disable");
                 }
             }
-        }
 
-        public object AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        case 3:
+                            return _x._3.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_struct_nullable_disable");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                     case 3:
-                        return _x._3.Value;
+                        return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
                     default:
-                        return ThrowInternalError<object>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_struct_nullable_disable");
                 }
             }
-        }
 
-        public bool Equals(in Variant_struct_nullable_disable other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
-                case 3:
-                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -912,102 +487,485 @@ namespace dotVariant._G.Foo
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_struct_nullable_disable");
                 }
             }
-        }
 
-        public bool TryMatch(out long l)
-        {
-            l = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out double d)
-        {
-            d = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-        public bool TryMatch(out object o)
-        {
-            o = _n == 3 ? _x._3.Value : default;
-            return _n == 3;
-        }
-
-        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>.
+            /// </summary>
+            /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
+            public bool TryMatch(out long l)
             {
-                case 0:
+                l = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<long> l)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
+            public void Match(out long l)
+            {
+                if (_n == 1)
+                {
+                    l = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "long", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public void Match(global::System.Action<long> l)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "long", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<long> l, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    l(_x._1.Value);
-                    break;
-                case 2:
-                    d(_x._2.Value);
-                    break;
-                case 3:
-                    o(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="l"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="long"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    l(_x._1.Value);
-                    break;
-                case 2:
-                    d(_x._2.Value);
-                    break;
-                case 3:
-                    o(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return l(_x._1.Value);
-                case 2:
-                    return d(_x._2.Value);
-                case 3:
-                    return o(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "long", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="l"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return l(_x._1.Value);
-                case 2:
+                return _n == 1 ? l(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="long"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? l(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
+            /// </summary>
+            /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
+            public bool TryMatch(out double d)
+            {
+                d = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<double> d)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
+            public void Match(out double d)
+            {
+                if (_n == 2)
+                {
+                    d = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public void Match(global::System.Action<double> d)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<double> d, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="d"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="double"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d)
+            {
+                if (_n == 2)
+                {
                     return d(_x._2.Value);
-                case 3:
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="d"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
+            {
+                return _n == 2 ? d(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? d(_x._2.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
+            /// </summary>
+            /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
+            public bool TryMatch(out object o)
+            {
+                o = _n == 3 ? _x._3.Value : default;
+                return _n == 3;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<object> o)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
+            public void Match(out object o)
+            {
+                if (_n == 3)
+                {
+                    o = _x._3.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public void Match(global::System.Action<object> o)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<object> o, global::System.Action _)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="o"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable does not contain a value of type <see cref="object"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o)
+            {
+                if (_n == 3)
+                {
                     return o(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="o"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
+            {
+                return _n == 3 ? o(_x._3.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+            {
+                return _n == 3 ? o(_x._3.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable,
+            /// and invoke a special delegate if Variant_struct_nullable_disable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_struct_nullable_disable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        l(_x._1.Value);
+                        break;
+                    case 2:
+                        d(_x._2.Value);
+                        break;
+                    case 3:
+                        o(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_disable,
+            /// and throw an exception if Variant_struct_nullable_disable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_disable");
+                        break;
+                    case 1:
+                        l(_x._1.Value);
+                        break;
+                    case 2:
+                        d(_x._2.Value);
+                        break;
+                    case 3:
+                        o(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_disable and return the result,
+            /// and invoke a special delegate if Variant_struct_nullable_disable is empty and return its result.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_struct_nullable_disable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return l(_x._1.Value);
+                    case 2:
+                        return d(_x._2.Value);
+                    case 3:
+                        return o(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_disable and return the result,
+            /// and throw an exception if Variant_struct_nullable_disable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_disable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_disable");
+                    case 1:
+                        return l(_x._1.Value);
+                    case 2:
+                        return d(_x._2.Value);
+                    case 3:
+                        return o(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
+                }
             }
         }
     }
@@ -1034,9 +992,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
             }
         }
@@ -1056,9 +1014,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
             }
         }
@@ -1078,9 +1036,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
             }
         }
@@ -1103,9 +1061,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1131,9 +1089,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1159,9 +1117,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1188,9 +1146,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1216,9 +1174,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1244,9 +1202,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1275,22 +1233,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_disable");
                         yield break;
                     case 1:
-                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                        yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                        yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                        yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
                         yield break;
                 }
             }
@@ -1316,22 +1274,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                        yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                        yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                        yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
                         yield break;
                 }
             }
@@ -1356,8 +1314,8 @@ namespace Foo
                 global::System.Func<long, TResult> l)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1373,8 +1331,8 @@ namespace Foo
                 global::System.Func<double, TResult> d)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1390,8 +1348,8 @@ namespace Foo
                 global::System.Func<object, TResult> o)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
-                _variant => o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3),
+                _variant => o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value));
         }
 
         /// <summary>
@@ -1411,9 +1369,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                    return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1438,9 +1396,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                    return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1465,9 +1423,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                    return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1493,9 +1451,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                    return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1520,9 +1478,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                    return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1547,9 +1505,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                    return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1575,18 +1533,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_disable");
                     case 1:
-                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
                 }
             });
         }
@@ -1610,18 +1568,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_disable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
                 }
             });
         }
@@ -1776,7 +1734,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_struct_nullable_disable _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1785,20 +1743,20 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_struct_nullable_disable.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_struct_nullable_disable"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_struct_nullable_disable.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_struct_nullable_disable"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -9,42 +9,45 @@ namespace Foo
 {
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial struct Variant_struct_nullable_enable
         : global::System.IEquatable<Variant_struct_nullable_enable>
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
-        private readonly global::dotVariant._G.Foo.Variant_struct_nullable_enable _variant;
+        private readonly __VariantImpl _variant;
 
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_enable(long l)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(l);
+            => _variant = new __VariantImpl(l);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_enable(double d)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(d);
+            => _variant = new __VariantImpl(d);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public Variant_struct_nullable_enable(object o)
-            => _variant = new global::dotVariant._G.Foo.Variant_struct_nullable_enable(o);
+            => _variant = new __VariantImpl(o);
 
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_struct_nullable_enable(long l)
             => new Variant_struct_nullable_enable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator Variant_struct_nullable_enable(double d)
             => new Variant_struct_nullable_enable(d);
 
@@ -52,609 +55,196 @@ namespace Foo
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="long"/>.
         /// </summary>
         /// <param name="l">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_enable Create(long l)
             => new Variant_struct_nullable_enable(l);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="double"/>.
         /// </summary>
         /// <param name="d">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_enable Create(double d)
             => new Variant_struct_nullable_enable(d);
         /// <summary>
         /// Create a Variant_struct_nullable_enable with a value of type <see cref="object"/>.
         /// </summary>
         /// <param name="o">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static Variant_struct_nullable_enable Create(object o)
             => new Variant_struct_nullable_enable(o);
 
 
-        /// <summary>
-        /// <see langword="true"/> if Variant_struct_nullable_enable was constructed without a value.
-        /// </summary>
-        /// <remarks>
-        /// Because Variant_struct_nullable_enable is a value type, its default constructor cannot be disabled.
-        /// A default-constructed Variant_struct_nullable_enable will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
-        /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
-        /// </remarks>
+        /// <inheritdoc cref="__VariantImpl.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool IsEmpty
             => _variant.IsEmpty;
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override bool Equals(object? other)
             => other is Variant_struct_nullable_enable v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool Equals(Variant_struct_nullable_enable other)
             => _variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_struct_nullable_enable lhs, Variant_struct_nullable_enable rhs)
-            => lhs.Equals(rhs);
+        => lhs.Equals(rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_struct_nullable_enable lhs, Variant_struct_nullable_enable rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override int GetHashCode()
             => _variant.GetHashCode();
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
-        public readonly void Match(out long l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
-        public readonly void Match(out double d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
-        public readonly void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out object? o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
-
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>.
-        /// </summary>
-        /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out long)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool TryMatch(out long l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l = ((global::dotVariant._Private.Accessor_1<long>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                l = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
-        /// </summary>
-        /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
-        public readonly bool TryMatch(out double d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d = ((global::dotVariant._Private.Accessor_2<double>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                d = default;
-                return false;
-            }
-        }
-        /// <summary>
-        /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
-        /// </summary>
-        /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
-        public readonly bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o = ((global::dotVariant._Private.Accessor_3<object>)_variant).Value;
-                return true;
-            }
-            else
-            {
-                o = default;
-                return false;
-            }
-        }
+            => _variant.TryMatch(out l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{long})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly bool TryMatch(global::System.Action<long> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly bool TryMatch(global::System.Action<double> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly bool TryMatch(global::System.Action<object> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+            => _variant.TryMatch(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(out long)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(out long l)
+            => _variant.Match(out l);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{long})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Match(global::System.Action<long> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<double> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<object> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{long}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Match(global::System.Action<long> l, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<double> d, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
-        public readonly void Match(global::System.Action<object> o, global::System.Action _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                _();
-            }
-        }
+            => _variant.Match(l, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="l"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'long', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="d"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'double', actual '{_variant.TypeString}').");
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="o"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                throw new global::System.InvalidOperationException($"Failed to match on 'Foo.Variant_struct_nullable_enable' (expected 'object', actual '{_variant.TypeString}').");
-            }
-        }
+            => _variant.Match(l);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="l"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="d"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="o"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
-        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                return _;
-            }
-        }
+            => _variant.Match(l, _);
 
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{long, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
-            {
-                return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(l, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out double)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(out double d)
+            => _variant.TryMatch(out d);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{double})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(global::System.Action<double> d)
+            => _variant.TryMatch(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out double)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(out double d)
+            => _variant.Match(out d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{double})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<double> d)
+            => _variant.Match(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{double}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<double> d, global::System.Action _)
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d)
+            => _variant.Match(d);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{double, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
-            {
-                return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
-        /// <summary>
-        /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            => _variant.Match(d, _);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out object?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
+            => _variant.TryMatch(out o);
+
+        /// <inheritdoc cref="__VariantImpl.TryMatch(out global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly bool TryMatch(global::System.Action<object> o)
+            => _variant.TryMatch(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(out object?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out object? o)
+            => _variant.Match(out o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<object> o)
+            => _variant.Match(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match(global::System.Action{object}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly void Match(global::System.Action<object> o, global::System.Action _)
+            => _variant.Match(o, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o)
+            => _variant.Match(o);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
+            => _variant.Match(o, _);
+
+        /// <inheritdoc cref="__VariantImpl.Match{TResult}(global::System.Func{object, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
-            {
-                return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match(o, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_enable,
-        /// and throw an exception if Variant_struct_nullable_enable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{long}, global::System.Action{double}, global::System.Action{object})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
-                    break;
-                case 1:
-                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                    break;
-                case 2:
-                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                    break;
-                case 3:
-                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(l, d, o);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable,
-        /// and invoke a special delegate if Variant_struct_nullable_enable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_struct_nullable_enable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="__VariantImpl.Visit(global::System.Action{long}, global::System.Action{double}, global::System.Action{object}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    _();
-                    break;
-                case 1:
-                    l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                    break;
-                case 2:
-                    d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                    break;
-                case 3:
-                    o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                    break;
-                default:
-                    global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit(l, d, o, _);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_enable and return the result,
-        /// and throw an exception if Variant_struct_nullable_enable is empty.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{long, TResult}, global::System.Func{double, TResult}, global::System.Func{object, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError<TResult>();
-                case 1:
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                case 2:
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                case 3:
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(l, d, o);
 
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable and return the result,
-        /// and invoke a special delegate if Variant_struct_nullable_enable is empty and return its result.
-        /// </summary>
-        /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
-        /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
-        /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
-        /// <param name="_">The delegate to invoke if Variant_struct_nullable_enable is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="__VariantImpl.Visit{TResult}(global::System.Func{long, TResult}, global::System.Func{double, TResult}, global::System.Func{object, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            switch (((int)(global::dotVariant._Private.Discriminator)_variant))
-            {
-                case 0:
-                    return _();
-                case 1:
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
-                case 2:
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
-                case 3:
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
-                default:
-                    return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit(l, d, o, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -667,178 +257,163 @@ namespace Foo
         }
 
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(Variant_struct_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Discriminator)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_1<long>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_1<long>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(Variant_struct_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_1<long>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_2<double>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_2<double>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(Variant_struct_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_2<double>)v._variant;
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_3<object>(Variant_struct_nullable_enable v) => (global::dotVariant._Private.Accessor_3<object>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(Variant_struct_nullable_enable v)
+            => (global::dotVariant.GeneratorSupport.Accessor_3<object>)v._variant;
     }
 }
 
-namespace dotVariant._G.Foo
+namespace Foo
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct Variant_struct_nullable_enable
+    partial struct Variant_struct_nullable_enable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
-            public Union(long value)
-            {
-                _2 = default;
-                _3 = default;
-                _1 = new Value_1(value);
-            }
-            public Union(double value)
-            {
-                _1 = default;
-                _3 = default;
-                _2 = new Value_2(value);
-            }
-            public Union(object value)
-            {
-                _1 = default;
-                _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
         {
-            public readonly long Value;
-            public readonly object _dummy1;
-
-            public Value_1(long value)
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
             {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly double Value;
-            public readonly object _dummy1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_1 _1;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_2 _2;
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_3 _3;
 
-            public Value_2(double value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly object Value;
-
-            public Value_3(object value)
-            {
-                Value = value;
-            }
-        }
-
-        private readonly Union _x;
-        private readonly byte _n;
-
-        public Variant_struct_nullable_enable(long l)
-        {
-            _n = 1;
-            _x = new Union(l);
-        }
-        public Variant_struct_nullable_enable(double d)
-        {
-            _n = 2;
-            _x = new Union(d);
-        }
-        public Variant_struct_nullable_enable(object o)
-        {
-            _n = 3;
-            _x = new Union(o);
-        }
-
-
-        public static explicit operator global::dotVariant._Private.Discriminator(Variant_struct_nullable_enable v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        public static explicit operator global::dotVariant._Private.Accessor_1<long>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_1<long>(v._x._1.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_2<double>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_2<double>(v._x._2.Value);
-        public static explicit operator global::dotVariant._Private.Accessor_3<object>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant._Private.Accessor_3<object>(v._x._3.Value);
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("Variant_struct_nullable_enable is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("Variant_struct_nullable_enable has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        public bool IsEmpty => _n == 0;
-
-        public string TypeString
-        {
-            get
-            {
-                switch (_n)
+                public Union(long value)
                 {
-                    case 0:
-                        return "<empty>";
-                    case 1:
-                        return "long";
-                    case 2:
-                        return "double";
-                    case 3:
-                        return "object";
-                    default:
-                        return ThrowInternalError<string>();
+                    _2 = default;
+                    _3 = default;
+                    _1 = new Value_1(value);
+                }
+                public Union(double value)
+                {
+                    _1 = default;
+                    _3 = default;
+                    _2 = new Value_2(value);
+                }
+                public Union(object value)
+                {
+                    _1 = default;
+                    _2 = default;
+                    _3 = new Value_3(value);
                 }
             }
-        }
 
-        public string ValueString
-        {
-            get
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_1
+            {
+                public readonly long Value;
+                public readonly object _dummy1;
+
+                public Value_1(long value)
+                {
+                    _dummy1 = null!;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_2
+            {
+                public readonly double Value;
+                public readonly object _dummy1;
+
+                public Value_2(double value)
+                {
+                    _dummy1 = null!;
+                    Value = value;
+                }
+            }
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_3
+            {
+                public readonly object Value;
+
+                public Value_3(object value)
+                {
+                    Value = value;
+                }
+            }
+
+            private readonly Union _x;
+            private readonly byte _n;
+
+            public __VariantImpl(long l)
+            {
+                _n = 1;
+                _x = new Union(l);
+            }
+            public __VariantImpl(double d)
+            {
+                _n = 2;
+                _x = new Union(d);
+            }
+            public __VariantImpl(object o)
+            {
+                _n = 3;
+                _x = new Union(o);
+            }
+
+
+            public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in __VariantImpl v)
+                => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2.Value);
+            public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(in __VariantImpl v)
+                => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3.Value);
+
+            /// <summary>
+            /// <see langword="true"/> if Variant_struct_nullable_enable was constructed without a value.
+            /// </summary>
+            /// <remarks>
+            /// Because Variant_struct_nullable_enable is a value type, its default constructor cannot be disabled.
+            /// A default-constructed Variant_struct_nullable_enable will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
+            /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
+            /// </remarks>
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        case 1:
+                            return "long";
+                        case 2:
+                            return "double";
+                        case 3:
+                            return "object";
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_enable");
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -851,55 +426,55 @@ namespace dotVariant._G.Foo
                     case 3:
                         return _x._3.Value.ToString() ?? "null";
                     default:
-                        return ThrowInternalError<string>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_enable");
                 }
             }
-        }
 
-        public object? AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object? AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        case 1:
+                            return _x._1.Value;
+                        case 2:
+                            return _x._2.Value;
+                        case 3:
+                            return _x._3.Value;
+                        default:
+                            return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant_struct_nullable_enable");
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     case 1:
-                        return _x._1.Value;
+                        return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
                     case 2:
-                        return _x._2.Value;
+                        return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
                     case 3:
-                        return _x._3.Value;
+                        return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
                     default:
-                        return ThrowInternalError<object?>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_struct_nullable_enable");
                 }
             }
-        }
 
-        public bool Equals(in Variant_struct_nullable_enable other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                case 1:
-                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
-                case 2:
-                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
-                case 3:
-                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -912,102 +487,485 @@ namespace dotVariant._G.Foo
                     case 3:
                         return global::System.HashCode.Combine(_x._3.Value);
                     default:
-                        return ThrowInternalError<int>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_struct_nullable_enable");
                 }
             }
-        }
 
-        public bool TryMatch(out long l)
-        {
-            l = _n == 1 ? _x._1.Value : default;
-            return _n == 1;
-        }
-        public bool TryMatch(out double d)
-        {
-            d = _n == 2 ? _x._2.Value : default;
-            return _n == 2;
-        }
-        public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
-        {
-            o = _n == 3 ? _x._3.Value : default;
-            return _n == 3;
-        }
-
-        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
-        {
-            switch (_n)
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>.
+            /// </summary>
+            /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
+            public bool TryMatch(out long l)
             {
-                case 0:
+                l = _n == 1 ? _x._1.Value : default;
+                return _n == 1;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<long> l)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">Receives the stored value if it is of type <see cref="long"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
+            public void Match(out long l)
+            {
+                if (_n == 1)
+                {
+                    l = _x._1.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "long", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public void Match(global::System.Action<long> l)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "long", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<long> l, global::System.Action _)
+            {
+                if (_n == 1)
+                {
+                    l(_x._1.Value);
+                }
+                else
+                {
                     _();
-                    break;
-                case 1:
-                    l(_x._1.Value);
-                    break;
-                case 2:
-                    d(_x._2.Value);
-                    break;
-                case 3:
-                    o(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
+                }
             }
-        }
 
-        public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="l"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="long"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l)
             {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                case 1:
-                    l(_x._1.Value);
-                    break;
-                case 2:
-                    d(_x._2.Value);
-                    break;
-                case 3:
-                    o(_x._3.Value);
-                    break;
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                case 1:
+                if (_n == 1)
+                {
                     return l(_x._1.Value);
-                case 2:
-                    return d(_x._2.Value);
-                case 3:
-                    return o(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "long", "{TypeString}");
             }
-        }
 
-        public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
-        {
-            switch (_n)
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="l"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
             {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                case 1:
-                    return l(_x._1.Value);
-                case 2:
+                return _n == 1 ? l(_x._1.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="long"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="l">The delegate to invoke with the stored value if it is of type <see cref="long"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
+            {
+                return _n == 1 ? l(_x._1.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
+            /// </summary>
+            /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
+            public bool TryMatch(out double d)
+            {
+                d = _n == 2 ? _x._2.Value : default;
+                return _n == 2;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<double> d)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">Receives the stored value if it is of type <see cref="double"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
+            public void Match(out double d)
+            {
+                if (_n == 2)
+                {
+                    d = _x._2.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public void Match(global::System.Action<double> d)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<double> d, global::System.Action _)
+            {
+                if (_n == 2)
+                {
+                    d(_x._2.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="d"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="double"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d)
+            {
+                if (_n == 2)
+                {
                     return d(_x._2.Value);
-                case 3:
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "double", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="d"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
+            {
+                return _n == 2 ? d(_x._2.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="d">The delegate to invoke with the stored value if it is of type <see cref="double"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
+            {
+                return _n == 2 ? d(_x._2.Value) : _();
+            }
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
+            /// </summary>
+            /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
+            public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
+            {
+                o = _n == 3 ? _x._3.Value : default;
+                return _n == 3;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public bool TryMatch(global::System.Action<object> o)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                    return true;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">Receives the stored value if it is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
+            public void Match([global::System.Diagnostics.CodeAnalysis.NotNull] out object? o)
+            {
+                if (_n == 3)
+                {
+                    o = _x._3.Value;
+                    return;
+                }
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public void Match(global::System.Action<object> o)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                    return;
+                }
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            public void Match(global::System.Action<object> o, global::System.Action _)
+            {
+                if (_n == 3)
+                {
+                    o(_x._3.Value);
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="o"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable does not contain a value of type <see cref="object"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o)
+            {
+                if (_n == 3)
+                {
                     return o(_x._3.Value);
-                default:
-                    return ThrowInternalError<TResult>();
+                }
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "object", "{TypeString}");
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="o"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
+            {
+                return _n == 3 ? o(_x._3.Value) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="o">The delegate to invoke with the stored value if it is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+            {
+                return _n == 3 ? o(_x._3.Value) : _();
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable,
+            /// and invoke a special delegate if Variant_struct_nullable_enable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_struct_nullable_enable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    case 1:
+                        l(_x._1.Value);
+                        break;
+                    case 2:
+                        d(_x._2.Value);
+                        break;
+                    case 3:
+                        o(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_enable,
+            /// and throw an exception if Variant_struct_nullable_enable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit(global::System.Action<long> l, global::System.Action<double> d, global::System.Action<object> o)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_enable");
+                        break;
+                    case 1:
+                        l(_x._1.Value);
+                        break;
+                    case 2:
+                        d(_x._2.Value);
+                        break;
+                    case 3:
+                        o(_x._3.Value);
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_struct_nullable_enable and return the result,
+            /// and invoke a special delegate if Variant_struct_nullable_enable is empty and return its result.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <param name="_">The delegate to invoke if Variant_struct_nullable_enable is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return l(_x._1.Value);
+                    case 2:
+                        return d(_x._2.Value);
+                    case 3:
+                        return o(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
+                }
+            }
+
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within Variant_struct_nullable_enable and return the result,
+            /// and throw an exception if Variant_struct_nullable_enable is empty.
+            /// </summary>
+            /// <param name="l">The delegate to invoke if the stored value is of type <see cref="long"/>.</param>
+            /// <param name="d">The delegate to invoke if the stored value is of type <see cref="double"/>.</param>
+            /// <param name="o">The delegate to invoke if the stored value is of type <see cref="object"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_struct_nullable_enable is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>(global::System.Func<long, TResult> l, global::System.Func<double, TResult> d, global::System.Func<object, TResult> o)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_enable");
+                    case 1:
+                        return l(_x._1.Value);
+                    case 2:
+                        return d(_x._2.Value);
+                    case 3:
+                        return o(_x._3.Value);
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
+                }
             }
         }
     }
@@ -1034,9 +992,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
             }
         }
@@ -1056,9 +1014,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
             }
         }
@@ -1078,9 +1036,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
             }
         }
@@ -1103,9 +1061,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1131,9 +1089,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1159,9 +1117,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1188,9 +1146,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 1)
                 {
-                    yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                    yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                 }
                 else
                 {
@@ -1216,9 +1174,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 2)
                 {
-                    yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                    yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                 }
                 else
                 {
@@ -1244,9 +1202,9 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                if (((int)(global::dotVariant._Private.Discriminator)variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant) == 3)
                 {
-                    yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                    yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                 }
                 else
                 {
@@ -1275,22 +1233,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_enable");
                         yield break;
                     case 1:
-                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                        yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                        yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                        yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
                         yield break;
                 }
             }
@@ -1316,22 +1274,22 @@ namespace Foo
         {
             foreach (var variant in source)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)variant))
                 {
                     case 0:
                         yield return _();
                         break;
                     case 1:
-                        yield return l(((global::dotVariant._Private.Accessor_1<long>)variant).Value);
+                        yield return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)variant).Value);
                         break;
                     case 2:
-                        yield return d(((global::dotVariant._Private.Accessor_2<double>)variant).Value);
+                        yield return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)variant).Value);
                         break;
                     case 3:
-                        yield return o(((global::dotVariant._Private.Accessor_3<object>)variant).Value);
+                        yield return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)variant).Value);
                         break;
                     default:
-                        global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError();
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
                         yield break;
                 }
             }
@@ -1356,8 +1314,8 @@ namespace Foo
                 global::System.Func<long, TResult> l)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 1),
-                _variant => l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1),
+                _variant => l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="double"/> element of an observable sequence
@@ -1373,8 +1331,8 @@ namespace Foo
                 global::System.Func<double, TResult> d)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 2),
-                _variant => d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2),
+                _variant => d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value));
         }
         /// <summary>
         /// Projects each <see cref="object"/> element of an observable sequence
@@ -1390,8 +1348,8 @@ namespace Foo
                 global::System.Func<object, TResult> o)
         {
             return global::System.Reactive.Linq.Observable.Select(
-                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant._Private.Discriminator)_variant) == 3),
-                _variant => o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value));
+                global::System.Reactive.Linq.Observable.Where(source, _variant => ((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3),
+                _variant => o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value));
         }
 
         /// <summary>
@@ -1411,9 +1369,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                    return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1438,9 +1396,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                    return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1465,9 +1423,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                    return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1493,9 +1451,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 1)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 1)
                 {
-                    return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                    return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                 }
                 else
                 {
@@ -1520,9 +1478,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 2)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 2)
                 {
-                    return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                    return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                 }
                 else
                 {
@@ -1547,9 +1505,9 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                if (((int)(global::dotVariant._Private.Discriminator)_variant) == 3)
+                if (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant) == 3)
                 {
-                    return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                    return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                 }
                 else
                 {
@@ -1575,18 +1533,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowEmptyError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_enable");
                     case 1:
-                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
                 }
             });
         }
@@ -1610,18 +1568,18 @@ namespace Foo
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         return _();
                     case 1:
-                        return l(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        return l(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                     case 2:
-                        return d(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        return d(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                     case 3:
-                        return o(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        return o(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                     default:
-                        return global::dotVariant._G.Foo.Variant_struct_nullable_enable.ThrowInternalError<TResult>();
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
                 }
             });
         }
@@ -1776,7 +1734,7 @@ namespace Foo
 
             public void OnNext(global::Foo.Variant_struct_nullable_enable _variant)
             {
-                switch (((int)(global::dotVariant._Private.Discriminator)_variant))
+                switch (((int)(global::dotVariant.GeneratorSupport.Discriminator)_variant))
                 {
                     case 0:
                         if (_accept0)
@@ -1785,20 +1743,20 @@ namespace Foo
                         }
                         else
                         {
-                            OnError(global::dotVariant._G.Foo.Variant_struct_nullable_enable.MakeEmptyError());
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_struct_nullable_enable"));
                         }
                         break;
                     case 1:
-                        Subject1.OnNext(((global::dotVariant._Private.Accessor_1<long>)_variant).Value);
+                        Subject1.OnNext(((global::dotVariant.GeneratorSupport.Accessor_1<long>)_variant).Value);
                         break;
                     case 2:
-                        Subject2.OnNext(((global::dotVariant._Private.Accessor_2<double>)_variant).Value);
+                        Subject2.OnNext(((global::dotVariant.GeneratorSupport.Accessor_2<double>)_variant).Value);
                         break;
                     case 3:
-                        Subject3.OnNext(((global::dotVariant._Private.Accessor_3<object>)_variant).Value);
+                        Subject3.OnNext(((global::dotVariant.GeneratorSupport.Accessor_3<object>)_variant).Value);
                         break;
                     default:
-                        OnError(global::dotVariant._G.Foo.Variant_struct_nullable_enable.MakeInternalError());
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_struct_nullable_enable"));
                         break;
                 }
             }

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
     <!-- Transitive closure of generator runtime dependencies -->
-    <PackageReference Include="Scriban" Version="3.6.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Scriban" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Interactive" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>

--- a/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
@@ -131,7 +131,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 switch ({{ $get_n }})
                 {
                     case 0:
-                        {{ storage_type }}.ThrowEmptyError();
+                        {{ throw_empty_error }};
                         yield break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
@@ -139,7 +139,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         break;
                     {{~ end ~}}
                     default:
-                        {{ storage_type }}.ThrowInternalError();
+                        {{ throw_internal_error }};
                         yield break;
                 }
             }
@@ -177,7 +177,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         break;
                     {{~ end ~}}
                     default:
-                        {{ storage_type }}.ThrowInternalError();
+                        {{ throw_internal_error }};
                         yield break;
                 }
             }

--- a/src/dotVariant.Generator/templates/IObservable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IObservable.scriban-cs
@@ -113,13 +113,13 @@ namespace {{ Options.ExtensionClassNamespace }}
                 switch ({{ get_n }})
                 {
                     case 0:
-                        return {{ storage_type }}.ThrowEmptyError<TResult>();
+                        return {{ throw_empty_error "TResult" }};
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
                         return {{ $p.Hint }}({{ get_value $p }});
                     {{~ end ~}}
                     default:
-                        return {{ storage_type }}.ThrowInternalError<TResult>();
+                        return {{ throw_internal_error "TResult" }};
                 }
             });
         }
@@ -153,7 +153,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         return {{ $p.Hint }}({{ get_value $p }});
                     {{~ end ~}}
                     default:
-                        return {{ storage_type }}.ThrowInternalError<TResult>();
+                        return {{ throw_internal_error "TResult" }};
                 }
             });
         }
@@ -323,7 +323,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         }
                         else
                         {
-                            OnError({{ storage_type }}.MakeEmptyError());
+                            OnError({{ make_empty_error }});
                         }
                         break;
                     {{~ for $p in Params ~}}
@@ -332,7 +332,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         break;
                     {{~ end ~}}
                     default:
-                        OnError({{ storage_type }}.MakeInternalError());
+                        OnError({{ make_internal_error }});
                         break;
                 }
             }

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -119,169 +119,139 @@ func $storage(param)
 end
 ~}}
 {{~ ## STORAGE WRAPPER ## ~}}
-namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
+{{~ if Variant.Namespace ~}}
+namespace {{ Variant.Namespace }}
 {
-    [global::System.Diagnostics.DebuggerNonUserCode]
-    internal readonly struct {{ Variant.Name }}
-    {{~ if needs_dispose ~}}
-        : global::System.IDisposable
-    {{~ end ~}}
+{{~ end ~}}
+    partial {{ Variant.Keyword }} {{ Variant.Name }}
     {
-        {{~ ## UNION TYPE ## ~}}
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
-        private readonly struct Union
-        {
-            {{~ ## UNION MEMBERS ## ~}}
-            {{~ for $p in Params ~}}
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_{{ $p.Index }} _{{ $p.Index }};
-            {{~ end ~}}
-
-            {{~ ## UNION CONSTRUCTORS ## ~}}
-            {{~ for $p in Params ~}}
-            public Union({{ value_type $p }} value)
-            {
-                {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
-                _{{ $other.Index }} = default;
-                {{~ end ~}}
-                _{{ $p.Index }} = new Value_{{ $p.Index }}(value);
-            }
-            {{~ end ~}}
-        }
-
-        {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
-        {{~ for $p in Params ~}}
         [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_{{ $p.Index }}
+        [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+        private readonly struct __VariantImpl
+        {{~ if needs_dispose ~}}
+            : global::System.IDisposable
+        {{~ end ~}}
         {
-            public readonly {{ value_type $p }} Value;
-            {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-            public readonly object _dummy{{ $dummy }};
+            {{~ ## UNION TYPE ## ~}}
+            [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
+            private readonly struct Union
+            {
+                {{~ ## UNION MEMBERS ## ~}}
+                {{~ for $p in Params ~}}
+                [global::System.Runtime.InteropServices.FieldOffset(0)]
+                public readonly Value_{{ $p.Index }} _{{ $p.Index }};
+                {{~ end ~}}
+
+                {{~ ## UNION CONSTRUCTORS ## ~}}
+                {{~ for $p in Params ~}}
+                public Union({{ value_type $p }} value)
+                {
+                    {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
+                    _{{ $other.Index }} = default;
+                    {{~ end ~}}
+                    _{{ $p.Index }} = new Value_{{ $p.Index }}(value);
+                }
+                {{~ end ~}}
+            }
+
+            {{~ ## PER-TYPE WRAPPERS WITH PADDING ## ~}}
+            {{~ for $p in Params ~}}
+            [global::System.Diagnostics.DebuggerNonUserCode]
+            private readonly struct Value_{{ $p.Index }}
+            {
+                public readonly {{ value_type $p }} Value;
+                {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+                public readonly object _dummy{{ $dummy }};
+                {{~ end ~}}
+
+                public Value_{{ $p.Index }}({{ value_type $p }} value)
+                {
+                    {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
+                    _dummy{{ $dummy }} = null{{ global_forgive }};
+                    {{~ end ~}}
+                    Value = value;
+                }
+            }
             {{~ end ~}}
 
-            public Value_{{ $p.Index }}({{ value_type $p }} value)
+            private readonly Union _x;
+            private readonly byte _n;
+
+            {{~ ## STORAGE CONSTRUCTORS ## ~}}
+            {{~ for $p in Params ~}}
+            public __VariantImpl({{ value_type $p }} {{ $p.Hint }})
             {
-                {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
-                _dummy{{ $dummy }} = null{{ global_forgive }};
-                {{~ end ~}}
-                Value = value;
+                _n = {{ $p.Index }};
+                _x = new Union({{ $p.Hint }});
             }
-        }
-        {{~ end ~}}
+            {{~ end ~}}
 
-        private readonly Union _x;
-        private readonly byte _n;
-
-        {{~ ## STORAGE CONSTRUCTORS ## ~}}
-        {{~ for $p in Params ~}}
-        public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
-        {
-            _n = {{ $p.Index }};
-            _x = new Union({{ $p.Hint }});
-        }
-        {{~ end ~}}
-
-        {{~ if needs_dispose ~}}
-        public void Dispose()
-        {
-            switch (_n)
-            {
-                case 0:
-                    break;
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    {{~ if $p.IsDisposable ~}}
-                    {{ coalesce $p ($storage $p) ".Dispose()" }};
-                    {{~ end ~}}
-                    break;
-                {{~ end ~}}
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-        {{~ end ~}}
-
-        {{~ ## INTERNAL ACCESS ## ~}}
-        public static explicit operator global::dotVariant._Private.Discriminator({{ Variant.Name }} v)
-            => (global::dotVariant._Private.Discriminator)v._n;
-        {{~ for $p in Params ~}}
-        public static explicit operator global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>(in {{ Variant.Name }} v)
-            => new global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>(v._x._{{ $p.Index }}.Value);
-        {{~ end ~}}
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        {{~ if Language.Version >= 800 ~}}
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        {{~ end ~}}
-        public static void ThrowEmptyError()
-        {
-            throw MakeEmptyError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        {{~ if Language.Version >= 800 ~}}
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        {{~ end ~}}
-        public static T ThrowEmptyError<T>()
-        {
-            throw MakeEmptyError();
-        }
-
-        public static global::System.Exception MakeEmptyError()
-        {
-            return new global::System.InvalidOperationException("{{ Variant.Name }} is empty.");
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        {{~ if Language.Version >= 800 ~}}
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        {{~ end ~}}
-        public static void ThrowInternalError()
-        {
-            throw MakeInternalError();
-        }
-
-        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        {{~ if Language.Version >= 800 ~}}
-        [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
-        {{~ end ~}}
-        public static T ThrowInternalError<T>()
-        {
-            throw MakeInternalError();
-        }
-
-        public static global::System.Exception MakeInternalError()
-        {
-            return new global::System.InvalidOperationException("{{ Variant.Name }} has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
-        }
-
-        {{~ ## UNION IsEmpty ## ~}}
-        public bool IsEmpty => _n == 0;
-
-        {{~ ## UNION TypeString ## ~}}
-        public string TypeString
-        {
-            get
+            {{~ if needs_dispose ~}}
+            public void Dispose()
             {
                 switch (_n)
                 {
                     case 0:
-                        return "<empty>";
+                        break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        return "{{ $p.DiagName }}";
+                        {{~ if $p.IsDisposable ~}}
+                        {{ coalesce $p ($storage $p) ".Dispose()" }};
+                        {{~ end ~}}
+                        break;
                     {{~ end ~}}
                     default:
-                        return ThrowInternalError<string>();
+                        {{ throw_internal_error }};
+                        break;
                 }
             }
-        }
+            {{~ end ~}}
 
-        {{~ ## UNION ValueString ## ~}}
-        public string ValueString
-        {
-            get
+            {{~ ## INTERNAL ACCESS ## ~}}
+            public static explicit operator {{ discriminator }}(in __VariantImpl v)
+                => ({{ discriminator }})v._n;
+            {{~ for $p in Params ~}}
+            public static explicit operator {{ accessor $p.Index (value_type $p) }}(in __VariantImpl v)
+                => new {{ accessor $p.Index (value_type $p) }}(v._x._{{ $p.Index }}.Value);
+            {{~ end ~}}
+
+            /// <summary>
+            /// <see langword="true"/> if {{ Variant.Name }} was constructed without a value.
+            /// </summary>
+            {{~ if !Variant.IsClass ~}}
+            /// <remarks>
+            /// Because {{ Variant.Name }} is a value type, its default constructor cannot be disabled.
+            /// A default-constructed {{ Variant.Name }} will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
+            /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
+            /// </remarks>
+            {{~ end ~}}
+            public bool IsEmpty => _n == 0;
+
+            /// <summary>
+            /// The string representation of the stored value's type.
+            /// </summary>
+            public string TypeString
+            {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return "<empty>";
+                        {{~ for $p in Params ~}}
+                        case {{ $p.Index }}:
+                            return "{{ $p.DiagName }}";
+                        {{~ end ~}}
+                        default:
+                            return {{ throw_internal_error "string" }};
+                    }
+                }
+            }
+
+            /// <summary>
+            /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+            /// </summary>
+            public override string ToString()
             {
                 switch (_n)
                 {
@@ -292,55 +262,52 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                         return {{ coalesce_ToString $p ($storage $p) }};
                     {{~ end ~}}
                     default:
-                        return ThrowInternalError<string>();
+                        return {{ throw_internal_error "string" }};
                 }
             }
-        }
 
-        {{~ ## UNION AsObject ## ~}}
-        public object{{ global_nullable }} AsObject
-        {
-            get
+            /// <summary>
+            /// The stored value cast to type <see cref="object"/>.
+            /// </summary>
+            public object{{ global_nullable }} AsObject
             {
+                get
+                {
+                    switch (_n)
+                    {
+                        case 0:
+                            return null;
+                        {{~ for $p in Params ~}}
+                        case {{ $p.Index }}:
+                            return {{ $storage $p }};
+                        {{~ end ~}}
+                        default:
+                            return {{ throw_internal_error "object" + global_nullable }};
+                    }
+                }
+            }
+
+            public bool Equals(in __VariantImpl other)
+            {
+                if (_n != other._n)
+                {
+                    return false;
+                }
                 switch (_n)
                 {
                     case 0:
-                        return null;
+                        return true;
                     {{~ for $p in Params ~}}
-                    case {{ $p.Index }}:
-                        return {{ $storage $p }};
+                    {{~ $i = $p.Index ~}}
+                    case {{ $i }}:
+                        return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
                     {{~ end ~}}
                     default:
-                        return ThrowInternalError<object{{ global_nullable }}>();
+                        return {{ throw_internal_error "bool" }};
                 }
             }
-        }
 
-        {{~ ## UNION Equals ## ~}}
-        public bool Equals(in {{ Variant.Name }} other)
-        {
-            if (_n != other._n)
-            {
-                return false;
-            }
-            switch (_n)
-            {
-                case 0:
-                    return true;
-                {{~ for $p in Params ~}}
-                {{~ $i = $p.Index ~}}
-                case {{ $i }}:
-                    return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
-                {{~ end ~}}
-                default:
-                    return ThrowInternalError<bool>();
-            }
-        }
-
-        {{~ ## UNION GetHashCode ## ~}}
-        public override int GetHashCode()
-        {
-            unchecked
+            public override int GetHashCode()
             {
                 switch (_n)
                 {
@@ -356,88 +323,244 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
                         {{~ end ~}}
                     {{~ end ~}}
                     default:
-                        return ThrowInternalError<int>();
+                        return {{ throw_internal_error "int" }};
+                }
+            }
+
+            {{~ for $p in Params ~}}
+            {{~ ## UNION TryMatch ## ~}}
+            /// <summary>
+            /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
+            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
+            {
+                {{ $p.Hint }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
+                return _n == {{ $p.Index }};
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+            public bool TryMatch({{ action_type $p }} {{ $p.Hint }})
+            {
+                if (_n == {{ $p.Index }})
+                {
+                    {{ $p.Hint }}({{ $storage $p }});
+                    return true;
+                }
+                return false;
+            }
+
+            {{~ ## UNION Match ## ~}}
+            /// <summary>
+            /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
+            public void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
+            {
+                if (_n == {{ $p.Index }})
+                {
+                    {{ $p.Hint }} = {{ $storage $p }};
+                    return;
+                }
+                throw {{ make_mismatch_error $p.DiagName "{TypeString}" }};
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+            public void Match({{ action_type $p }} {{ $p.Hint }})
+            {
+                if (_n == {{ $p.Index }})
+                {
+                    {{ $p.Hint }}({{ $storage $p }});
+                    return;
+                }
+                {{ throw_mismatch_error $p.DiagName "{TypeString}" }};
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// otherwise invoke an alternative delegate.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
+            public void Match({{ action_type $p }} {{ $p.Hint }}, global::System.Action _)
+            {
+                if (_n == {{ $p.Index }})
+                {
+                    {{ $p.Hint }}({{ $storage $p }});
+                }
+                else
+                {
+                    _();
+                }
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }})
+            {
+                if (_n == {{ $p.Index }})
+                {
+                    return {{ $p.Hint }}({{ $storage $p }});
+                }
+                return {{ throw_mismatch_error $p.DiagName "{TypeString}" "TResult" }};
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// otherwise return a provided value.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="_">The value to return if the stored value is of a different type.</param>
+            /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="other"> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, TResult _)
+            {
+                return _n == {{ $p.Index }} ? {{ $p.Hint }}({{ $storage $p }}) : _;
+            }
+
+            /// <summary>
+            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// otherwise invoke an alternative delegate and return its result.
+            /// </summary>
+            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ cref $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, global::System.Func<TResult> _)
+            {
+                return _n == {{ $p.Index }} ? {{ $p.Hint }}({{ $storage $p }}) : _();
+            }
+            {{~ end ~}}
+
+            {{~ ## UNION Visit(Action) ## ~}}
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }},
+            /// and invoke a special delegate if {{ Variant.Name }} is empty.
+            /// </summary>
+            {{~ for $p in Params ~}}
+            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            {{~ end ~}}
+            /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit({{ action_params }}, global::System.Action _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        _();
+                        break;
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        {{ $p.Hint }}({{ $storage $p }});
+                        break;
+                    {{~ end ~}}
+                    default:
+                        {{ throw_internal_error }};
+                        break;
+                }
+            }
+
+            {{~ ## UNION Visit(Action) ## ~}}
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }},
+            /// and throw an exception if {{ Variant.Name }} is empty.
+            /// </summary>
+            {{~ for $p in Params ~}}
+            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            {{~ end ~}}
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            public void Visit({{ action_params }})
+            {
+                switch (_n)
+                {
+                    case 0:
+                        {{ throw_empty_error }};
+                        break;
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        {{ $p.Hint }}({{ $storage $p }});
+                        break;
+                    {{~ end ~}}
+                    default:
+                        {{ throw_internal_error }};
+                        break;
+                }
+            }
+
+            {{~ ## UNION Visit(Func) ## ~}}
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }} and return the result,
+            /// and invoke a special delegate if {{ Variant.Name }} is empty and return its result.
+            /// </summary>
+            {{~ for $p in Params ~}}
+            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            {{~ end ~}}
+            /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return _();
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        return {{ $p.Hint }}({{ $storage $p }});
+                    {{~ end ~}}
+                    default:
+                        return {{ throw_internal_error "TResult" }};
+                }
+            }
+
+            {{~ ## UNION Visit(Func) ## ~}}
+            /// <summary>
+            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }} and return the result,
+            /// and throw an exception if {{ Variant.Name }} is empty.
+            /// </summary>
+            {{~ for $p in Params ~}}
+            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            {{~ end ~}}
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+            /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+            public TResult Visit<TResult>({{ func_params }})
+            {
+                switch (_n)
+                {
+                    case 0:
+                        return {{ throw_empty_error "TResult" }};
+                    {{~ for $p in Params ~}}
+                    case {{ $p.Index }}:
+                        return {{ $p.Hint }}({{ $storage $p }});
+                    {{~ end ~}}
+                    default:
+                        return {{ throw_internal_error "TResult" }};
                 }
             }
         }
-
-        {{~ ## UNION TryMatch ## ~}}
-        {{~ for $p in Params ~}}
-        public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
-        {
-            {{ $p.Hint }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
-            return _n == {{ $p.Index }};
-        }
-        {{~ end ~}}
-
-        {{~ ## UNION Visit(Action) ## ~}}
-        public void Visit({{ action_params }}, global::System.Action _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    _();
-                    break;
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    {{ $p.Hint }}({{ $storage $p }});
-                    break;
-                {{~ end ~}}
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        {{~ ## UNION Visit(Action) ## ~}}
-        public void Visit({{ action_params }})
-        {
-            switch (_n)
-            {
-                case 0:
-                    ThrowEmptyError();
-                    break;
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    {{ $p.Hint }}({{ $storage $p }});
-                    break;
-                    {{~ end ~}}
-                default:
-                    ThrowInternalError();
-                    break;
-            }
-        }
-
-        {{~ ## UNION Visit(Func) ## ~}}
-        public TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
-        {
-            switch (_n)
-            {
-                case 0:
-                    return _();
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    return {{ $p.Hint }}({{ $storage $p }});
-                {{~ end ~}}
-                default:
-                    return ThrowInternalError<TResult>();
-            }
-        }
-
-        {{~ ## UNION Visit(Func) ## ~}}
-        public TResult Visit<TResult>({{ func_params }})
-        {
-            switch (_n)
-            {
-                case 0:
-                    return ThrowEmptyError<TResult>();
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    return {{ $p.Hint }}({{ $storage $p }});
-                {{~ end ~}}
-                default:
-                    return ThrowInternalError<TResult>();
-            }
-        }
     }
+{{~ if Variant.Namespace ~}}
 }
+{{~ end ~}}

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -11,146 +11,22 @@ Global input variables are fed from C# RenderInfo members:
 - Runtime : RuntimeInfo
 - Variant : VariantInfo
 ## ~}}
-{{~
-emit_nullability = Language.Version >= 800 && Language.Nullable == "enable"
-
-# The type to use for variables and function parameters
-# Works with both "Params" and "Variant"
-func value_type(type, name = null)
-    if (name == null)
-        name = type.Name
-    end
-    if type.IsClass
-        ret emit_nullability && type.Nullability == "nullable" ? (name + "?" ): name
-    else
-        ret name
-    end
-end
-
-# The type to use for out or ref parameters
-# Works with both "Params" and "Variant"
-func outref_type(type, name = null)
-    if (name == null)
-        name = type.Name
-    end
-    if type.IsClass
-        ret emit_nullability ? (name + "?") : name
-    else
-        ret name
-    end
-end
-
-func func_type(param, result = "TResult")
-    ret "global::System.Func<" + (value_type param) + ", " + result + ">"
-end
-
-func action_type(param)
-    ret "global::System.Action<" + (value_type param) + ">"
-end
-
-# Conditionally append forgive-operator to an expression
-# Works with both "Params" and "Variant"
-func forgive(type, expression)
-    if type.IsClass
-        ret emit_nullability && type.Nullability == "nonnull" ? (expression + "!") : expression
-    else
-        ret expression
-    end
-end
-
-# Conditionally apply a null-caolescing member access with trailing null-expression after the ??
-# Works with both "Params" and "Variant"
-func coalesce(type, expression, sub_expression, null_expression = null)
-    if type.Nullability == "nullable"
-        ret expression + "?" + sub_expression + (null_expression != null ? (" ?? " + null_expression) : "")
-    else
-        ret expression + sub_expression
-    end
-end
-
-func coalesce_ToString(type, expression)
-    if type.Nullability == "nonnull" && type.ToStringNullability == "nonnull"
-        ret expression + ".ToString()"
-    else
-        ret expression + (type.Nullability == "nullable" ? "?" : "") + ".ToString() ?? \"null\""
-    end
-end
-
-func param_hint(param)
-    ret param.Hint
-end
-
-func annotate_NotNullWhen(param)
-    if param.IsClass && emit_nullability
-        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] " : ""
-    else
-        ret ""
-    end
-end
-
-func annotate_NotNull(param)
-    if param.IsClass && emit_nullability
-        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNull] " : ""
-    else
-        ret ""
-    end
-end
-
-func throw_InvalidOperation(expected, actual)
-    $msg = "$\"Failed to match on '" +  Variant.DiagName + "' (expected '" + expected + "', actual '" + actual + "').\""
-    ret "throw new global::System.InvalidOperationException(" + $msg + ")"
-end
-
-storage_type = "global::dotVariant._G." + (Variant.Namespace ? (Variant.Namespace + ".") : "") + Variant.Name
-func get_value(param, expression = "_variant")
-    ret "((global::dotVariant._Private.Accessor_" + param.Index + "<" + value_type param + ">)" + expression + ").Value"
-end
-
-func get_n(expression = "_variant")
-    ret "((int)(global::dotVariant._Private.Discriminator)" + expression + ")"
-end
-
-func cref(name)
-    ret name | string.replace "<" "{" | string.replace ">" "}"
-end
-
-func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Hint; end) | array.join ", "
-action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Hint; end) | array.join ", "
-method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : ""
-param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
-global_nullable = emit_nullability ? "?" : ""
-global_forgive = emit_nullability ? "!" : ""
-needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
-
-readonly storage_type
-readonly get_value
-readonly get_n
-readonly func_params
-readonly action_params
-readonly method_modifiers
-readonly param_modifiers
-readonly global_nullable
-readonly global_forgive
-readonly needs_dispose
-readonly cref
-~}}
+{{~ include "globals" ~}}
 {{~ if Language.Version >= 800 ~}}
 #nullable {{ Language.Nullable }}
 {{~ end ~}}
 {{~ if Variant.Namespace ~}}
 namespace {{ Variant.Namespace }}
 {
-    {{~ end ~}}
+{{~ end ~}}
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    [global::System.Diagnostics.DebuggerNonUserCode]
     partial {{ Variant.Keyword }} {{ Variant.Name }}
         : global::System.IEquatable<{{ Variant.Name }}>
         {{~ if needs_dispose ~}}
         , global::System.IDisposable
         {{~ end ~}}
     {
-        [global::System.Diagnostics.DebuggerBrowsable(global::System.Diagnostics.DebuggerBrowsableState.Never)]
         private readonly {{ storage_type }} _variant;
 
         {{~ ## VARIANT CONSTRUCTORS ## ~}}
@@ -159,6 +35,7 @@ namespace {{ Variant.Namespace }}
         /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
         /// </summary>
         /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
             => _variant = new {{ storage_type }}({{ $p.Hint }});
         {{~ end ~}}
@@ -170,6 +47,7 @@ namespace {{ Variant.Namespace }}
         /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
         /// </summary>
         /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static implicit operator {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
             => new {{ Variant.Name }}({{ $p.Hint }});
         {{~ end ~}}
@@ -181,6 +59,7 @@ namespace {{ Variant.Namespace }}
         /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
         /// </summary>
         /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static {{ Variant.Name }} Create({{ value_type $p }} {{ $p.Hint }})
             => new {{ Variant.Name }}({{ $p.Hint }});
         {{~ end ~}}
@@ -188,6 +67,7 @@ namespace {{ Variant.Namespace }}
         {{~ ## DISPOSE ## ~}}
         {{~ if needs_dispose && !Variant.UserDefined.Dispose }}
         /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public void Dispose()
         {
             _variant.Dispose();
@@ -195,324 +75,105 @@ namespace {{ Variant.Namespace }}
         {{~ end ~}}
 
         {{~ ## VARIANT IsEmpty ## ~}}
-        /// <summary>
-        /// <see langword="true"/> if {{ Variant.Name }} was constructed without a value.
-        /// </summary>
-        {{~ if !Variant.IsClass ~}}
-        /// <remarks>
-        /// Because {{ Variant.Name }} is a value type, its default constructor cannot be disabled.
-        /// A default-constructed {{ Variant.Name }} will always have a <see cref="IsEmpty"/> value of <see langword"true"/>
-        /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
-        /// </remarks>
-        {{~ end ~}}
+        /// <inheritdoc cref="{{ cref storage_type }}.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}bool IsEmpty
             => _variant.IsEmpty;
 
         {{~ ## VARIANT Equals ## ~}}
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}override bool Equals(object{{ global_nullable }} other)
             => other is {{ Variant.Name }} v && Equals(v);
 
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}bool Equals({{ value_type Variant }} other)
             => {{ if Variant.IsClass; "!(other is null) && "; end }}_variant.Equals(other._variant);
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==({{ param_modifiers; value_type Variant }} lhs, {{ param_modifiers; value_type Variant }} rhs)
-            => {{ coalesce Variant "lhs" ".Equals(rhs)" "(rhs is null)" }};
+        => {{ coalesce Variant "lhs" ".Equals(rhs)" "(rhs is null)" }};
 
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=({{ param_modifiers; value_type Variant }} lhs, {{ param_modifiers; value_type Variant }} rhs)
-            => !(lhs == rhs);
+        => !(lhs == rhs);
 
         {{~ ## VARIANT GetHashCode ## ~}}
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}override int GetHashCode()
             => _variant.GetHashCode();
 
         {{~ ## VARIANT ToString ## ~}}
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}override string ToString()
-            => _variant.ValueString;
+            => _variant.ToString();
 
-        {{~ ## VARIANT Match(out T) ## ~}}
         {{~ for $p in Params ~}}
-        /// <summary>
-        /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
-        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                {{ $p.Hint }} = {{ get_value $p }};
-            }
-            else
-            {
-                {{ throw_InvalidOperation $p.DiagName "{_variant.TypeString}" }};
-            }
-        }
-        {{~ end ~}}
-
-        {{~ ## VARIANT TryMatch(out T) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
+        {{~ ## VARIANT TryMatch ## ~}}
+        /// <inheritdoc cref="{{ cref storage_type }}.TryMatch(out {{ cref (outref_type $p) }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                {{ $p.Hint }} = {{ get_value $p }};
-                return true;
-            }
-            else
-            {
-                {{ $p.Hint }} = default;
-                return false;
-            }
-        }
-        {{~ end ~}}
+            => _variant.TryMatch(out {{ $p.Hint }});
 
-        {{~ ## VARIANT TryMatch(Action<T>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.TryMatch(out {{ cref (action_type $p) }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}bool TryMatch({{ action_type $p }} {{ $p.Hint }})
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                {{ $p.Hint }}({{ get_value $p }});
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        {{~ end ~}}
+            => _variant.TryMatch({{ $p.Hint }});
 
-        {{~ ## VARIANT Match(Action<T>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+        {{~ ## VARIANT Match ## ~}}
+        /// <inheritdoc cref="{{ cref storage_type }}.Match(out {{ cref (outref_type $p) }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
+            => _variant.Match(out {{ $p.Hint }});
+
+        /// <inheritdoc cref="{{ cref storage_type }}.Match({{ cref (action_type $p) }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }})
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                {{ $p.Hint }}({{ get_value $p }});
-            }
-            else
-            {
-                {{ throw_InvalidOperation $p.DiagName "{_variant.TypeString}" }};
-            }
-        }
-        {{~ end ~}}
+            => _variant.Match({{ $p.Hint }});
 
-        {{~ ## VARIANT Match(Action<T>, Action) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
-        /// otherwise invoke an alternative delegate.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.Match({{ cref (action_type $p) }}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }}, global::System.Action _)
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                {{ $p.Hint }}({{ get_value $p }});
-            }
-            else
-            {
-                _();
-            }
-        }
-        {{~ end ~}}
+            => _variant.Match({{ $p.Hint }}, _);
 
-        {{~ ## VARIANT Match(Func<T, R>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
-        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>.</returns>
-        /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/></exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }})
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                return {{ $p.Hint }}({{ get_value $p }});
-            }
-            else
-            {
-                {{ throw_InvalidOperation $p.DiagName "{_variant.TypeString}" }};
-            }
-        }
-        {{~ end ~}}
+            => _variant.Match({{ $p.Hint }});
 
-        {{~ ## VARIANT Match(Func<T, R>, R) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
-        /// otherwise return a provided value.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <param name="_">The value to return if the stored value is of a different type.</param>
-        /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>, or <paramref name="default"/>.</returns>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> or <paramref name="other"> is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, TResult _)
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                return {{ $p.Hint }}({{ get_value $p }});
-            }
-            else
-            {
-                return _;
-            }
-        }
-        {{~ end ~}}
+            => _variant.Match({{ $p.Hint }}, _);
 
-        {{~ ## VARIANT Match(Func<T, R>, Func<R>) ## ~}}
-        {{~ for $p in Params ~}}
-        /// <summary>
-        /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
-        /// otherwise invoke an alternative delegate and return its result.
-        /// </summary>
-        /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ cref $p.Hint }}"> or <paramref name="_"> is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, global::System.Func<TResult> _)
-        {
-            if ({{ get_n }} == {{ $p.Index }})
-            {
-                return {{ $p.Hint }}({{ get_value $p }});
-            }
-            else
-            {
-                return _();
-            }
-        }
+            => _variant.Match({{ $p.Hint }}, _);
+
         {{~ end ~}}
 
-        {{~ ## VARIANT Visit(Action<A>, Action<B>, ...) ## ~}}
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }},
-        /// and throw an exception if {{ Variant.Name }} is empty.
-        /// </summary>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        {{~ ## VARIANT Visit ## ~}}
+        /// <inheritdoc cref="{{ cref storage_type }}.Visit({{ cref action_types }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}void Visit({{ action_params }})
-        {
-            switch ({{ get_n }})
-            {
-                case 0:
-                    {{ storage_type }}.ThrowEmptyError();
-                    break;
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    {{ $p.Hint }}({{ get_value $p }});
-                    break;
-                {{~ end ~}}
-                default:
-                    {{ storage_type }}.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit({{ forward_params }});
 
-        {{~ ## VARIANT Visit(Action<A>, Action<B>, ..., empty) ## ~}}
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }},
-        /// and invoke a special delegate if {{ Variant.Name }} is empty.
-        /// </summary>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <inheritdoc cref="{{ cref storage_type }}.Visit({{ cref action_types }}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}void Visit({{ action_params }}, global::System.Action _)
-        {
-            switch ({{ get_n }})
-            {
-                case 0:
-                    _();
-                    break;
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    {{ $p.Hint }}({{ get_value $p }});
-                    break;
-                {{~ end ~}}
-                default:
-                    {{ storage_type }}.ThrowInternalError();
-                    break;
-            }
-        }
+            => _variant.Visit({{ forward_params }}, _);
 
-        {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ...) ## ~}}
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }} and return the result,
-        /// and throw an exception if {{ Variant.Name }} is empty.
-        /// </summary>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="{{ cref storage_type }}.Visit{TResult}({{ cref func_types }})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}TResult Visit<TResult>({{ func_params }})
-        {
-            switch ({{ get_n }})
-            {
-                case 0:
-                    return {{ storage_type }}.ThrowEmptyError<TResult>();
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    return {{ $p.Hint }}({{ get_value $p }});
-                {{~ end ~}}
-                default:
-                    return {{ storage_type }}.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit({{ forward_params }});
 
-        {{~ ## VARIANT Visit(Func<A, R>, Func<B, R>, ..., empty) ## ~}}
-        /// <summary>
-        /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }} and return the result,
-        /// and invoke a special delegate if {{ Variant.Name }} is empty and return its result.
-        /// </summary>
-        {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
-        {{~ end ~}}
-        /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
-        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
-        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        /// <inheritdoc cref="{{ cref storage_type }}.Visit{TResult}({{ cref func_types }}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
-        {
-            switch ({{ get_n }})
-            {
-                case 0:
-                    return _();
-                {{~ for $p in Params ~}}
-                case {{ $p.Index }}:
-                    return {{ $p.Hint }}({{ get_value $p }});
-                {{~ end ~}}
-                default:
-                    return {{ storage_type }}.ThrowInternalError<TResult>();
-            }
-        }
+            => _variant.Visit({{ forward_params }}, _);
 
         private sealed class _VariantTypeProxy
         {
@@ -527,10 +188,14 @@ namespace {{ Variant.Namespace }}
 
         {{~ ## INTERNAL ACCESS ## ~}}
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Discriminator({{ Variant.Name }} v) => (global::dotVariant._Private.Discriminator)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator {{ discriminator }}({{ Variant.Name }} v)
+            => ({{ discriminator }})v._variant;
         {{~ for $p in Params ~}}
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-        public static explicit operator global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>({{ Variant.Name }} v) => (global::dotVariant._Private.Accessor_{{ $p.Index }}<{{ value_type $p }}>)v._variant;
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static explicit operator {{ accessor $p.Index (value_type $p) }}({{ Variant.Name }} v)
+            => ({{ accessor $p.Index (value_type $p) }})v._variant;
         {{~ end ~}}
     }
 {{~ if Variant.Namespace ~}}

--- a/src/dotVariant.Generator/templates/globals.scriban-cs
+++ b/src/dotVariant.Generator/templates/globals.scriban-cs
@@ -1,0 +1,187 @@
+{{~
+# Copyright Miro Knejp 2021.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+~}}
+{{~ ##
+Global input variables are fed from C# RenderInfo members:
+- Language : LanguageInfo
+- Options : OptionsInfo
+- Params : ParamInfo[]
+- Runtime : RuntimeInfo
+- Variant : VariantInfo
+## ~}}
+{{~
+emit_nullability = Language.Version >= 800 && Language.Nullable == "enable"
+readonly emit_nullability
+
+# The type to use for variables and function parameters
+# Works with both "Params" and "Variant"
+func value_type(type, name = null)
+    if (name == null)
+        name = type.Name
+    end
+    if type.IsClass
+        ret emit_nullability && type.Nullability == "nullable" ? (name + "?" ): name
+    else
+        ret name
+    end
+end
+readonly value_type
+
+# The type to use for out or ref parameters
+# Works with both "Params" and "Variant"
+func outref_type(type, name = null)
+    if (name == null)
+        name = type.Name
+    end
+    if type.IsClass
+        ret emit_nullability ? (name + "?") : name
+    else
+        ret name
+    end
+end
+readonly outref_type
+
+func func_type(param, result = "TResult")
+    ret "global::System.Func<" + (value_type param) + ", " + result + ">"
+end
+readonly func_type
+
+func action_type(param)
+    ret "global::System.Action<" + (value_type param) + ">"
+end
+readonly action_type
+
+# Conditionally append forgive-operator to an expression
+# Works with both "Params" and "Variant"
+func forgive(type, expression)
+    if type.IsClass
+        ret emit_nullability && type.Nullability == "nonnull" ? (expression + "!") : expression
+    else
+        ret expression
+    end
+end
+readonly forgive
+
+# Conditionally apply a null-caolescing member access with trailing null-expression after the ??
+# Works with both "Params" and "Variant"
+func coalesce(type, expression, sub_expression, null_expression = null)
+    if type.Nullability == "nullable"
+        ret expression + "?" + sub_expression + (null_expression != null ? (" ?? " + null_expression) : "")
+    else
+        ret expression + sub_expression
+    end
+end
+readonly coalesce
+
+func coalesce_ToString(type, expression)
+    if type.Nullability == "nonnull" && type.ToStringNullability == "nonnull"
+        ret expression + ".ToString()"
+    else
+        ret expression + (type.Nullability == "nullable" ? "?" : "") + ".ToString() ?? \"null\""
+    end
+end
+readonly coalesce_ToString
+
+func param_hint(param)
+    ret param.Hint
+end
+readonly param_hint
+
+func annotate_NotNullWhen(param)
+    if param.IsClass && emit_nullability
+        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] " : ""
+    else
+        ret ""
+    end
+end
+readonly annotate_NotNullWhen
+
+func annotate_NotNull(param)
+    if param.IsClass && emit_nullability
+        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNull] " : ""
+    else
+        ret ""
+    end
+end
+readonly annotate_NotNull
+
+func throw_mismatch_error(expected, actual, type = "")
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError" + (type == "" ? "" : "<" + type + ">") + "(" + ([Variant.DiagName, expected, actual] | array.join ", " @string.literal) + ")"
+end
+readonly throw_mismatch_error
+
+func throw_internal_error(type = "")
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowInternalError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagName) + ")"
+end
+readonly throw_internal_error
+
+func throw_empty_error(type = "")
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagName) + ")"
+end
+readonly throw_empty_error_error
+
+func make_mismatch_error(expected, actual)
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeMismatchError(" + ([Variant.DiagName, expected, actual] | array.join ", " @string.literal) + ")"
+end
+readonly make_mismatch_error
+
+func make_internal_error()
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeInternalError(" + (string.literal Variant.DiagName) + ")"
+end
+readonly make_internal_error
+
+func make_empty_error()
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeEmptyError(" + (string.literal Variant.DiagName) + ")"
+end
+readonly make_empty_error_error
+
+#storage_type = "global::dotVariant._G." + (Variant.Namespace ? (Variant.Namespace + ".") : "") + Variant.Name
+storage_type = "__VariantImpl"
+readonly storage_type
+
+func get_value(param, expression = "_variant")
+    ret "((global::dotVariant.GeneratorSupport.Accessor_" + param.Index + "<" + value_type param + ">)" + expression + ").Value"
+end
+readonly get_value
+
+func get_n(expression = "_variant")
+    ret "((int)(global::dotVariant.GeneratorSupport.Discriminator)" + expression + ")"
+end
+readonly get_n
+
+func cref(name)
+    ret name | string.replace "<" "{" | string.replace ">" "}"
+end
+readonly cref
+
+func accessor(index, type)
+    ret "global::dotVariant.GeneratorSupport.Accessor_" + index + "<" + type + ">"
+end
+readonly accessor
+
+func_types = Params | array.each @(do; ret func_type $0; end) | array.join ", "
+func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Hint; end) | array.join ", "
+action_types = Params | array.each @(do; ret action_type $0; end) | array.join ", "
+action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Hint; end) | array.join ", "
+method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : ""
+param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
+global_nullable = emit_nullability ? "?" : ""
+global_forgive = emit_nullability ? "!" : ""
+needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
+forward_params = Params | array.each @(do; ret $0.Hint; end) | array.join ", "
+discriminator = "global::dotVariant.GeneratorSupport.Discriminator"
+
+readonly func_types
+readonly func_params
+readonly action_types
+readonly action_params
+readonly method_modifiers
+readonly param_modifiers
+readonly global_nullable
+readonly global_forgive
+readonly needs_dispose
+readonly forward_params
+readonly discriminator
+~}}

--- a/src/dotVariant.Runtime/GeneratorSupport/Accessor.cs
+++ b/src/dotVariant.Runtime/GeneratorSupport/Accessor.cs
@@ -4,7 +4,7 @@
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 //
 
-namespace dotVariant._Private
+namespace dotVariant.GeneratorSupport
 {
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public readonly struct Accessor_1<T> { public readonly T Value; public Accessor_1(T value) => Value = value; }

--- a/src/dotVariant.Runtime/GeneratorSupport/Discriminator.cs
+++ b/src/dotVariant.Runtime/GeneratorSupport/Discriminator.cs
@@ -1,0 +1,11 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+namespace dotVariant.GeneratorSupport
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public enum Discriminator : byte { }
+}

--- a/src/dotVariant.Runtime/GeneratorSupport/Throw.cs
+++ b/src/dotVariant.Runtime/GeneratorSupport/Throw.cs
@@ -1,0 +1,71 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using System;
+
+namespace dotVariant.GeneratorSupport
+{
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public static class Errors
+    {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowEmptyError(string name)
+        {
+            throw MakeEmptyError(name);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowEmptyError<T>(string name)
+        {
+            throw MakeEmptyError(name);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowInternalError(string name)
+        {
+            throw MakeInternalError(name);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowInternalError<T>(string name)
+        {
+            throw MakeInternalError(name);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static void ThrowMismatchError(string name, string expected, string actual)
+        {
+            throw MakeMismatchError(name, expected, actual);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+        public static T ThrowMismatchError<T>(string name, string expected, string actual)
+        {
+            throw MakeMismatchError(name, expected, actual);
+        }
+
+        public static Exception MakeEmptyError(string name)
+        {
+            return new InvalidOperationException(name + " is empty.");
+        }
+
+        public static Exception MakeInternalError(string name)
+        {
+            return new InvalidOperationException(name + " has encountered an internal error. Please file an issue at https://github.com/mknejp/dotvariant");
+        }
+
+        public static Exception MakeMismatchError(string name, string expected, string actual)
+        {
+            return new InvalidOperationException($"Failed to match on {name} (expected: {expected}, actual: {actual}).");
+        }
+    }
+}

--- a/src/dotVariant.Runtime/NullableAttributes.cs
+++ b/src/dotVariant.Runtime/NullableAttributes.cs
@@ -4,8 +4,9 @@
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
 //
 
-namespace dotVariant._Private
+namespace System.Diagnostics.CodeAnalysis
 {
-    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
-    public enum Discriminator : byte { }
+    internal sealed class DoesNotReturn : Attribute
+    {
+    }
 }

--- a/src/dotVariant.Test/dotVariant.Test.projitems
+++ b/src/dotVariant.Test/dotVariant.Test.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>

--- a/src/dotVariant.sln
+++ b/src/dotVariant.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31025.218

--- a/src/dotVariant/dotVariant.csproj
+++ b/src/dotVariant/dotVariant.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <!-- <config>
     <add key="globalPackagesFolder" value=".packages" />


### PR DESCRIPTION
- Make the union wrapper a nested class of the original type again.
  This is needed for generics to work properly, otherwise we would have
  to copy the generic constraints to the wrapper. This now also gets rid
  of the `dotVariant._G` namespace and hides everything inside the type.
- Moved some code that is identical for all variants to the support
  library.
- Cleanup and simplification of the Scriban files.
- Move implementation of most public methods to the private union type
  to make the wrapper as thin as possible. Using `<inheritdoc>` the
  public interface and the `_variant` interface now share documentation.
