### PR TITLE
Refine the distinction of identifier vs type

### DIFF
--- a/src/dotVariant.Generator.Test/RenderInfo.Test.cs
+++ b/src/dotVariant.Generator.Test/RenderInfo.Test.cs
@@ -60,14 +60,45 @@ namespace dotVariant.Generator.Test
                     // VariantInfo properties
                     //
                     (
-                        "type name",
+                        "identifier",
                         @"
                         [dotVariant.Variant]
                         public partial class XyzVariant
                         {
                             static partial void VariantOf(int a, float b);
                         }",
-                        ri => Assert.That(ri.Variant.Name, Is.EqualTo("XyzVariant"))
+                        ri => Assert.That(ri.Variant.Identifier, Is.EqualTo("XyzVariant"))
+                    ),
+                    (
+                        "type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class XyzVariant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Variant.Type, Is.EqualTo("XyzVariant"));
+                            Assert.That(ri.Variant.QualifiedType, Is.EqualTo("global::XyzVariant"));
+                        })
+                    ),
+                    (
+                        "type with namespace",
+                        @"
+                        namespace Foo.Bar
+                        {
+                            [dotVariant.Variant]
+                            public partial class XyzVariant
+                            {
+                                static partial void VariantOf(int a, float b);
+                            }
+                        }",
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Variant.Type, Is.EqualTo("XyzVariant"));
+                            Assert.That(ri.Variant.QualifiedType, Is.EqualTo("global::Foo.Bar.XyzVariant"));
+                        })
                     ),
                     (
                         "namespace name",
@@ -97,7 +128,17 @@ namespace dotVariant.Generator.Test
                         ri => Assert.That(ri.Variant.Namespace, Is.Null)
                     ),
                     (
-                        "diagnostic name",
+                        "diagnostic type",
+                        @"
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(int a, float b);
+                        }",
+                        ri => Assert.That(ri.Variant.DiagType, Is.EqualTo("Variant"))
+                    ),
+                    (
+                        "diagnostic type with namesapce",
                         @"
                         namespace Foo.Bar
                         {
@@ -107,7 +148,7 @@ namespace dotVariant.Generator.Test
                                 static partial void VariantOf(int a, float b);
                             }
                         }",
-                        ri => Assert.That(ri.Variant.DiagName, Is.EqualTo("Foo.Bar.Variant"))
+                        ri => Assert.That(ri.Variant.DiagType, Is.EqualTo("Foo.Bar.Variant"))
                     ),
                     (
                         "class type",
@@ -148,7 +189,7 @@ namespace dotVariant.Generator.Test
                         ri => Assert.That(ri.Variant.Nullability, Is.EqualTo("nullable"))
                     ),
                     (
-                        "struct are nonnull",
+                        "structs are nonnull",
                         @"
                         [dotVariant.Variant]
                         public partial struct Variant
@@ -306,54 +347,71 @@ namespace dotVariant.Generator.Test
                         })
                     ),
                     (
-                        "hint",
+                        "identifier",
                         @"
                         [dotVariant.Variant]
                         public partial class Variant
                         {
-                            static partial void VariantOf(int foobar);
+                            static partial void VariantOf(int a, double b, string c;
                         }",
-                        ri => Assert.That(ri.Params[0].Hint, Is.EqualTo("foobar"))
+                        ri => Assert.Multiple(() =>
+                        {
+                            Assert.That(ri.Params[0].Identifier, Is.EqualTo("a"));
+                            Assert.That(ri.Params[1].Identifier, Is.EqualTo("b"));
+                            Assert.That(ri.Params[2].Identifier, Is.EqualTo("c"));
+                        })
                     ),
                     (
-                        "fully qualified type name",
+                        "qualified type",
                         @"
+                        using System;
                         [dotVariant.Variant]
                         public partial class Variant
                         {
-                            static partial void VariantOf(System.TimeSpan a);
+                            static partial void VariantOf(TimeSpan a);
                         }",
-                        ri => Assert.That(ri.Params[0].Name, Is.EqualTo("global::System.TimeSpan"))
+                        ri => Assert.That(ri.Params[0].Type, Is.EqualTo("global::System.TimeSpan"))
                     ),
                     (
-                        "shortened specila type name",
+                        "shortened special type",
                         @"
                         [dotVariant.Variant]
                         public partial class Variant
                         {
                             static partial void VariantOf(int a);
                         }",
-                        ri => Assert.That(ri.Params[0].Name, Is.EqualTo("int"))
+                        ri => Assert.That(ri.Params[0].Type, Is.EqualTo("int"))
                     ),
                     (
-                        "diagnostic type name",
+                        "diagnostic type",
+                        @"
+                        using System;
+                        [dotVariant.Variant]
+                        public partial class Variant
+                        {
+                            static partial void VariantOf(TimeSpan a);
+                        }",
+                        ri => Assert.That(ri.Params[0].DiagType, Is.EqualTo("System.TimeSpan"))
+                    ),
+                    (
+                        "diagnostic type for nullable value type",
                         @"
                         [dotVariant.Variant]
                         public partial class Variant
                         {
-                            static partial void VariantOf(System.TimeStamp a);
+                            static partial void VariantOf(int? a);
                         }",
-                        ri => Assert.That(ri.Params[0].DiagName, Is.EqualTo("System.TimeStamp"))
+                        ri => Assert.That(ri.Params[0].DiagType, Is.EqualTo("int?"))
                     ),
                     (
-                        "diagnostic special type name",
+                        "diagnostic special type",
                         @"
                         [dotVariant.Variant]
                         public partial class Variant
                         {
                             static partial void VariantOf(int a);
                         }",
-                        ri => Assert.That(ri.Params[0].DiagName, Is.EqualTo("int"))
+                        ri => Assert.That(ri.Params[0].DiagType, Is.EqualTo("int"))
                     ),
                     (
                         "class type",

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -501,7 +501,7 @@ namespace Foo
                         case 3:
                             return "string";
                         case 4:
-                            return "System.Array?";
+                            return "System.Array";
                         default:
                             return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_enable");
                     }
@@ -997,7 +997,7 @@ namespace Foo
                     a = _x._4.Value;
                     return;
                 }
-                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+                throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "System.Array", "{TypeString}");
             }
 
             /// <summary>
@@ -1014,7 +1014,7 @@ namespace Foo
                     a(_x._4.Value);
                     return;
                 }
-                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+                global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "System.Array", "{TypeString}");
             }
 
             /// <summary>
@@ -1050,7 +1050,7 @@ namespace Foo
                 {
                     return a(_x._4.Value);
                 }
-                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "System.Array?", "{TypeString}");
+                return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "System.Array", "{TypeString}");
             }
 
             /// <summary>

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -58,14 +58,14 @@ namespace dotVariant.Generator
         /// <param name="Accessibility">
         /// The accessibility modifier of the variant class.
         /// </param>
-        /// <param name="DiagName">
-        /// The fully qualified name of the type (without global:: alias, for diagnostic strings/messages).
+        /// <param name="DiagType">
+        /// The fully qualified name of the type (without <c>global::</c> qualifier) used for diagnostic strings/messages.
         /// </param>
         /// <param name="ExtensionsAccessibility">
         /// The accessibility to use for the class containing extension methods. <see langword="null"/> if extensions are impossible to define.
         /// </param>
-        /// <param name="FullName">
-        /// The fully qualified name of the type.
+        /// <param name="Identifier">
+        /// The identifier of the type, i.e. without type parameters or enclsoing namespace/type qualifiers.
         /// </param>
         /// <param name="IsClass">
         /// <see langword="true"/> if this is an object type.
@@ -79,43 +79,47 @@ namespace dotVariant.Generator
         /// <param name="Namespace">
         /// Namespace of the variant type, or <see langword="null"/> if in the global namespace.
         /// </param>
-        /// <param name="Name">
-        /// Name of the variant type within the context of its namespace.
-        /// </param>
         /// <param name="Nullability">
         /// <c>"nonnull"</c> or <c>"nullable"</c>. For a class this determines if certain public methods need nullability annotations.
         /// Always <c>"nonnull"</c> for a value type.
+        /// </param>
+        /// <param name="QualifiedType">
+        /// The fully qualified name of the type including type parameters.
+        /// </param>
+        /// <param name="Type">
+        /// Top-level name of the variant's type including type parameter list.
         /// </param>
         /// <param name="UserDefined">
         /// Contains info about relevant members the user has defined.
         /// </param>
         public sealed record VariantInfo(
             string? Accessibility,
-            string DiagName,
+            string DiagType,
             string? ExtensionsAccessibility,
-            string FullName,
+            string Identifier,
             bool IsClass,
             bool IsReadonly,
             string Keyword,
             string? Namespace,
-            string Name,
             string Nullability,
+            string QualifiedType,
+            string Type,
             VariantInfo.UserDefinitions UserDefined)
         {
             /// <param name="Dispose">
-            /// <see langword="true"/> if a user-defined <see cref="IDisposable.Dispose()"/> exists.
+            /// <see langword="true"/> if a user-defined <see cref="System.IDisposable.Dispose()"/> exists.
             /// </param>
             public sealed record UserDefinitions(
                 bool Dispose);
         }
 
-        /// <param name="DiagName">
-        /// A shorter type name (without global:: qualifier, for diagnostic strings/messages, may contain nullability annotation).
+        /// <param name="DiagType">
+        /// A shorter type name (without <c>global::</c> qualifier) for diagnostic strings/messages, may contain nullability annotation).
         /// </param>
         /// <param name="EmitImplicitCast">
         /// <see langword="true"/> if the implicit cast from option to variant should be emitted for this type.
         /// </param>
-        /// <param name="Hint">
+        /// <param name="Identifier">
         /// The user-provided parameter name in <c>VariantOf</c>.
         /// </param>
         /// <param name="Index">
@@ -126,9 +130,6 @@ namespace dotVariant.Generator
         /// </param>
         /// <param name="IsDisposable">
         /// <see langword="true"/> if this type implements <see cref="IDisposable"/>.
-        /// </param>
-        /// <param name="Name">
-        /// The fully qualified name of the type. Never contains a nullability annotation.
         /// </param>
         /// <param name="Nullability">
         /// <c>"nonnull"</c> or <c>"nullable"</c>. Determines whether the parameter was originally annotated as nullable or null oblivious versus not nullable.
@@ -141,17 +142,20 @@ namespace dotVariant.Generator
         /// <param name="ToStringNullability">
         /// <c>"nonnull"</c> or <c>"nullable"</c> annotation of the parameters's <see cref="object.ToString()"/> return type.
         /// </param>
+        /// <param name="Type">
+        /// The fully qualified name of the type including type parameter list, without nullability annotation.
+        /// </param>
         public sealed record ParamInfo(
-            string DiagName,
+            string DiagType,
             bool EmitImplicitCast,
-            string Hint,
+            string Identifier,
             int Index,
             bool IsClass,
             bool IsDisposable,
-            string Name,
             string Nullability,
             int ObjectPadding,
-            string ToStringNullability);
+            string ToStringNullability,
+            string Type);
 
         public static RenderInfo FromDescriptor(
             Descriptor desc,
@@ -166,16 +170,16 @@ namespace dotVariant.Generator
                 desc
                 .Options
                 .Select((p, i) => new ParamInfo(
-                    Name: p.Type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                    DiagName: p.Type.ToDisplayString(),
-                    Hint: p.Name,
+                    DiagType: p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", ""),
+                    Identifier: p.Name,
                     ObjectPadding: maxObjects - NumReferenceFields(p),
                     Index: i + 1,
                     IsClass: p.Type.IsReferenceType,
                     IsDisposable: IsDisposable(p.Type, compilation),
                     Nullability: p.Type.NullableAnnotation == NullableAnnotation.NotAnnotated ? "nonnull" : "nullable",
                     EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type)),
-                    ToStringNullability: IsToStringNullable(p.Type) ? "nullable" : "nonnull"));
+                    ToStringNullability: IsToStringNullable(p.Type) ? "nullable" : "nonnull",
+                    Type: p.Type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
 
             var typeNamespace = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
 
@@ -191,15 +195,16 @@ namespace dotVariant.Generator
                     HasSystemReactiveLinq: HasReactive(compilation)),
                 Variant: new(
                     Accessibility: VariantAccessibility(type),
-                    DiagName: type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                    DiagType: type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
                     ExtensionsAccessibility: ExtensionsAccessibility(type),
-                    FullName: type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    Identifier: type.Name,
                     IsClass: type.IsReferenceType,
                     IsReadonly: IsReadonly(type, token),
                     Keyword: desc.Syntax.Keyword.Text,
                     Namespace: typeNamespace,
-                    Name: type.Name,
                     Nullability: type.IsReferenceType ? "nullable" : "nonnull",
+                    QualifiedType: type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    Type: type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat).Replace("global::", ""),
                     UserDefined: new(
                         // If the user defined any method named Dispose() bail out. Too risky!
                         Dispose: ImplementsDispose(type, compilation) || HasAnyDisposeMethod(type))));

--- a/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
@@ -15,29 +15,29 @@ end
 namespace {{ Options.ExtensionClassNamespace }}
 {
 {{~ end ~}}
-    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
+    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Identifier }}_Ex
     {
         {{~ ## Match(IEnumerable<V>, Func<A, R>) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ cref $p.Name }}"/> and dropping all others.
+        /// Transform a {{ Variant.Identifier }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ cref $p.Type }}"/> and dropping all others.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }})
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }})
         {
             foreach (var variant in source)
             {
                 if ({{ $get_n }} == {{ $p.Index }})
                 {
-                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                    yield return {{ $p.Identifier }}({{ $get_value $p }});
                 }
             }
         }
@@ -46,26 +46,26 @@ namespace {{ Options.ExtensionClassNamespace }}
         {{~ ## Match(IEnumerable<V>, Func<A, R>, R) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ cref $p.Name }}"/> and replacing all others by a fallback value.
+        /// Transform a {{ Variant.Identifier }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ cref $p.Type }}"/> and replacing all others by a fallback value.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }},
                 TResult _)
         {
             foreach (var variant in source)
             {
                 if ({{ $get_n }} == {{ $p.Index }})
                 {
-                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                    yield return {{ $p.Identifier }}({{ $get_value $p }});
                 }
                 else
                 {
@@ -78,26 +78,26 @@ namespace {{ Options.ExtensionClassNamespace }}
         {{~ ## Match(IEnumerable<V>, Func<A, R>, Func<R>) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="{{ cref $p.Name }}"/> and replacing all others with the result of a fallback selector.
+        /// Transform a {{ Variant.Identifier }}-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="{{ cref $p.Type }}"/> and replacing all others with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Match<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }},
                 global::System.Func<TResult> _)
         {
             foreach (var variant in source)
             {
                 if ({{ $get_n }} == {{ $p.Index }})
                 {
-                    yield return {{ $p.Hint }}({{ $get_value $p }});
+                    yield return {{ $p.Identifier }}({{ $get_value $p }});
                 }
                 else
                 {
@@ -109,21 +109,21 @@ namespace {{ Options.ExtensionClassNamespace }}
 
         {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ...) ## ~}}
         /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// Transform a {{ Variant.Identifier }}-based enumerable sequence by applying a selector function to each element
         /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException"/>
         /// if an element is empty.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+        /// <param name="{{ $p.Identifier }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Type }}"/>.</param>
         {{~ end ~}}
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
-        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty {{ Variant.Name }}.</exception>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty {{ Variant.Identifier }}.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.QualifiedType }}> source,
                 {{ func_params }})
         {
             foreach (var variant in source)
@@ -135,7 +135,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         yield break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        yield return {{ $p.Hint }}({{ $get_value $p }});
+                        yield return {{ $p.Identifier }}({{ $get_value $p }});
                         break;
                     {{~ end ~}}
                     default:
@@ -147,12 +147,12 @@ namespace {{ Options.ExtensionClassNamespace }}
 
         {{~ ## Visit(IEnumerable<V>, Func<A, R>, Func<B, R>, ..., empty) ## ~}}
         /// <summary>
-        /// Transform a {{ Variant.Name }}-based enumerable sequence by applying a selector function to each element
+        /// Transform a {{ Variant.Identifier }}-based enumerable sequence by applying a selector function to each element
         /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+        /// <param name="{{ $p.Identifier }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Type }}"/>.</param>
         {{~ end ~}}
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
@@ -160,7 +160,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.Collections.Generic.IEnumerable<TResult>
             Visit<TResult>(
-                this global::System.Collections.Generic.IEnumerable<{{ Variant.FullName }}> source,
+                this global::System.Collections.Generic.IEnumerable<{{ Variant.QualifiedType }}> source,
                 {{ func_params }},
                 global::System.Func<TResult> _)
         {
@@ -173,7 +173,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        yield return {{ $p.Hint }}({{ $get_value $p }});
+                        yield return {{ $p.Identifier }}({{ $get_value $p }});
                         break;
                     {{~ end ~}}
                     default:

--- a/src/dotVariant.Generator/templates/IObservable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IObservable.scriban-cs
@@ -7,51 +7,51 @@
 namespace {{ Options.ExtensionClassNamespace }}
 {
 {{~ end ~}}
-    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Name }}_Ex
+    {{ Variant.ExtensionsAccessibility }} static partial class _{{ Variant.Identifier }}_Ex
     {
         {{~ ## Match(IObservable<V>, Func<A, R>) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Projects each <see cref="{{ $p.Name }}"/> element of an observable sequence
+        /// Projects each <see cref="{{ $p.Type }}"/> element of an observable sequence
         /// into a new form and drops all other elements.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }})
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }})
         {
             return global::System.Reactive.Linq.Observable.Select(
                 global::System.Reactive.Linq.Observable.Where(source, _variant => {{ get_n }} == {{ $p.Index }}),
-                _variant => {{ $p.Hint }}({{ get_value $p }}));
+                _variant => {{ $p.Identifier }}({{ get_value $p }}));
         }
         {{~ end ~}}
 
         {{~ ## Match(IObservable<V>, Func<A, R>, R) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Projects each <see cref="{{ cref $p.Name }}"/> element of an observable sequence
+        /// Projects each <see cref="{{ cref $p.Type }}"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback value.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }},
                 TResult _)
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if ({{ get_n }} == {{ $p.Index }})
                 {
-                    return {{ $p.Hint }}({{ get_value $p }});
+                    return {{ $p.Identifier }}({{ get_value $p }});
                 }
                 else
                 {
@@ -64,25 +64,25 @@ namespace {{ Options.ExtensionClassNamespace }}
         {{~ ## Match(IObservable<V>, Func<A, R>, Func<R>) ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Projects each <see cref="{{ cref $p.Name }}"/> element of an observable sequence
+        /// Projects each <see cref="{{ cref $p.Type }}"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback selector result.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
-        /// <param name="{{ $p.Hint }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="{{ $p.Identifier }}">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
         /// <param name="_">Value to produce for elements which do not match the desired type.</param>
         /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Match<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
-                {{ func_type $p }} {{ $p.Hint }},
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
+                {{ func_type $p }} {{ $p.Identifier }},
                 global::System.Func<TResult> _)
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
             {
                 if ({{ get_n }} == {{ $p.Index }})
                 {
-                    return {{ $p.Hint }}({{ get_value $p }});
+                    return {{ $p.Identifier }}({{ get_value $p }});
                 }
                 else
                 {
@@ -99,13 +99,13 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// </summary>
         /// <param name="source">An observable sequence whose elements to visit.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+        /// <param name="{{ $p.Identifier }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Type }}"/>.</param>
         {{~ end ~}}
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Visit<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
                 {{ func_params }})
         {
             return global::System.Reactive.Linq.Observable.Select(source, _variant =>
@@ -116,7 +116,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         return {{ throw_empty_error "TResult" }};
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ get_value $p }});
+                        return {{ $p.Identifier }}({{ get_value $p }});
                     {{~ end ~}}
                     default:
                         return {{ throw_internal_error "TResult" }};
@@ -131,14 +131,14 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// </summary>
         /// <param name="source">An observable sequence whose elements to visit.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+        /// <param name="{{ $p.Identifier }}">The delegate to invoke if the element's value is of type <see cref="{{ cref $p.Type }}"/>.</param>
         {{~ end ~}}
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             Visit<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
                 {{ func_params }},
                 global::System.Func<TResult> _)
         {
@@ -150,7 +150,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                         return _();
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ get_value $p }});
+                        return {{ $p.Identifier }}({{ get_value $p }});
                     {{~ end ~}}
                     default:
                         return {{ throw_internal_error "TResult" }};
@@ -161,7 +161,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         {{~ ## VisitMany(IObservable<V>, Func<IObservable<A>, IObservable<R>>, Func<IObservable<B>, IObservable<R>>, ...) ## ~}}
         {{~ if Params.size > 1 # Otherwise signature conflicts with the generic version below, and they are identical ~}}
         /// <summary>
-        /// Splits the observable sequence of {{ Variant.Name }} elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of {{ Variant.Identifier }} elements into one independent sub-sequences per value type,
         /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence,
         /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
         /// </summary>
@@ -176,25 +176,25 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// </remarks>
         /// <param name="source">An observable sequence whose elements to split into sub-sequences.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">Transform an observable sequence of <see cref="{{ cref $p.Name }}"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="{{ $p.Identifier }}">Transform an observable sequence of <see cref="{{ cref $p.Type }}"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         {{~ end ~}}
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
-                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Hint; end) | array.join ", " }})
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
+                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }})
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}) =>
             {
-                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }});
+                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Identifier + "(_" + $0.Index + ")"; end) | array.join ", " }});
             });
         }
         {{~ end ~}}
 
         {{~ ## VisitMany(IObservable<V>, Func<IObservable<A>, IObservable<R>>, Func<IObservable<B>, IObservable<R>>, ..., Func<IObservable<Unit>, IObservable<R>> empty) ## ~}}
         /// <summary>
-        /// Splits the observable sequence of {{ Variant.Name }} elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of {{ Variant.Identifier }} elements into one independent sub-sequences per value type,
         /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence.
         /// </summary>
         /// <remarks>
@@ -208,26 +208,26 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// </remarks>
         /// <param name="source">An observable sequence whose elements to split into sub-sequences.</param>
         {{~ for $p in Params ~}}
-        /// <param name="{{ $p.Hint }}">Transform an observable sequence of <see cref="{{ cref $p.Name }}"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="{{ $p.Identifier }}">Transform an observable sequence of <see cref="{{ cref $p.Type }}"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         {{~ end ~}}
         /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
-                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Hint; end) | array.join ", " }},
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
+                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }},
                 global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}, _0) =>
             {
-                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Hint + "(_" + $0.Index + ")"; end) | array.join ", " }}, _(_0));
+                return global::System.Reactive.Linq.Observable.Merge({{ Params | array.each @(do; ret $0.Identifier + "(_" + $0.Index + ")"; end) | array.join ", " }}, _(_0));
             });
         }
 
         {{~ ## VisitMany(IObservable<V>, Func<IObservable<A>, IObservable<B>, ..., IObservable<M>>) ## ~}}
         /// <summary>
-        /// Splits the observable sequence of {{ Variant.Name }} elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of {{ Variant.Identifier }} elements into one independent sub-sequences per value type,
         /// and combines the resulting values into one observable sequence according to the combining selector,
         /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
         /// </summary>
@@ -246,7 +246,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
                 global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<TResult>> selector)
         {
             return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
@@ -261,7 +261,7 @@ namespace {{ Options.ExtensionClassNamespace }}
 
         {{~ ## VisitMany(IObservable<V>, Func<IObservable<A>, IObservable<B>, ..., IObservable<Unit>, IObservable<M>>) ## ~}}
         /// <summary>
-        /// Splits the observable sequence of {{ Variant.Name }} elements into one independent sub-sequences per value type,
+        /// Splits the observable sequence of {{ Variant.Identifier }} elements into one independent sub-sequences per value type,
         /// and combines the resulting values into one observable sequence according to the combining selector.
         /// </summary>
         /// <remarks>
@@ -278,7 +278,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
-                this global::System.IObservable<{{ Variant.FullName }}> source,
+                this global::System.IObservable<{{ Variant.QualifiedType }}> source,
                 global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
             return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
@@ -291,7 +291,7 @@ namespace {{ Options.ExtensionClassNamespace }}
             });
         }
 
-        private sealed class VisitManyObserver : global::System.IObserver<{{ Variant.FullName }}>, global::System.IDisposable
+        private sealed class VisitManyObserver : global::System.IObserver<{{ Variant.QualifiedType }}>, global::System.IDisposable
         {
             public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
             {{~ for $p in Params ~}}
@@ -312,7 +312,7 @@ namespace {{ Options.ExtensionClassNamespace }}
                 Subject0.Dispose();
             }
 
-            public void OnNext({{ Variant.FullName }} _variant)
+            public void OnNext({{ Variant.QualifiedType }} _variant)
             {
                 switch ({{ get_n }})
                 {

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -123,7 +123,7 @@ end
 namespace {{ Variant.Namespace }}
 {
 {{~ end ~}}
-    partial {{ Variant.Keyword }} {{ Variant.Name }}
+    partial {{ Variant.Keyword }} {{ Variant.Type }}
     {
         [global::System.Diagnostics.DebuggerNonUserCode]
         [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
@@ -179,10 +179,10 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## STORAGE CONSTRUCTORS ## ~}}
             {{~ for $p in Params ~}}
-            public __VariantImpl({{ value_type $p }} {{ $p.Hint }})
+            public __VariantImpl({{ value_type $p }} {{ $p.Identifier }})
             {
                 _n = {{ $p.Index }};
-                _x = new Union({{ $p.Hint }});
+                _x = new Union({{ $p.Identifier }});
             }
             {{~ end ~}}
 
@@ -220,12 +220,12 @@ namespace {{ Variant.Namespace }}
             {{~ end ~}}
 
             /// <summary>
-            /// <see langword="true"/> if {{ Variant.Name }} was constructed without a value.
+            /// <see langword="true"/> if {{ Variant.Identifier }} was constructed without a value.
             /// </summary>
             {{~ if !Variant.IsClass ~}}
             /// <remarks>
-            /// Because {{ Variant.Name }} is a value type, its default constructor cannot be disabled.
-            /// A default-constructed {{ Variant.Name }} will always have a <c>IsEmpty</c> value of <see langword="true"/>
+            /// Because {{ Variant.Identifier }} is a value type, its default constructor cannot be disabled.
+            /// A default-constructed {{ Variant.Identifier }} will always have a <c>IsEmpty</c> value of <see langword="true"/>
             /// and never satisfy any matching attempts except for the wildcard <c>_</c> parameter.
             /// </remarks>
             {{~ end ~}}
@@ -244,7 +244,7 @@ namespace {{ Variant.Namespace }}
                             return "<empty>";
                         {{~ for $p in Params ~}}
                         case {{ $p.Index }}:
-                            return "{{ $p.DiagName }}";
+                            return "{{ $p.DiagType }}";
                         {{~ end ~}}
                         default:
                             return {{ throw_internal_error "string" }};
@@ -304,7 +304,7 @@ namespace {{ Variant.Namespace }}
                     {{~ for $p in Params ~}}
                     {{~ $i = $p.Index ~}}
                     case {{ $i }}:
-                        return global::System.Collections.Generic.EqualityComparer<{{ $p.Name }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
+                        return global::System.Collections.Generic.EqualityComparer<{{ $p.Type }}>.Default.Equals({{ $storage $p }}, other.{{ $storage $p }});
                     {{~ end ~}}
                     default:
                         return {{ throw_internal_error "bool" }};
@@ -334,27 +334,27 @@ namespace {{ Variant.Namespace }}
             {{~ for $p in Params ~}}
             {{~ ## UNION TryMatch ## ~}}
             /// <summary>
-            /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
+            /// Retrieve the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/>.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-            /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
-            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
+            /// <param name="{{ $p.Identifier }}">Receives the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
+            /// <returns><see langword="true"/> if {{ Variant.Identifier }} contained a value of type <see cref="{{ cref $p.Type }}"/>.</returns>
+            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Identifier }})
             {
-                {{ $p.Hint }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
+                {{ $p.Identifier }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
                 return _n == {{ $p.Index }};
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>.
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/>.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-            /// <returns><see langword="true"/> if {{ Variant.Name }} contained a value of type <see cref="{{ cref $p.Name }}"/>.</returns>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"> is rethrown.</exception>
-            public bool TryMatch({{ action_type $p }} {{ $p.Hint }})
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
+            /// <returns><see langword="true"/> if {{ Variant.Identifier }} contained a value of type <see cref="{{ cref $p.Type }}"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"> is rethrown.</exception>
+            public bool TryMatch({{ action_type $p }} {{ $p.Identifier }})
             {
                 if (_n == {{ $p.Index }})
                 {
-                    {{ $p.Hint }}({{ $storage $p }});
+                    {{ $p.Identifier }}({{ $storage $p }});
                     return true;
                 }
                 return false;
@@ -362,50 +362,50 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## UNION Match ## ~}}
             /// <summary>
-            /// Retrieve the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// Retrieve the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/>,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">Receives the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/>.</exception>
-            public void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
+            /// <param name="{{ $p.Identifier }}">Receives the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} does not contain a value of type <see cref="{{ cref $p.Type }}"/>.</exception>
+            public void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Identifier }})
             {
                 if (_n == {{ $p.Index }})
                 {
-                    {{ $p.Hint }} = {{ $storage $p }};
+                    {{ $p.Identifier }} = {{ $storage $p }};
                     return;
                 }
-                throw {{ make_mismatch_error $p.DiagName "{TypeString}" }};
+                throw {{ make_mismatch_error $p.DiagType "{TypeString}" }};
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/>,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/>.</exception>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"/> is rethrown.</exception>
-            public void Match({{ action_type $p }} {{ $p.Hint }})
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} does not contain a value of type <see cref="{{ cref $p.Type }}"/>.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"/> is rethrown.</exception>
+            public void Match({{ action_type $p }} {{ $p.Identifier }})
             {
                 if (_n == {{ $p.Index }})
                 {
-                    {{ $p.Hint }}({{ $storage $p }});
+                    {{ $p.Identifier }}({{ $storage $p }});
                     return;
                 }
-                {{ throw_mismatch_error $p.DiagName "{TypeString}" }};
+                {{ throw_mismatch_error $p.DiagType "{TypeString}" }};
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/>,
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/>,
             /// otherwise invoke an alternative delegate.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
             /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"/> or <paramref name="_"/> is rethrown.</exception>
-            public void Match({{ action_type $p }} {{ $p.Hint }}, global::System.Action _)
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"/> or <paramref name="_"/> is rethrown.</exception>
+            public void Match({{ action_type $p }} {{ $p.Identifier }}, global::System.Action _)
             {
                 if (_n == {{ $p.Index }})
                 {
-                    {{ $p.Hint }}({{ $storage $p }});
+                    {{ $p.Identifier }}({{ $storage $p }});
                 }
                 else
                 {
@@ -414,57 +414,57 @@ namespace {{ Variant.Namespace }}
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/> and return the result,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
-            /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>.</returns>
-            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} does not contain a value of type <see cref="{{ cref $p.Name }}"/>.</exception>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"/> is rethrown.</exception>
-            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }})
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
+            /// <returns>The value returned from invoking <paramref name="{{ $p.Identifier }}"/>.</returns>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} does not contain a value of type <see cref="{{ cref $p.Type }}"/>.</exception>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"/> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }})
             {
                 if (_n == {{ $p.Index }})
                 {
-                    return {{ $p.Hint }}({{ $storage $p }});
+                    return {{ $p.Identifier }}({{ $storage $p }});
                 }
-                return {{ throw_mismatch_error $p.DiagName "{TypeString}" "TResult" }};
+                return {{ throw_mismatch_error $p.DiagType "{TypeString}" "TResult" }};
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/> and return the result,
             /// otherwise return a provided value.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
             /// <param name="_">The value to return if the stored value is of a different type.</param>
-            /// <returns>The value returned from invoking <paramref name="{{ $p.Hint }}"/>, or <paramref name="default"/>.</returns>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"/> or <paramref name="other"/> is rethrown.</exception>
-            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, TResult _)
+            /// <returns>The value returned from invoking <paramref name="{{ $p.Identifier }}"/>, or <paramref name="default"/>.</returns>
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"/> or <paramref name="other"/> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }}, TResult _)
             {
-                return _n == {{ $p.Index }} ? {{ $p.Hint }}({{ $storage $p }}) : _;
+                return _n == {{ $p.Index }} ? {{ $p.Identifier }}({{ $storage $p }}) : _;
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within {{ Variant.Name }} if it is of type <see cref="{{ cref $p.Name }}"/> and return the result,
+            /// Invoke a delegate with the value stored within {{ Variant.Identifier }} if it is of type <see cref="{{ cref $p.Type }}"/> and return the result,
             /// otherwise invoke an alternative delegate and return its result.
             /// </summary>
-            /// <param name="{{ $p.Hint }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke with the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
             /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
-            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Hint }}"/> or <paramref name="_"/> is rethrown.</exception>
-            public TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, global::System.Func<TResult> _)
+            /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="{{ $p.Identifier }}"/> or <paramref name="_"/> is rethrown.</exception>
+            public TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }}, global::System.Func<TResult> _)
             {
-                return _n == {{ $p.Index }} ? {{ $p.Hint }}({{ $storage $p }}) : _();
+                return _n == {{ $p.Index }} ? {{ $p.Identifier }}({{ $storage $p }}) : _();
             }
             {{~ end ~}}
 
             {{~ ## UNION Visit(Action) ## ~}}
             /// <summary>
-            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }},
-            /// and invoke a special delegate if {{ Variant.Name }} is empty.
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Identifier }},
+            /// and invoke a special delegate if {{ Variant.Identifier }} is empty.
             /// </summary>
             {{~ for $p in Params ~}}
-            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Type }}"/>.</param>
             {{~ end ~}}
-            /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
+            /// <param name="_">The delegate to invoke if {{ Variant.Identifier }} is empty.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             public void Visit({{ action_params }}, global::System.Action _)
             {
@@ -475,7 +475,7 @@ namespace {{ Variant.Namespace }}
                         break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        {{ $p.Hint }}({{ $storage $p }});
+                        {{ $p.Identifier }}({{ $storage $p }});
                         break;
                     {{~ end ~}}
                     default:
@@ -486,13 +486,13 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## UNION Visit(Action) ## ~}}
             /// <summary>
-            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }},
-            /// and throw an exception if {{ Variant.Name }} is empty.
+            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Identifier }},
+            /// and throw an exception if {{ Variant.Identifier }} is empty.
             /// </summary>
             {{~ for $p in Params ~}}
-            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Type }}"/>.</param>
             {{~ end ~}}
-            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} is empty.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             public void Visit({{ action_params }})
             {
@@ -503,7 +503,7 @@ namespace {{ Variant.Namespace }}
                         break;
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        {{ $p.Hint }}({{ $storage $p }});
+                        {{ $p.Identifier }}({{ $storage $p }});
                         break;
                     {{~ end ~}}
                     default:
@@ -514,13 +514,13 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## UNION Visit(Func) ## ~}}
             /// <summary>
-            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Name }} and return the result,
-            /// and invoke a special delegate if {{ Variant.Name }} is empty and return its result.
+            /// Invoke the delegate whose parameter type matches that of type of the value stored within {{ Variant.Identifier }} and return the result,
+            /// and invoke a special delegate if {{ Variant.Identifier }} is empty and return its result.
             /// </summary>
             {{~ for $p in Params ~}}
-            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Type }}"/>.</param>
             {{~ end ~}}
-            /// <param name="_">The delegate to invoke if {{ Variant.Name }} is empty.</param>
+            /// <param name="_">The delegate to invoke if {{ Variant.Identifier }} is empty.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
             public TResult Visit<TResult>({{ func_params }}, global::System.Func<TResult> _)
@@ -531,7 +531,7 @@ namespace {{ Variant.Namespace }}
                         return _();
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ $storage $p }});
+                        return {{ $p.Identifier }}({{ $storage $p }});
                     {{~ end ~}}
                     default:
                         return {{ throw_internal_error "TResult" }};
@@ -540,13 +540,13 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## UNION Visit(Func) ## ~}}
             /// <summary>
-            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Name }} and return the result,
-            /// and throw an exception if {{ Variant.Name }} is empty.
+            /// Invoke the delegate whose parameter type matches that of the value stored within {{ Variant.Identifier }} and return the result,
+            /// and throw an exception if {{ Variant.Identifier }} is empty.
             /// </summary>
             {{~ for $p in Params ~}}
-            /// <param name="{{ $p.Hint }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Name }}"/>.</param>
+            /// <param name="{{ $p.Identifier }}">The delegate to invoke if the stored value is of type <see cref="{{ cref $p.Type }}"/>.</param>
             {{~ end ~}}
-            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Name }} is empty.</exception>
+            /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} is empty.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
             public TResult Visit<TResult>({{ func_params }})
@@ -557,7 +557,7 @@ namespace {{ Variant.Namespace }}
                         return {{ throw_empty_error "TResult" }};
                     {{~ for $p in Params ~}}
                     case {{ $p.Index }}:
-                        return {{ $p.Hint }}({{ $storage $p }});
+                        return {{ $p.Identifier }}({{ $storage $p }});
                     {{~ end ~}}
                     default:
                         return {{ throw_internal_error "TResult" }};

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -21,8 +21,8 @@ namespace {{ Variant.Namespace }}
 {{~ end ~}}
     [global::System.Diagnostics.DebuggerTypeProxy(typeof(_VariantTypeProxy))]
     [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
-    partial {{ Variant.Keyword }} {{ Variant.Name }}
-        : global::System.IEquatable<{{ Variant.Name }}>
+    partial {{ Variant.Keyword }} {{ Variant.Type }}
+        : global::System.IEquatable<{{ Variant.Type }}>
         {{~ if needs_dispose ~}}
         , global::System.IDisposable
         {{~ end ~}}
@@ -32,36 +32,36 @@ namespace {{ Variant.Namespace }}
         {{~ ## VARIANT CONSTRUCTORS ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
+        /// Create a {{ Variant.Identifier }} with a value of type <see cref="{{ cref $p.Type }}"/>.
         /// </summary>
-        /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
-            => _variant = new {{ storage_type }}({{ $p.Hint }});
+        public {{ Variant.Identifier }}({{ value_type $p }} {{ $p.Identifier }})
+            => _variant = new {{ storage_type }}({{ $p.Identifier }});
         {{~ end ~}}
 
         {{~ ## IMPLICIT CONVERSIONS ## ~}}
         {{~ for $p in Params ~}}
         {{~ if $p.EmitImplicitCast ~}}
         /// <summary>
-        /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
+        /// Create a {{ Variant.Identifier }} with a value of type <see cref="{{ cref $p.Type }}"/>.
         /// </summary>
-        /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static implicit operator {{ Variant.Name }}({{ value_type $p }} {{ $p.Hint }})
-            => new {{ Variant.Name }}({{ $p.Hint }});
+        public static implicit operator {{ Variant.Type }}({{ value_type $p }} {{ $p.Identifier }})
+            => new {{ Variant.Identifier }}({{ $p.Identifier }});
         {{~ end ~}}
         {{~ end ~}}
 
         {{~ ## STATIC CREATE FACTORIES ## ~}}
         {{~ for $p in Params ~}}
         /// <summary>
-        /// Create a {{ Variant.Name }} with a value of type <see cref="{{ cref $p.Name }}"/>.
+        /// Create a {{ Variant.Identifier }} with a value of type <see cref="{{ cref $p.Type }}"/>.
         /// </summary>
-        /// <param name="{{ $p.Hint }}">The value to initlaize the variant with.</param>
+        /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static {{ Variant.Name }} Create({{ value_type $p }} {{ $p.Hint }})
-            => new {{ Variant.Name }}({{ $p.Hint }});
+        public static {{ Variant.Type }} Create({{ value_type $p }} {{ $p.Identifier }})
+            => new {{ Variant.Identifier }}({{ $p.Identifier }});
         {{~ end ~}}
 
         {{~ ## DISPOSE ## ~}}
@@ -84,7 +84,7 @@ namespace {{ Variant.Namespace }}
         /// <inheritdoc/>
         [global::System.Diagnostics.DebuggerNonUserCode]
         public {{ method_modifiers }}override bool Equals(object{{ global_nullable }} other)
-            => other is {{ Variant.Name }} v && Equals(v);
+            => other is {{ Variant.Type }} v && Equals(v);
 
         /// <inheritdoc/>
         [global::System.Diagnostics.DebuggerNonUserCode]
@@ -113,44 +113,44 @@ namespace {{ Variant.Namespace }}
         {{~ ## VARIANT TryMatch ## ~}}
         /// <inheritdoc cref="{{ cref storage_type }}.TryMatch(out {{ cref (outref_type $p) }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Hint }})
-            => _variant.TryMatch(out {{ $p.Hint }});
+        public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+            => _variant.TryMatch(out {{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.TryMatch({{ cref (action_type $p) }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}bool TryMatch({{ action_type $p }} {{ $p.Hint }})
-            => _variant.TryMatch({{ $p.Hint }});
+        public {{ method_modifiers }}bool TryMatch({{ action_type $p }} {{ $p.Identifier }})
+            => _variant.TryMatch({{ $p.Identifier }});
 
         {{~ ## VARIANT Match ## ~}}
         /// <inheritdoc cref="{{ cref storage_type }}.Match(out {{ cref (outref_type $p) }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Hint }})
-            => _variant.Match(out {{ $p.Hint }});
+        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+            => _variant.Match(out {{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match({{ cref (action_type $p) }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }})
-            => _variant.Match({{ $p.Hint }});
+        public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Identifier }})
+            => _variant.Match({{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match({{ cref (action_type $p) }}, global::System.Action)"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Hint }}, global::System.Action _)
-            => _variant.Match({{ $p.Hint }}, _);
+        public {{ method_modifiers }}void Match({{ action_type $p }} {{ $p.Identifier }}, global::System.Action _)
+            => _variant.Match({{ $p.Identifier }}, _);
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }})
-            => _variant.Match({{ $p.Hint }});
+        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }})
+            => _variant.Match({{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }}, TResult)"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, TResult _)
-            => _variant.Match({{ $p.Hint }}, _);
+        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }}, TResult _)
+            => _variant.Match({{ $p.Identifier }}, _);
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match{TResult}({{ cref (func_type $p) }}, global::System.Func{TResult})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Hint }}, global::System.Func<TResult> _)
-            => _variant.Match({{ $p.Hint }}, _);
+        public {{ method_modifiers }}TResult Match<TResult>({{ func_type $p }} {{ $p.Identifier }}, global::System.Func<TResult> _)
+            => _variant.Match({{ $p.Identifier }}, _);
 
         {{~ end ~}}
 
@@ -178,7 +178,7 @@ namespace {{ Variant.Namespace }}
         private sealed class _VariantTypeProxy
         {
             public object{{ global_nullable }} Value { get; }
-            public _VariantTypeProxy({{ Variant.Name }} v)
+            public _VariantTypeProxy({{ Variant.Type }} v)
             {
                 Value = v._variant.AsObject;
                 {{~ # Force a reference to the VariantOf function so the user doesn't get IDE0051 "Private member 'VariantOf' is unused." ~}}
@@ -189,12 +189,12 @@ namespace {{ Variant.Namespace }}
         {{~ ## INTERNAL ACCESS ## ~}}
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static explicit operator {{ discriminator }}({{ Variant.Name }} v)
+        public static explicit operator {{ discriminator }}({{ Variant.Type }} v)
             => ({{ discriminator }})v._variant;
         {{~ for $p in Params ~}}
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static explicit operator {{ accessor $p.Index (value_type $p) }}({{ Variant.Name }} v)
+        public static explicit operator {{ accessor $p.Index (value_type $p) }}({{ Variant.Type }} v)
             => ({{ accessor $p.Index (value_type $p) }})v._variant;
         {{~ end ~}}
     }

--- a/src/dotVariant.Generator/templates/globals.scriban-cs
+++ b/src/dotVariant.Generator/templates/globals.scriban-cs
@@ -19,7 +19,7 @@ readonly emit_nullability
 # Works with both "Params" and "Variant"
 func value_type(type, name = null)
     if (name == null)
-        name = type.Name
+        name = type.Type
     end
     if type.IsClass
         ret emit_nullability && type.Nullability == "nullable" ? (name + "?" ): name
@@ -33,7 +33,7 @@ readonly value_type
 # Works with both "Params" and "Variant"
 func outref_type(type, name = null)
     if (name == null)
-        name = type.Name
+        name = type.Type
     end
     if type.IsClass
         ret emit_nullability ? (name + "?") : name
@@ -108,36 +108,35 @@ end
 readonly annotate_NotNull
 
 func throw_mismatch_error(expected, actual, type = "")
-    ret "global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError" + (type == "" ? "" : "<" + type + ">") + "(" + ([Variant.DiagName, expected, actual] | array.join ", " @string.literal) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError" + (type == "" ? "" : "<" + type + ">") + "(" + ([Variant.DiagType, expected, actual] | array.join ", " @string.literal) + ")"
 end
 readonly throw_mismatch_error
 
 func throw_internal_error(type = "")
-    ret "global::dotVariant.GeneratorSupport.Errors.ThrowInternalError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagName) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowInternalError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagType) + ")"
 end
 readonly throw_internal_error
 
 func throw_empty_error(type = "")
-    ret "global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagName) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError" + (type == "" ? "" : "<" + type + ">") + "(" + (string.literal Variant.DiagType) + ")"
 end
 readonly throw_empty_error_error
 
 func make_mismatch_error(expected, actual)
-    ret "global::dotVariant.GeneratorSupport.Errors.MakeMismatchError(" + ([Variant.DiagName, expected, actual] | array.join ", " @string.literal) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeMismatchError(" + ([Variant.DiagType, expected, actual] | array.join ", " @string.literal) + ")"
 end
 readonly make_mismatch_error
 
 func make_internal_error()
-    ret "global::dotVariant.GeneratorSupport.Errors.MakeInternalError(" + (string.literal Variant.DiagName) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeInternalError(" + (string.literal Variant.DiagType) + ")"
 end
 readonly make_internal_error
 
 func make_empty_error()
-    ret "global::dotVariant.GeneratorSupport.Errors.MakeEmptyError(" + (string.literal Variant.DiagName) + ")"
+    ret "global::dotVariant.GeneratorSupport.Errors.MakeEmptyError(" + (string.literal Variant.DiagType) + ")"
 end
 readonly make_empty_error_error
 
-#storage_type = "global::dotVariant._G." + (Variant.Namespace ? (Variant.Namespace + ".") : "") + Variant.Name
 storage_type = "__VariantImpl"
 readonly storage_type
 
@@ -162,15 +161,15 @@ end
 readonly accessor
 
 func_types = Params | array.each @(do; ret func_type $0; end) | array.join ", "
-func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Hint; end) | array.join ", "
+func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Identifier; end) | array.join ", "
 action_types = Params | array.each @(do; ret action_type $0; end) | array.join ", "
-action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Hint; end) | array.join ", "
+action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Identifier; end) | array.join ", "
 method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : ""
 param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
 global_nullable = emit_nullability ? "?" : ""
 global_forgive = emit_nullability ? "!" : ""
 needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0
-forward_params = Params | array.each @(do; ret $0.Hint; end) | array.join ", "
+forward_params = Params | array.each @(do; ret $0.Identifier; end) | array.join ", "
 discriminator = "global::dotVariant.GeneratorSupport.Discriminator"
 
 readonly func_types


### PR DESCRIPTION
Within the `RenderInfo` type and the Scriban scripts, be more thorough
about the distinction of identifiers and type names. This will become
especially important when dealing with generic types.

Given the following definition:

```cs
using System;
namespace Foo
{
  [dotVariant.Variant]
  partial class Variant<T>
  {
    static partial void VariantOf(Action<TimeSpan> a, Action<T> b, T c);
  }
}
```

you get:
- `VariantInfo`:
  - Identifier: `Variant`
  - Type: `Variant<T>`
  - QualifiedType: `global::Foo.Variant<T>`
  - DiagType: `Foo.Variant<T>`

- `ParamInfo[0]`:
  - Identifier: `a`
  - Type: `global::System.Action<global::System.TimeSpan>`
  - DiagType: `System.Action<System.TimeSpan>`

- `ParamInfo[1]`:
  - Identifier: `b`
  - Type: `global::System.Action<T>`
  - DiagType: `System.Action<T>`

- `ParamInfo[2]`:
  - Identifier: `c`
  - Type: `T`
  - DiagType: `T`

The `Type` property is fully qualified because we have no use for
unqualified parameter types.