### PR TITLE
Rework handling of nullability

### DIFF
--- a/src/dotVariant.Generator.Test/GeneratorTools.cs
+++ b/src/dotVariant.Generator.Test/GeneratorTools.cs
@@ -60,7 +60,8 @@ namespace dotVariant.Generator.Test
             where TGenerator : ISourceGenerator, new()
             => GetGeneratorDiagnostics(sources, () => new TGenerator());
 
-        public static CSharpCompilation Compile(IDictionary<string, string> sources)
+        public static CSharpCompilation Compile(
+            IDictionary<string, string> sources)
             => CSharpCompilation.Create(
                 "test",
                 sources.Select(s => CSharpSyntaxTree.ParseText(s.Value, path: s.Key)),

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -98,11 +98,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_class_nullable_disable lhs, Variant_class_nullable_disable rhs)
-        => lhs?.Equals(rhs) ?? (rhs is null);
+            => lhs?.Equals(rhs) ?? (rhs is null);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_class_nullable_disable lhs, Variant_class_nullable_disable rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
@@ -259,7 +259,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_class_nullable_disable v)
             {
                 Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
                 VariantOf(default, default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -36,7 +36,7 @@ namespace Foo
         public Variant_class_nullable_enable(string s)
             => _variant = new __VariantImpl(s);
         /// <summary>
-        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
+        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array?"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
@@ -65,7 +65,7 @@ namespace Foo
         public static implicit operator Variant_class_nullable_enable(string s)
             => new Variant_class_nullable_enable(s);
         /// <summary>
-        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
+        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array?"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
@@ -94,7 +94,7 @@ namespace Foo
         public static Variant_class_nullable_enable Create(string s)
             => new Variant_class_nullable_enable(s);
         /// <summary>
-        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array"/>.
+        /// Create a Variant_class_nullable_enable with a value of type <see cref="global::System.Array?"/>.
         /// </summary>
         /// <param name="a">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
@@ -119,11 +119,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_class_nullable_enable? lhs, Variant_class_nullable_enable? rhs)
-        => lhs?.Equals(rhs) ?? (rhs is null);
+            => lhs?.Equals(rhs) ?? (rhs is null);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_class_nullable_enable? lhs, Variant_class_nullable_enable? rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
@@ -320,7 +320,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_class_nullable_enable v)
             {
                 Value = v._variant.AsObject;
-                VariantOf(default, default, default!, default);
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf(default, default, default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 
@@ -572,7 +575,7 @@ namespace Foo
                     case 3:
                         return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
                     case 4:
-                        return global::System.Collections.Generic.EqualityComparer<global::System.Array>.Default.Equals(_x._4.Value, other._x._4.Value);
+                        return global::System.Collections.Generic.EqualityComparer<global::System.Array?>.Default.Equals(_x._4.Value, other._x._4.Value);
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_class_nullable_enable");
                 }
@@ -958,10 +961,10 @@ namespace Foo
                 return _n == 3 ? s(_x._3.Value) : _();
             }
             /// <summary>
-            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>.
             /// </summary>
-            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
-            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
+            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array?"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array?"/>.</returns>
             public bool TryMatch(out global::System.Array? a)
             {
                 a = _n == 4 ? _x._4.Value : default;
@@ -969,10 +972,10 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>.
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array"/>.</returns>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
+            /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array?"/>.</returns>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"> is rethrown.</exception>
             public bool TryMatch(global::System.Action<global::System.Array?> a)
             {
@@ -985,11 +988,11 @@ namespace Foo
             }
 
             /// <summary>
-            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array"/>.</param>
-            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/>.</exception>
+            /// <param name="a">Receives the stored value if it is of type <see cref="global::System.Array?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array?"/>.</exception>
             public void Match(out global::System.Array? a)
             {
                 if (_n == 4)
@@ -1001,11 +1004,11 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
-            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/>.</exception>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array?"/>.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> is rethrown.</exception>
             public void Match(global::System.Action<global::System.Array?> a)
             {
@@ -1018,10 +1021,10 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/>,
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>,
             /// otherwise invoke an alternative delegate.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
             /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> or <paramref name="_"/> is rethrown.</exception>
             public void Match(global::System.Action<global::System.Array?> a, global::System.Action _)
@@ -1037,12 +1040,12 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/> and return the result,
             /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
             /// <returns>The value returned from invoking <paramref name="a"/>.</returns>
-            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array"/>.</exception>
+            /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable does not contain a value of type <see cref="global::System.Array?"/>.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> is rethrown.</exception>
             public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a)
             {
@@ -1054,10 +1057,10 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/> and return the result,
             /// otherwise return a provided value.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
             /// <param name="_">The value to return if the stored value is of a different type.</param>
             /// <returns>The value returned from invoking <paramref name="a"/>, or <paramref name="default"/>.</returns>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> or <paramref name="other"/> is rethrown.</exception>
@@ -1067,10 +1070,10 @@ namespace Foo
             }
 
             /// <summary>
-            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array"/> and return the result,
+            /// Invoke a delegate with the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/> and return the result,
             /// otherwise invoke an alternative delegate and return its result.
             /// </summary>
-            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke with the stored value if it is of type <see cref="global::System.Array?"/>.</param>
             /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> or <paramref name="_"/> is rethrown.</exception>
             public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
@@ -1085,7 +1088,7 @@ namespace Foo
             /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
             /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
             /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array?"/>.</param>
             /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a, global::System.Action _)
@@ -1120,7 +1123,7 @@ namespace Foo
             /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
             /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
             /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array?"/>.</param>
             /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             public void Visit(global::System.Action<int> i, global::System.Action<float> f, global::System.Action<string> s, global::System.Action<global::System.Array?> a)
@@ -1155,7 +1158,7 @@ namespace Foo
             /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
             /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
             /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array?"/>.</param>
             /// <param name="_">The delegate to invoke if Variant_class_nullable_enable is empty.</param>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
@@ -1185,7 +1188,7 @@ namespace Foo
             /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
             /// <param name="f">The delegate to invoke if the stored value is of type <see cref="float"/>.</param>
             /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
-            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array"/>.</param>
+            /// <param name="a">The delegate to invoke if the stored value is of type <see cref="global::System.Array?"/>.</param>
             /// <exception cref="global::System.InvalidOperationException">Variant_class_nullable_enable is empty.</exception>
             /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
             /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
@@ -1284,7 +1287,7 @@ namespace Foo
         }
         /// <summary>
         /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.Array"/> and dropping all others.
+        /// containing a value of type <see cref="global::System.Array?"/> and dropping all others.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
@@ -1391,7 +1394,7 @@ namespace Foo
         }
         /// <summary>
         /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.Array"/> and replacing all others by a fallback value.
+        /// containing a value of type <see cref="global::System.Array?"/> and replacing all others by a fallback value.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
@@ -1504,7 +1507,7 @@ namespace Foo
         }
         /// <summary>
         /// Transform a Variant_class_nullable_enable-based enumerable sequence by applying a selector function to those elements
-        /// containing a value of type <see cref="global::System.Array"/> and replacing all others with the result of a fallback selector.
+        /// containing a value of type <see cref="global::System.Array?"/> and replacing all others with the result of a fallback selector.
         /// </summary>
         /// <param name="source">An enumerable sequence whose elements to match on.</param>
         /// <param name="a">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
@@ -1540,7 +1543,7 @@ namespace Foo
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
         /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
         /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array?"/>.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_class_nullable_enable.</exception>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
@@ -1584,7 +1587,7 @@ namespace Foo
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
         /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
         /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array?"/>.</param>
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
         /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
@@ -1678,7 +1681,7 @@ namespace Foo
                 _variant => s(((global::dotVariant.GeneratorSupport.Accessor_3<string>)_variant).Value));
         }
         /// <summary>
-        /// Projects each <see cref="global::System.Array"/> element of an observable sequence
+        /// Projects each <see cref="global::System.Array?"/> element of an observable sequence
         /// into a new form and drops all other elements.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
@@ -1777,7 +1780,7 @@ namespace Foo
             });
         }
         /// <summary>
-        /// Projects each <see cref="global::System.Array"/> element of an observable sequence
+        /// Projects each <see cref="global::System.Array?"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback value.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
@@ -1886,7 +1889,7 @@ namespace Foo
             });
         }
         /// <summary>
-        /// Projects each <see cref="global::System.Array"/> element of an observable sequence
+        /// Projects each <see cref="global::System.Array?"/> element of an observable sequence
         /// into a new form and replaces all other elements by a fallback selector result.
         /// </summary>
         /// <param name="source">An observable sequence whose elements to match on.</param>
@@ -1921,7 +1924,7 @@ namespace Foo
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
         /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
         /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array?"/>.</param>
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
@@ -1957,7 +1960,7 @@ namespace Foo
         /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
         /// <param name="f">The delegate to invoke if the element's value is of type <see cref="float"/>.</param>
         /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
-        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array"/>.</param>
+        /// <param name="a">The delegate to invoke if the element's value is of type <see cref="global::System.Array?"/>.</param>
         /// <param name="_">The delegate to invoke if an element is empty.</param>
         /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
@@ -2005,7 +2008,7 @@ namespace Foo
         /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="f">Transform an observable sequence of <see cref="float"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
-        /// <param name="a">Transform an observable sequence of <see cref="global::System.Array"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="a">Transform an observable sequence of <see cref="global::System.Array?"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
         public static global::System.IObservable<TResult>
@@ -2036,7 +2039,7 @@ namespace Foo
         /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="f">Transform an observable sequence of <see cref="float"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
-        /// <param name="a">Transform an observable sequence of <see cref="global::System.Array"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="a">Transform an observable sequence of <see cref="global::System.Array?"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
         /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
         /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
         /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -85,11 +85,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_disposable lhs, Variant_disposable rhs)
-        => lhs?.Equals(rhs) ?? (rhs is null);
+            => lhs?.Equals(rhs) ?? (rhs is null);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_disposable lhs, Variant_disposable rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
@@ -206,7 +206,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_disposable v)
             {
                 Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
                 VariantOf(default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -56,11 +56,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_nullable_value_type lhs, Variant_nullable_value_type rhs)
-        => lhs?.Equals(rhs) ?? (rhs is null);
+            => lhs?.Equals(rhs) ?? (rhs is null);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_nullable_value_type lhs, Variant_nullable_value_type rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
@@ -137,7 +137,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_nullable_value_type v)
             {
                 Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
                 VariantOf(default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -77,11 +77,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_public lhs, Variant_public rhs)
-        => lhs?.Equals(rhs) ?? (rhs is null);
+            => lhs?.Equals(rhs) ?? (rhs is null);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_public lhs, Variant_public rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public override int GetHashCode()
@@ -198,7 +198,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_public v)
             {
                 Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
                 VariantOf(default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -91,11 +91,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_struct_nullable_disable lhs, Variant_struct_nullable_disable rhs)
-        => lhs.Equals(rhs);
+            => lhs.Equals(rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_struct_nullable_disable lhs, Variant_struct_nullable_disable rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override int GetHashCode()
@@ -252,7 +252,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_struct_nullable_disable v)
             {
                 Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
                 VariantOf(default, default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -91,11 +91,11 @@ namespace Foo
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator ==(Variant_struct_nullable_enable lhs, Variant_struct_nullable_enable rhs)
-        => lhs.Equals(rhs);
+            => lhs.Equals(rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public static bool operator !=(Variant_struct_nullable_enable lhs, Variant_struct_nullable_enable rhs)
-        => !(lhs == rhs);
+            => !(lhs == rhs);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
         public readonly override int GetHashCode()
@@ -252,7 +252,10 @@ namespace Foo
             public _VariantTypeProxy(Variant_struct_nullable_enable v)
             {
                 Value = v._variant.AsObject;
-                VariantOf(default, default, default!);
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf(default, default, default);
+                #pragma warning restore 8604, 8625
             }
         }
 

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -100,5 +100,18 @@ namespace dotVariant.Generator
                     .OfType<IFieldSymbol>() // Inludes backing fields of auto-properties
                     .Where(m => !m.IsStatic)
                     .Sum(m => NumReferenceFields(m.Type));
+
+        public static bool CanBeNull(IParameterSymbol p)
+        {
+            if (p.Type.IsReferenceType)
+            {
+                return p.NullableAnnotation != NullableAnnotation.NotAnnotated;
+            }
+            if (p.Type.IsValueType)
+            {
+                return p.NullableAnnotation == NullableAnnotation.Annotated;
+            }
+            return false;
+        }
     }
 }

--- a/src/dotVariant.Generator/templates/IObservable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IObservable.scriban-cs
@@ -183,7 +183,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
                 this global::System.IObservable<{{ Variant.QualifiedType }}> source,
-                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }})
+                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + $0.Type + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }})
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}) =>
             {
@@ -216,7 +216,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
                 this global::System.IObservable<{{ Variant.QualifiedType }}> source,
-                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + (value_type $0) + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }},
+                {{ Params | array.each @(do; ret "global::System.Func<global::System.IObservable<" + $0.Type + ">, global::System.IObservable<TResult>> " + $0.Identifier; end) | array.join ", " }},
                 global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
         {
             return VisitMany(source, ({{ Params | array.each @(do; ret "_" + $0.Index; end) | array.join ", "}}, _0) =>
@@ -247,7 +247,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
                 this global::System.IObservable<{{ Variant.QualifiedType }}> source,
-                global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<TResult>> selector)
+                global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + $0.Type + ">"; end) | array.join ", " }}, global::System.IObservable<TResult>> selector)
         {
             return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
@@ -279,7 +279,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         public static global::System.IObservable<TResult>
             VisitMany<TResult>(
                 this global::System.IObservable<{{ Variant.QualifiedType }}> source,
-                global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + (value_type $0) + ">"; end) | array.join ", " }}, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
+                global::System.Func<{{ Params | array.each @(do; ret "global::System.IObservable<" + $0.Type + ">"; end) | array.join ", " }}, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> selector)
         {
             return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
             {
@@ -295,7 +295,7 @@ namespace {{ Options.ExtensionClassNamespace }}
         {
             public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
             {{~ for $p in Params ~}}
-            public readonly global::System.Reactive.Subjects.Subject<{{ value_type $p }}> Subject{{ $p.Index }} = new global::System.Reactive.Subjects.Subject<{{ value_type $p }}>();
+            public readonly global::System.Reactive.Subjects.Subject<{{ $p.Type }}> Subject{{ $p.Index }} = new global::System.Reactive.Subjects.Subject<{{ $p.Type }}>();
             {{~ end ~}}
             private readonly bool _accept0;
 

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -144,7 +144,7 @@ namespace {{ Variant.Namespace }}
 
                 {{~ ## UNION CONSTRUCTORS ## ~}}
                 {{~ for $p in Params ~}}
-                public Union({{ value_type $p }} value)
+                public Union({{ $p.Type }} value)
                 {
                     {{~ for $other in Params | array.remove_at ($p.Index - 1) ~}}
                     _{{ $other.Index }} = default;
@@ -159,12 +159,12 @@ namespace {{ Variant.Namespace }}
             [global::System.Diagnostics.DebuggerNonUserCode]
             private readonly struct Value_{{ $p.Index }}
             {
-                public readonly {{ value_type $p }} Value;
+                public readonly {{ $p.Type }} Value;
                 {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
                 public readonly object _dummy{{ $dummy }};
                 {{~ end ~}}
 
-                public Value_{{ $p.Index }}({{ value_type $p }} value)
+                public Value_{{ $p.Index }}({{ $p.Type }} value)
                 {
                     {{~ for $dummy in (1..$p.ObjectPadding) limit:$p.ObjectPadding ~}}
                     _dummy{{ $dummy }} = null{{ global_forgive }};
@@ -179,7 +179,7 @@ namespace {{ Variant.Namespace }}
 
             {{~ ## STORAGE CONSTRUCTORS ## ~}}
             {{~ for $p in Params ~}}
-            public __VariantImpl({{ value_type $p }} {{ $p.Identifier }})
+            public __VariantImpl({{ $p.Type }} {{ $p.Identifier }})
             {
                 _n = {{ $p.Index }};
                 _x = new Union({{ $p.Identifier }});
@@ -215,14 +215,14 @@ namespace {{ Variant.Namespace }}
             public static explicit operator {{ discriminator }}(in __VariantImpl v)
                 => ({{ discriminator }})v._n;
             {{~ for $p in Params ~}}
-            public static explicit operator {{ accessor $p.Index (value_type $p) }}(in __VariantImpl v)
-                => new {{ accessor $p.Index (value_type $p) }}(v._x._{{ $p.Index }}.Value);
+            public static explicit operator {{ accessor $p.Index $p.Type }}(in __VariantImpl v)
+                => new {{ accessor $p.Index $p.Type }}(v._x._{{ $p.Index }}.Value);
             {{~ end ~}}
 
             /// <summary>
             /// <see langword="true"/> if {{ Variant.Identifier }} was constructed without a value.
             /// </summary>
-            {{~ if !Variant.IsClass ~}}
+            {{~ if !Variant.IsReferenceType ~}}
             /// <remarks>
             /// Because {{ Variant.Identifier }} is a value type, its default constructor cannot be disabled.
             /// A default-constructed {{ Variant.Identifier }} will always have a <c>IsEmpty</c> value of <see langword="true"/>
@@ -338,7 +338,7 @@ namespace {{ Variant.Namespace }}
             /// </summary>
             /// <param name="{{ $p.Identifier }}">Receives the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
             /// <returns><see langword="true"/> if {{ Variant.Identifier }} contained a value of type <see cref="{{ cref $p.Type }}"/>.</returns>
-            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+            public bool TryMatch({{ annotate_NotNullWhen $p }}out {{ $p.OutType }} {{ $p.Identifier }})
             {
                 {{ $p.Identifier }} = _n == {{ $p.Index }} ? {{ $storage $p }} : default;
                 return _n == {{ $p.Index }};
@@ -367,7 +367,7 @@ namespace {{ Variant.Namespace }}
             /// </summary>
             /// <param name="{{ $p.Identifier }}">Receives the stored value if it is of type <see cref="{{ cref $p.Type }}"/>.</param>
             /// <exception cref="global::System.InvalidOperationException">{{ Variant.Identifier }} does not contain a value of type <see cref="{{ cref $p.Type }}"/>.</exception>
-            public void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+            public void Match({{ annotate_NotNull $p }}out {{ $p.OutType }} {{ $p.Identifier }})
             {
                 if (_n == {{ $p.Index }})
                 {

--- a/src/dotVariant.Generator/templates/Variant.scriban-cs
+++ b/src/dotVariant.Generator/templates/Variant.scriban-cs
@@ -36,7 +36,7 @@ namespace {{ Variant.Namespace }}
         /// </summary>
         /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ Variant.Identifier }}({{ value_type $p }} {{ $p.Identifier }})
+        public {{ Variant.Identifier }}({{ $p.Type }} {{ $p.Identifier }})
             => _variant = new {{ storage_type }}({{ $p.Identifier }});
         {{~ end ~}}
 
@@ -48,8 +48,8 @@ namespace {{ Variant.Namespace }}
         /// </summary>
         /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static implicit operator {{ Variant.Type }}({{ value_type $p }} {{ $p.Identifier }})
-            => new {{ Variant.Identifier }}({{ $p.Identifier }});
+        public static implicit operator {{ Variant.Type }}({{ $p.Type }} {{ $p.Identifier }})
+            => new {{ Variant.Type }}({{ $p.Identifier }});
         {{~ end ~}}
         {{~ end ~}}
 
@@ -60,8 +60,8 @@ namespace {{ Variant.Namespace }}
         /// </summary>
         /// <param name="{{ $p.Identifier }}">The value to initlaize the variant with.</param>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static {{ Variant.Type }} Create({{ value_type $p }} {{ $p.Identifier }})
-            => new {{ Variant.Identifier }}({{ $p.Identifier }});
+        public static {{ Variant.Type }} Create({{ $p.Type }} {{ $p.Identifier }})
+            => new {{ Variant.Type }}({{ $p.Identifier }});
         {{~ end ~}}
 
         {{~ ## DISPOSE ## ~}}
@@ -88,16 +88,16 @@ namespace {{ Variant.Namespace }}
 
         /// <inheritdoc/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}bool Equals({{ value_type Variant }} other)
-            => {{ if Variant.IsClass; "!(other is null) && "; end }}_variant.Equals(other._variant);
+        public {{ method_modifiers }}bool Equals({{ variant_nullable_param }} other)
+            => {{ if Variant.IsReferenceType; "!(other is null) && "; end }}_variant.Equals(other._variant);
 
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static bool operator ==({{ param_modifiers; value_type Variant }} lhs, {{ param_modifiers; value_type Variant }} rhs)
-        => {{ coalesce Variant "lhs" ".Equals(rhs)" "(rhs is null)" }};
+        public static bool operator ==({{ param_modifiers; variant_nullable_param }} lhs, {{ param_modifiers; variant_nullable_param }} rhs)
+            => {{ coalesce Variant "lhs" ".Equals(rhs)" "(rhs is null)" }};
 
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static bool operator !=({{ param_modifiers; value_type Variant }} lhs, {{ param_modifiers; value_type Variant }} rhs)
-        => !(lhs == rhs);
+        public static bool operator !=({{ param_modifiers; variant_nullable_param }} lhs, {{ param_modifiers; variant_nullable_param }} rhs)
+            => !(lhs == rhs);
 
         {{~ ## VARIANT GetHashCode ## ~}}
         [global::System.Diagnostics.DebuggerNonUserCode]
@@ -111,9 +111,9 @@ namespace {{ Variant.Namespace }}
 
         {{~ for $p in Params ~}}
         {{~ ## VARIANT TryMatch ## ~}}
-        /// <inheritdoc cref="{{ cref storage_type }}.TryMatch(out {{ cref (outref_type $p) }})"/>
+        /// <inheritdoc cref="{{ cref storage_type }}.TryMatch(out {{ cref $p.OutType }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+        public {{ method_modifiers }}bool TryMatch({{ annotate_NotNullWhen $p }}out {{ $p.OutType }} {{ $p.Identifier }})
             => _variant.TryMatch(out {{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.TryMatch({{ cref (action_type $p) }})"/>
@@ -122,9 +122,9 @@ namespace {{ Variant.Namespace }}
             => _variant.TryMatch({{ $p.Identifier }});
 
         {{~ ## VARIANT Match ## ~}}
-        /// <inheritdoc cref="{{ cref storage_type }}.Match(out {{ cref (outref_type $p) }})"/>
+        /// <inheritdoc cref="{{ cref storage_type }}.Match(out {{ cref $p.OutType }})"/>
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ outref_type $p }} {{ $p.Identifier }})
+        public {{ method_modifiers }}void Match({{ annotate_NotNull $p }}out {{ $p.OutType }} {{ $p.Identifier }})
             => _variant.Match(out {{ $p.Identifier }});
 
         /// <inheritdoc cref="{{ cref storage_type }}.Match({{ cref (action_type $p) }})"/>
@@ -182,7 +182,10 @@ namespace {{ Variant.Namespace }}
             {
                 Value = v._variant.AsObject;
                 {{~ # Force a reference to the VariantOf function so the user doesn't get IDE0051 "Private member 'VariantOf' is unused." ~}}
-                VariantOf({{ Params | array.each @(do; ret forgive $0 "default"; end) | array.join ", " }});
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf({{ Params | array.each @(do; ret "default"; end) | array.join ", " }});
+                #pragma warning restore 8604, 8625
             }
         }
 
@@ -194,8 +197,8 @@ namespace {{ Variant.Namespace }}
         {{~ for $p in Params ~}}
         [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
         [global::System.Diagnostics.DebuggerNonUserCode]
-        public static explicit operator {{ accessor $p.Index (value_type $p) }}({{ Variant.Type }} v)
-            => ({{ accessor $p.Index (value_type $p) }})v._variant;
+        public static explicit operator {{ accessor $p.Index $p.Type }}({{ Variant.Type }} v)
+            => ({{ accessor $p.Index $p.Type }})v._variant;
         {{~ end ~}}
     }
 {{~ if Variant.Namespace ~}}

--- a/src/dotVariant.Generator/templates/globals.scriban-cs
+++ b/src/dotVariant.Generator/templates/globals.scriban-cs
@@ -16,58 +16,22 @@ emit_nullability = Language.Version >= 800 && Language.Nullable == "enable"
 readonly emit_nullability
 
 # The type to use for variables and function parameters
-# Works with both "Params" and "Variant"
-func value_type(type, name = null)
-    if (name == null)
-        name = type.Type
-    end
-    if type.IsClass
-        ret emit_nullability && type.Nullability == "nullable" ? (name + "?" ): name
-    else
-        ret name
-    end
-end
-readonly value_type
-
-# The type to use for out or ref parameters
-# Works with both "Params" and "Variant"
-func outref_type(type, name = null)
-    if (name == null)
-        name = type.Type
-    end
-    if type.IsClass
-        ret emit_nullability ? (name + "?") : name
-    else
-        ret name
-    end
-end
-readonly outref_type
+variant_nullable_param = emit_nullability && Variant.IsReferenceType ? (Variant.Type + "?" ) : Variant.Type
+readonly variant_nullable_param
 
 func func_type(param, result = "TResult")
-    ret "global::System.Func<" + (value_type param) + ", " + result + ">"
+    ret "global::System.Func<" + param.Type + ", " + result + ">"
 end
 readonly func_type
 
 func action_type(param)
-    ret "global::System.Action<" + (value_type param) + ">"
+    ret "global::System.Action<" + param.Type + ">"
 end
 readonly action_type
 
-# Conditionally append forgive-operator to an expression
-# Works with both "Params" and "Variant"
-func forgive(type, expression)
-    if type.IsClass
-        ret emit_nullability && type.Nullability == "nonnull" ? (expression + "!") : expression
-    else
-        ret expression
-    end
-end
-readonly forgive
-
 # Conditionally apply a null-caolescing member access with trailing null-expression after the ??
-# Works with both "Params" and "Variant"
 func coalesce(type, expression, sub_expression, null_expression = null)
-    if type.Nullability == "nullable"
+    if type.CanBeNull
         ret expression + "?" + sub_expression + (null_expression != null ? (" ?? " + null_expression) : "")
     else
         ret expression + sub_expression
@@ -75,23 +39,14 @@ func coalesce(type, expression, sub_expression, null_expression = null)
 end
 readonly coalesce
 
-func coalesce_ToString(type, expression)
-    if type.Nullability == "nonnull" && type.ToStringNullability == "nonnull"
-        ret expression + ".ToString()"
-    else
-        ret expression + (type.Nullability == "nullable" ? "?" : "") + ".ToString() ?? \"null\""
-    end
+func coalesce_ToString(param, expression)
+    ret expression + (param.CanBeNull ? "?" : "") + ".ToString()" + (param.ToStringNullability == "nullable" || param.CanBeNull ? " ?? \"null\"" : "")
 end
 readonly coalesce_ToString
 
-func param_hint(param)
-    ret param.Hint
-end
-readonly param_hint
-
 func annotate_NotNullWhen(param)
-    if param.IsClass && emit_nullability
-        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] " : ""
+    if param.IsReferenceType && emit_nullability
+        ret param.CanBeNull ? "" : "[global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] "
     else
         ret ""
     end
@@ -99,8 +54,8 @@ end
 readonly annotate_NotNullWhen
 
 func annotate_NotNull(param)
-    if param.IsClass && emit_nullability
-        ret param.Nullability == "nonnull" ? "[global::System.Diagnostics.CodeAnalysis.NotNull] " : ""
+    if param.IsReferenceType && emit_nullability
+        ret param.CanBeNull ? "" : "[global::System.Diagnostics.CodeAnalysis.NotNull] "
     else
         ret ""
     end
@@ -141,7 +96,7 @@ storage_type = "__VariantImpl"
 readonly storage_type
 
 func get_value(param, expression = "_variant")
-    ret "((global::dotVariant.GeneratorSupport.Accessor_" + param.Index + "<" + value_type param + ">)" + expression + ").Value"
+    ret "((global::dotVariant.GeneratorSupport.Accessor_" + param.Index + "<" + param.Type + ">)" + expression + ").Value"
 end
 readonly get_value
 
@@ -164,8 +119,8 @@ func_types = Params | array.each @(do; ret func_type $0; end) | array.join ", "
 func_params = Params | array.each @(do; ret (func_type $0) + " " + $0.Identifier; end) | array.join ", "
 action_types = Params | array.each @(do; ret action_type $0; end) | array.join ", "
 action_params = Params | array.each @(do; ret (action_type $0) + " " + $0.Identifier; end) | array.join ", "
-method_modifiers = !Variant.IsClass && Language.Version >= 800 ? "readonly " : ""
-param_modifiers = !Variant.IsClass && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
+method_modifiers = !Variant.IsReferenceType && Language.Version >= 800 ? "readonly " : ""
+param_modifiers = !Variant.IsReferenceType && Variant.IsReadonly && Language.Version >= 702 ? "in " : ""
 global_nullable = emit_nullability ? "?" : ""
 global_forgive = emit_nullability ? "!" : ""
 needs_dispose = (Params | array.filter @(do; ret $0.IsDisposable; end) | array.size) > 0


### PR DESCRIPTION
Simplify the properties in RenderInfo records down to:
- CanBeNull: true if null is a valid value for this type
- IsReferenceType: true if this is known to be a reference type

Precompute the type to be used for `out` parameters.

Make sure nullability is correctly annotated on all
parameters, fields, and XML references.