### PR TITLE
Improve logic for detecting nullable `ToString()`

### DIFF
--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -113,5 +113,36 @@ namespace dotVariant.Generator
             }
             return false;
         }
+
+        public static bool IsToStringNullable(ITypeSymbol type, NullableContext context)
+            => type switch
+            {
+                // These are known statically
+                { SpecialType: SpecialType.System_Object } => true,
+                { SpecialType: SpecialType.System_Nullable_T } => true,
+                { SpecialType: SpecialType.System_Enum } => false,
+                { SpecialType: SpecialType.System_Boolean } => false,
+                { SpecialType: SpecialType.System_Char } => false,
+                { SpecialType: SpecialType.System_SByte } => false,
+                { SpecialType: SpecialType.System_Byte } => false,
+                { SpecialType: SpecialType.System_Int16 } => false,
+                { SpecialType: SpecialType.System_UInt16 } => false,
+                { SpecialType: SpecialType.System_Int32 } => false,
+                { SpecialType: SpecialType.System_UInt32 } => false,
+                { SpecialType: SpecialType.System_Int64 } => false,
+                { SpecialType: SpecialType.System_UInt64 } => false,
+                { SpecialType: SpecialType.System_Decimal } => false,
+                { SpecialType: SpecialType.System_Single } => false,
+                { SpecialType: SpecialType.System_Double } => false,
+                { SpecialType: SpecialType.System_String } => false,
+                { SpecialType: SpecialType.System_IntPtr } => false,
+                { SpecialType: SpecialType.System_UIntPtr } => false,
+                { SpecialType: SpecialType.System_DateTime } => false,
+                // If nullable annotations are disabled assume nullable
+                _ when !context.HasFlag(NullableContext.AnnotationsEnabled) => true,
+                // Otherwise check the signature of ToString()
+                _ => FindMethod(type, m => m.Name == nameof(ToString) && m.Parameters.IsEmpty)
+                    ?.ReturnNullableAnnotation != NullableAnnotation.NotAnnotated,
+            };
     }
 }

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -134,14 +134,14 @@ namespace dotVariant.Generator
         /// <param name="IsReferenceType">
         /// <see langword="true"/> if this is an object type (or generic with class constraint).
         /// </param>
+        /// <param name="IsToStringNullable">
+        /// <see langword="true"/> if the parameters's <see cref="object.ToString()"/> can return <see langword="null"/>.
+        /// </param>
         /// <param name="ObjectPadding">
         /// The number of <see langword="object"/> padding fields required for this type.
         /// </param>
         /// <param name="OutType">
         /// The type to use for <c>out</c>-qualified function parameters.
-        /// </param>
-        /// <param name="ToStringNullability">
-        /// <c>"notnull"</c> or <c>"nullable"</c> annotation of the parameters's <see cref="object.ToString()"/> return type.
         /// </param>
         /// <param name="Type">
         /// The fully qualified name of the type including type parameter list, without nullability annotation.
@@ -154,9 +154,9 @@ namespace dotVariant.Generator
             int Index,
             bool IsDisposable,
             bool IsReferenceType,
+            bool IsToStringNullable,
             int ObjectPadding,
             string OutType,
-            string ToStringNullability,
             string Type);
 
         public static RenderInfo FromDescriptor(
@@ -180,9 +180,9 @@ namespace dotVariant.Generator
                     Index: i + 1,
                     IsDisposable: IsDisposable(p.Type, compilation),
                     IsReferenceType: p.Type.IsReferenceType,
+                    IsToStringNullable: IsToStringNullable(p.Type, NullableContext.Enabled),
                     ObjectPadding: maxObjects - NumReferenceFields(p),
                     OutType: DetermineOutType(p, emitNullable),
-                    ToStringNullability: IsToStringNullable(p.Type) ? "nullable" : "notnull",
                     Type: AppendNullable(p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat), p.Type.IsReferenceType ? p.NullableAnnotation : NullableAnnotation.NotAnnotated)));
 
             var typeNamespace = type.ContainingNamespace.IsGlobalNamespace ? null : type.ContainingNamespace.ToDisplayString();
@@ -266,10 +266,6 @@ namespace dotVariant.Generator
             // Pass the script a unified numbering scheme
             return (int)v < 100 ? (int)v * 100 : (int)v;
         }
-
-        private static bool IsToStringNullable(ITypeSymbol type)
-            => FindMethod(type, m => m.Name == nameof(ToString) && m.Parameters.IsEmpty)?
-                .ReturnNullableAnnotation != NullableAnnotation.NotAnnotated;
 
         private static string? ExtensionsNamespace(AnalyzerConfigOptionsProvider options, string? typeNamespace)
         {

--- a/src/dotVariant.Generator/templates/globals.scriban-cs
+++ b/src/dotVariant.Generator/templates/globals.scriban-cs
@@ -40,7 +40,7 @@ end
 readonly coalesce
 
 func coalesce_ToString(param, expression)
-    ret expression + (param.CanBeNull ? "?" : "") + ".ToString()" + (param.ToStringNullability == "nullable" || param.CanBeNull ? " ?? \"null\"" : "")
+    ret expression + (param.CanBeNull ? "?" : "") + ".ToString()" + (param.IsToStringNullable || param.CanBeNull ? " ?? \"null\"" : "")
 end
 readonly coalesce_ToString
 


### PR DESCRIPTION
Some types are statically known to have non-null `ToString()` so add
these as exceptions.

Additionally add test cases for all the regular scenarios, some in both
nullable enabled and disabled contexts.