### PR TITLE
Disable current space optimization algorithm

### DIFF
--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-disable.out.cs
@@ -292,68 +292,28 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_class_nullable_disable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
+            public readonly int _1;
             public Union(int value)
             {
                 _2 = default;
                 _3 = default;
-                _1 = new Value_1(value);
+                _1 = value;
             }
+            public readonly float _2;
             public Union(float value)
             {
                 _1 = default;
                 _3 = default;
-                _2 = new Value_2(value);
+                _2 = value;
             }
+            public readonly string _3;
             public Union(string value)
             {
                 _1 = default;
                 _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly float Value;
-            public readonly object _dummy1;
-
-            public Value_2(float value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly string Value;
-
-            public Value_3(string value)
-            {
-                Value = value;
+                _3 = value;
             }
         }
 
@@ -380,11 +340,11 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_class_nullable_disable v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in Variant_class_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(in Variant_class_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(in Variant_class_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3);
 
         /// <summary>
         /// <see langword="true"/> if Variant_class_nullable_disable was constructed without a value.
@@ -424,11 +384,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value.ToString();
+                    return _x._2.ToString();
                 case 3:
-                    return _x._3.Value?.ToString() ?? "null";
+                    return _x._3?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_disable");
             }
@@ -446,11 +406,11 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     case 3:
-                        return _x._3.Value;
+                        return _x._3;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_class_nullable_disable");
                 }
@@ -468,11 +428,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2, other._x._2);
                 case 3:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3, other._x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_class_nullable_disable");
             }
@@ -485,11 +445,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 case 3:
-                    return global::System.HashCode.Combine(_x._3.Value);
+                    return global::System.HashCode.Combine(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_class_nullable_disable");
             }
@@ -502,7 +462,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            i = _n == 1 ? _x._1.Value : default;
+            i = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -516,7 +476,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return true;
             }
             return false;
@@ -532,7 +492,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i = _x._1.Value;
+                i = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "int", TypeString);
@@ -549,7 +509,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "int", TypeString);
@@ -566,7 +526,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
             }
             else
             {
@@ -586,7 +546,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return i(_x._1.Value);
+                return i(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "int", TypeString);
         }
@@ -601,7 +561,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            return _n == 1 ? i(_x._1.Value) : _;
+            return _n == 1 ? i(_x._1) : _;
         }
 
         /// <summary>
@@ -613,7 +573,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            return _n == 1 ? i(_x._1.Value) : _();
+            return _n == 1 ? i(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="float"/>.
@@ -622,7 +582,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch(out float f)
         {
-            f = _n == 2 ? _x._2.Value : default;
+            f = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -636,7 +596,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
                 return true;
             }
             return false;
@@ -652,7 +612,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f = _x._2.Value;
+                f = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "float", TypeString);
@@ -669,7 +629,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "float", TypeString);
@@ -686,7 +646,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
             }
             else
             {
@@ -706,7 +666,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return f(_x._2.Value);
+                return f(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "float", TypeString);
         }
@@ -721,7 +681,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            return _n == 2 ? f(_x._2.Value) : _;
+            return _n == 2 ? f(_x._2) : _;
         }
 
         /// <summary>
@@ -733,7 +693,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            return _n == 2 ? f(_x._2.Value) : _();
+            return _n == 2 ? f(_x._2) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_disable if it is of type <see cref="string"/>.
@@ -742,7 +702,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_disable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch(out string s)
         {
-            s = _n == 3 ? _x._3.Value : default;
+            s = _n == 3 ? _x._3 : default;
             return _n == 3;
         }
 
@@ -756,7 +716,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
                 return true;
             }
             return false;
@@ -772,7 +732,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s = _x._3.Value;
+                s = _x._3;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_disable", "string", TypeString);
@@ -789,7 +749,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_disable", "string", TypeString);
@@ -806,7 +766,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
             }
             else
             {
@@ -826,7 +786,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                return s(_x._3.Value);
+                return s(_x._3);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_disable", "string", TypeString);
         }
@@ -841,7 +801,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            return _n == 3 ? s(_x._3.Value) : _;
+            return _n == 3 ? s(_x._3) : _;
         }
 
         /// <summary>
@@ -853,7 +813,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            return _n == 3 ? s(_x._3.Value) : _();
+            return _n == 3 ? s(_x._3) : _();
         }
 
         /// <summary>
@@ -873,13 +833,13 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    f(_x._2.Value);
+                    f(_x._2);
                     break;
                 case 3:
-                    s(_x._3.Value);
+                    s(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
@@ -904,13 +864,13 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_disable");
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    f(_x._2.Value);
+                    f(_x._2);
                     break;
                 case 3:
-                    s(_x._3.Value);
+                    s(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_disable");
@@ -935,11 +895,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return f(_x._2.Value);
+                    return f(_x._2);
                 case 3:
-                    return s(_x._3.Value);
+                    return s(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
             }
@@ -962,11 +922,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_disable");
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return f(_x._2.Value);
+                    return f(_x._2);
                 case 3:
-                    return s(_x._3.Value);
+                    return s(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_disable");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-class-nullable-enable.out.cs
@@ -357,90 +357,39 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_class_nullable_enable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_4 _4;
-
+            public readonly int _1;
             public Union(int value)
             {
-                _2 = default;
-                _3 = default;
-                _4 = default;
-                _1 = new Value_1(value);
+                _2 = default!;
+                _3 = default!;
+                _4 = default!;
+                _1 = value;
             }
+            public readonly float _2;
             public Union(float value)
             {
-                _1 = default;
-                _3 = default;
-                _4 = default;
-                _2 = new Value_2(value);
+                _1 = default!;
+                _3 = default!;
+                _4 = default!;
+                _2 = value;
             }
+            public readonly string _3;
             public Union(string value)
             {
-                _1 = default;
-                _2 = default;
-                _4 = default;
-                _3 = new Value_3(value);
+                _1 = default!;
+                _2 = default!;
+                _4 = default!;
+                _3 = value;
             }
+            public readonly global::System.Array? _4;
             public Union(global::System.Array? value)
             {
-                _1 = default;
-                _2 = default;
-                _3 = default;
-                _4 = new Value_4(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly float Value;
-            public readonly object _dummy1;
-
-            public Value_2(float value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly string Value;
-
-            public Value_3(string value)
-            {
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_4
-        {
-            public readonly global::System.Array? Value;
-
-            public Value_4(global::System.Array? value)
-            {
-                Value = value;
+                _1 = default!;
+                _2 = default!;
+                _3 = default!;
+                _4 = value;
             }
         }
 
@@ -472,13 +421,13 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_class_nullable_enable v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in Variant_class_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<float>(in Variant_class_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<float>(v._x._2);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<string>(in Variant_class_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_3<string>(v._x._3);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(in Variant_class_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(v._x._4.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_4<global::System.Array?>(v._x._4);
 
         /// <summary>
         /// <see langword="true"/> if Variant_class_nullable_enable was constructed without a value.
@@ -520,13 +469,13 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value.ToString();
+                    return _x._2.ToString();
                 case 3:
-                    return _x._3.Value.ToString();
+                    return _x._3.ToString();
                 case 4:
-                    return _x._4.Value?.ToString() ?? "null";
+                    return _x._4?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_class_nullable_enable");
             }
@@ -544,13 +493,13 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     case 3:
-                        return _x._3.Value;
+                        return _x._3;
                     case 4:
-                        return _x._4.Value;
+                        return _x._4;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant_class_nullable_enable");
                 }
@@ -568,13 +517,13 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<float>.Default.Equals(_x._2, other._x._2);
                 case 3:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3.Value, other._x._3.Value);
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._3, other._x._3);
                 case 4:
-                    return global::System.Collections.Generic.EqualityComparer<global::System.Array?>.Default.Equals(_x._4.Value, other._x._4.Value);
+                    return global::System.Collections.Generic.EqualityComparer<global::System.Array?>.Default.Equals(_x._4, other._x._4);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_class_nullable_enable");
             }
@@ -587,13 +536,13 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 case 3:
-                    return global::System.HashCode.Combine(_x._3.Value);
+                    return global::System.HashCode.Combine(_x._3);
                 case 4:
-                    return global::System.HashCode.Combine(_x._4.Value);
+                    return global::System.HashCode.Combine(_x._4);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_class_nullable_enable");
             }
@@ -606,7 +555,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out int i)
         {
-            i = _n == 1 ? _x._1.Value : default;
+            i = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -620,7 +569,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return true;
             }
             return false;
@@ -636,7 +585,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i = _x._1.Value;
+                i = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "int", TypeString);
@@ -653,7 +602,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "int", TypeString);
@@ -670,7 +619,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
             }
             else
             {
@@ -690,7 +639,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return i(_x._1.Value);
+                return i(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "int", TypeString);
         }
@@ -705,7 +654,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            return _n == 1 ? i(_x._1.Value) : _;
+            return _n == 1 ? i(_x._1) : _;
         }
 
         /// <summary>
@@ -717,7 +666,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            return _n == 1 ? i(_x._1.Value) : _();
+            return _n == 1 ? i(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="float"/>.
@@ -726,7 +675,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="float"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out float f)
         {
-            f = _n == 2 ? _x._2.Value : default;
+            f = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -740,7 +689,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
                 return true;
             }
             return false;
@@ -756,7 +705,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f = _x._2.Value;
+                f = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "float", TypeString);
@@ -773,7 +722,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "float", TypeString);
@@ -790,7 +739,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                f(_x._2.Value);
+                f(_x._2);
             }
             else
             {
@@ -810,7 +759,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return f(_x._2.Value);
+                return f(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "float", TypeString);
         }
@@ -825,7 +774,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, TResult _)
         {
-            return _n == 2 ? f(_x._2.Value) : _;
+            return _n == 2 ? f(_x._2) : _;
         }
 
         /// <summary>
@@ -837,7 +786,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="f"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<float, TResult> f, global::System.Func<TResult> _)
         {
-            return _n == 2 ? f(_x._2.Value) : _();
+            return _n == 2 ? f(_x._2) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="string"/>.
@@ -846,7 +795,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? s)
         {
-            s = _n == 3 ? _x._3.Value : default;
+            s = _n == 3 ? _x._3 : default;
             return _n == 3;
         }
 
@@ -860,7 +809,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
                 return true;
             }
             return false;
@@ -876,7 +825,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s = _x._3.Value;
+                s = _x._3;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "string", TypeString);
@@ -893,7 +842,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "string", TypeString);
@@ -910,7 +859,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                s(_x._3.Value);
+                s(_x._3);
             }
             else
             {
@@ -930,7 +879,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                return s(_x._3.Value);
+                return s(_x._3);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "string", TypeString);
         }
@@ -945,7 +894,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            return _n == 3 ? s(_x._3.Value) : _;
+            return _n == 3 ? s(_x._3) : _;
         }
 
         /// <summary>
@@ -957,7 +906,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            return _n == 3 ? s(_x._3.Value) : _();
+            return _n == 3 ? s(_x._3) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_class_nullable_enable if it is of type <see cref="global::System.Array?"/>.
@@ -966,7 +915,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_class_nullable_enable contained a value of type <see cref="global::System.Array?"/>.</returns>
         public bool TryMatch(out global::System.Array? a)
         {
-            a = _n == 4 ? _x._4.Value : default;
+            a = _n == 4 ? _x._4 : default;
             return _n == 4;
         }
 
@@ -980,7 +929,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 4)
             {
-                a(_x._4.Value);
+                a(_x._4);
                 return true;
             }
             return false;
@@ -996,7 +945,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 4)
             {
-                a = _x._4.Value;
+                a = _x._4;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", TypeString);
@@ -1013,7 +962,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 4)
             {
-                a(_x._4.Value);
+                a(_x._4);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_class_nullable_enable", "System.Array?", TypeString);
@@ -1030,7 +979,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 4)
             {
-                a(_x._4.Value);
+                a(_x._4);
             }
             else
             {
@@ -1050,7 +999,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 4)
             {
-                return a(_x._4.Value);
+                return a(_x._4);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_class_nullable_enable", "System.Array?", TypeString);
         }
@@ -1065,7 +1014,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, TResult _)
         {
-            return _n == 4 ? a(_x._4.Value) : _;
+            return _n == 4 ? a(_x._4) : _;
         }
 
         /// <summary>
@@ -1077,7 +1026,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="a"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.Array?, TResult> a, global::System.Func<TResult> _)
         {
-            return _n == 4 ? a(_x._4.Value) : _();
+            return _n == 4 ? a(_x._4) : _();
         }
 
         /// <summary>
@@ -1098,16 +1047,16 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    f(_x._2.Value);
+                    f(_x._2);
                     break;
                 case 3:
-                    s(_x._3.Value);
+                    s(_x._3);
                     break;
                 case 4:
-                    a(_x._4.Value);
+                    a(_x._4);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
@@ -1133,16 +1082,16 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_class_nullable_enable");
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    f(_x._2.Value);
+                    f(_x._2);
                     break;
                 case 3:
-                    s(_x._3.Value);
+                    s(_x._3);
                     break;
                 case 4:
-                    a(_x._4.Value);
+                    a(_x._4);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_class_nullable_enable");
@@ -1168,13 +1117,13 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return f(_x._2.Value);
+                    return f(_x._2);
                 case 3:
-                    return s(_x._3.Value);
+                    return s(_x._3);
                 case 4:
-                    return a(_x._4.Value);
+                    return a(_x._4);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
             }
@@ -1198,13 +1147,13 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_class_nullable_enable");
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return f(_x._2.Value);
+                    return f(_x._2);
                 case 3:
-                    return s(_x._3.Value);
+                    return s(_x._3);
                 case 4:
-                    return a(_x._4.Value);
+                    return a(_x._4);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_class_nullable_enable");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-disposable.out.cs
@@ -236,46 +236,19 @@ namespace dotVariant._G.Foo
     internal readonly struct Variant_disposable
         : global::System.IDisposable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-
+            public readonly int _1;
             public Union(int value)
             {
                 _2 = default;
-                _1 = new Value_1(value);
+                _1 = value;
             }
+            public readonly global::System.IO.Stream _2;
             public Union(global::System.IO.Stream value)
             {
                 _1 = default;
-                _2 = new Value_2(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly global::System.IO.Stream Value;
-
-            public Value_2(global::System.IO.Stream value)
-            {
-                Value = value;
+                _2 = value;
             }
         }
 
@@ -306,7 +279,7 @@ namespace dotVariant._G.Foo
                 case 1:
                     break;
                 case 2:
-                    _x._2.Value?.Dispose();
+                    _x._2?.Dispose();
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
@@ -317,9 +290,9 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_disposable v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in Variant_disposable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(in Variant_disposable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<global::System.IO.Stream>(v._x._2);
 
         /// <summary>
         /// <see langword="true"/> if Variant_disposable was constructed without a value.
@@ -357,9 +330,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value?.ToString() ?? "null";
+                    return _x._2?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_disposable");
             }
@@ -377,9 +350,9 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_disposable");
                 }
@@ -397,9 +370,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<global::System.IO.Stream>.Default.Equals(_x._2, other._x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_disposable");
             }
@@ -412,9 +385,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_disposable");
             }
@@ -427,7 +400,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            i = _n == 1 ? _x._1.Value : default;
+            i = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -441,7 +414,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return true;
             }
             return false;
@@ -457,7 +430,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i = _x._1.Value;
+                i = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_disposable", "int", TypeString);
@@ -474,7 +447,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_disposable", "int", TypeString);
@@ -491,7 +464,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
             }
             else
             {
@@ -511,7 +484,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return i(_x._1.Value);
+                return i(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_disposable", "int", TypeString);
         }
@@ -526,7 +499,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            return _n == 1 ? i(_x._1.Value) : _;
+            return _n == 1 ? i(_x._1) : _;
         }
 
         /// <summary>
@@ -538,7 +511,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            return _n == 1 ? i(_x._1.Value) : _();
+            return _n == 1 ? i(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_disposable if it is of type <see cref="global::System.IO.Stream"/>.
@@ -547,7 +520,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_disposable contained a value of type <see cref="global::System.IO.Stream"/>.</returns>
         public bool TryMatch(out global::System.IO.Stream stream)
         {
-            stream = _n == 2 ? _x._2.Value : default;
+            stream = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -561,7 +534,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                stream(_x._2.Value);
+                stream(_x._2);
                 return true;
             }
             return false;
@@ -577,7 +550,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                stream = _x._2.Value;
+                stream = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_disposable", "System.IO.Stream", TypeString);
@@ -594,7 +567,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                stream(_x._2.Value);
+                stream(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_disposable", "System.IO.Stream", TypeString);
@@ -611,7 +584,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                stream(_x._2.Value);
+                stream(_x._2);
             }
             else
             {
@@ -631,7 +604,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return stream(_x._2.Value);
+                return stream(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_disposable", "System.IO.Stream", TypeString);
         }
@@ -646,7 +619,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, TResult _)
         {
-            return _n == 2 ? stream(_x._2.Value) : _;
+            return _n == 2 ? stream(_x._2) : _;
         }
 
         /// <summary>
@@ -658,7 +631,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="stream"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<global::System.IO.Stream, TResult> stream, global::System.Func<TResult> _)
         {
-            return _n == 2 ? stream(_x._2.Value) : _();
+            return _n == 2 ? stream(_x._2) : _();
         }
 
         /// <summary>
@@ -677,10 +650,10 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    stream(_x._2.Value);
+                    stream(_x._2);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
@@ -704,10 +677,10 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_disposable");
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    stream(_x._2.Value);
+                    stream(_x._2);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_disposable");
@@ -731,9 +704,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return stream(_x._2.Value);
+                    return stream(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
             }
@@ -755,9 +728,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_disposable");
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return stream(_x._2.Value);
+                    return stream(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_disposable");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-nullable-value-type.out.cs
@@ -162,26 +162,12 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_nullable_value_type
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-
+            public readonly int? _1;
             public Union(int? value)
             {
-                _1 = new Value_1(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly int? Value;
-
-            public Value_1(int? value)
-            {
-                Value = value;
+                _1 = value;
             }
         }
 
@@ -198,7 +184,7 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_nullable_value_type v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int?>(in Variant_nullable_value_type v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<int?>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<int?>(v._x._1);
 
         /// <summary>
         /// <see langword="true"/> if Variant_nullable_value_type was constructed without a value.
@@ -234,7 +220,7 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value?.ToString() ?? "null";
+                    return _x._1?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_nullable_value_type");
             }
@@ -252,7 +238,7 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant_nullable_value_type");
                 }
@@ -270,7 +256,7 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int?>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<int?>.Default.Equals(_x._1, other._x._1);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_nullable_value_type");
             }
@@ -283,7 +269,7 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_nullable_value_type");
             }
@@ -296,7 +282,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_nullable_value_type contained a value of type <see cref="int?"/>.</returns>
         public bool TryMatch(out int? i)
         {
-            i = _n == 1 ? _x._1.Value : default;
+            i = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -310,7 +296,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return true;
             }
             return false;
@@ -326,7 +312,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i = _x._1.Value;
+                i = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_nullable_value_type", "int?", TypeString);
@@ -343,7 +329,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_nullable_value_type", "int?", TypeString);
@@ -360,7 +346,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
             }
             else
             {
@@ -380,7 +366,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return i(_x._1.Value);
+                return i(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_nullable_value_type", "int?", TypeString);
         }
@@ -395,7 +381,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, TResult _)
         {
-            return _n == 1 ? i(_x._1.Value) : _;
+            return _n == 1 ? i(_x._1) : _;
         }
 
         /// <summary>
@@ -407,7 +393,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int?, TResult> i, global::System.Func<TResult> _)
         {
-            return _n == 1 ? i(_x._1.Value) : _();
+            return _n == 1 ? i(_x._1) : _();
         }
 
         /// <summary>
@@ -425,7 +411,7 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
@@ -448,7 +434,7 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_nullable_value_type");
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_nullable_value_type");
@@ -471,7 +457,7 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
             }
@@ -492,7 +478,7 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_nullable_value_type");
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_nullable_value_type");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-public.out.cs
@@ -227,46 +227,19 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_public
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-
+            public readonly int _1;
             public Union(int value)
             {
                 _2 = default;
-                _1 = new Value_1(value);
+                _1 = value;
             }
+            public readonly string _2;
             public Union(string value)
             {
                 _1 = default;
-                _2 = new Value_2(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly int Value;
-            public readonly object _dummy1;
-
-            public Value_1(int value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly string Value;
-
-            public Value_2(string value)
-            {
-                Value = value;
+                _2 = value;
             }
         }
 
@@ -288,9 +261,9 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_public v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<int>(in Variant_public v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<int>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<string>(in Variant_public v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<string>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<string>(v._x._2);
 
         /// <summary>
         /// <see langword="true"/> if Variant_public was constructed without a value.
@@ -328,9 +301,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value?.ToString() ?? "null";
+                    return _x._2?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_public");
             }
@@ -348,9 +321,9 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_public");
                 }
@@ -368,9 +341,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2, other._x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_public");
             }
@@ -383,9 +356,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_public");
             }
@@ -398,7 +371,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="int"/>.</returns>
         public bool TryMatch(out int i)
         {
-            i = _n == 1 ? _x._1.Value : default;
+            i = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -412,7 +385,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return true;
             }
             return false;
@@ -428,7 +401,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i = _x._1.Value;
+                i = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_public", "int", TypeString);
@@ -445,7 +418,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_public", "int", TypeString);
@@ -462,7 +435,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                i(_x._1.Value);
+                i(_x._1);
             }
             else
             {
@@ -482,7 +455,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return i(_x._1.Value);
+                return i(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_public", "int", TypeString);
         }
@@ -497,7 +470,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
         {
-            return _n == 1 ? i(_x._1.Value) : _;
+            return _n == 1 ? i(_x._1) : _;
         }
 
         /// <summary>
@@ -509,7 +482,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
         {
-            return _n == 1 ? i(_x._1.Value) : _();
+            return _n == 1 ? i(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_public if it is of type <see cref="string"/>.
@@ -518,7 +491,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_public contained a value of type <see cref="string"/>.</returns>
         public bool TryMatch(out string s)
         {
-            s = _n == 2 ? _x._2.Value : default;
+            s = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -532,7 +505,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                s(_x._2.Value);
+                s(_x._2);
                 return true;
             }
             return false;
@@ -548,7 +521,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                s = _x._2.Value;
+                s = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_public", "string", TypeString);
@@ -565,7 +538,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                s(_x._2.Value);
+                s(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_public", "string", TypeString);
@@ -582,7 +555,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                s(_x._2.Value);
+                s(_x._2);
             }
             else
             {
@@ -602,7 +575,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return s(_x._2.Value);
+                return s(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_public", "string", TypeString);
         }
@@ -617,7 +590,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
         {
-            return _n == 2 ? s(_x._2.Value) : _;
+            return _n == 2 ? s(_x._2) : _;
         }
 
         /// <summary>
@@ -629,7 +602,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
         {
-            return _n == 2 ? s(_x._2.Value) : _();
+            return _n == 2 ? s(_x._2) : _();
         }
 
         /// <summary>
@@ -648,10 +621,10 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    s(_x._2.Value);
+                    s(_x._2);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
@@ -675,10 +648,10 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_public");
                     break;
                 case 1:
-                    i(_x._1.Value);
+                    i(_x._1);
                     break;
                 case 2:
-                    s(_x._2.Value);
+                    s(_x._2);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_public");
@@ -702,9 +675,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return s(_x._2.Value);
+                    return s(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
             }
@@ -726,9 +699,9 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_public");
                 case 1:
-                    return i(_x._1.Value);
+                    return i(_x._1);
                 case 2:
-                    return s(_x._2.Value);
+                    return s(_x._2);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_public");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-disable.out.cs
@@ -285,68 +285,28 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_struct_nullable_disable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
+            public readonly long _1;
             public Union(long value)
             {
                 _2 = default;
                 _3 = default;
-                _1 = new Value_1(value);
+                _1 = value;
             }
+            public readonly double _2;
             public Union(double value)
             {
                 _1 = default;
                 _3 = default;
-                _2 = new Value_2(value);
+                _2 = value;
             }
+            public readonly object _3;
             public Union(object value)
             {
                 _1 = default;
                 _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly long Value;
-            public readonly object _dummy1;
-
-            public Value_1(long value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly double Value;
-            public readonly object _dummy1;
-
-            public Value_2(double value)
-            {
-                _dummy1 = null;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly object Value;
-
-            public Value_3(object value)
-            {
-                Value = value;
+                _3 = value;
             }
         }
 
@@ -373,11 +333,11 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_struct_nullable_disable v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(in Variant_struct_nullable_disable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3);
 
         /// <summary>
         /// <see langword="true"/> if Variant_struct_nullable_disable was constructed without a value.
@@ -422,11 +382,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value.ToString();
+                    return _x._2.ToString();
                 case 3:
-                    return _x._3.Value?.ToString() ?? "null";
+                    return _x._3?.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_disable");
             }
@@ -444,11 +404,11 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     case 3:
-                        return _x._3.Value;
+                        return _x._3;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_struct_nullable_disable");
                 }
@@ -466,11 +426,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2, other._x._2);
                 case 3:
-                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3, other._x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_struct_nullable_disable");
             }
@@ -483,11 +443,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 case 3:
-                    return global::System.HashCode.Combine(_x._3.Value);
+                    return global::System.HashCode.Combine(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_struct_nullable_disable");
             }
@@ -500,7 +460,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="long"/>.</returns>
         public bool TryMatch(out long l)
         {
-            l = _n == 1 ? _x._1.Value : default;
+            l = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -514,7 +474,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
                 return true;
             }
             return false;
@@ -530,7 +490,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l = _x._1.Value;
+                l = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "long", TypeString);
@@ -547,7 +507,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "long", TypeString);
@@ -564,7 +524,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
             }
             else
             {
@@ -584,7 +544,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return l(_x._1.Value);
+                return l(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "long", TypeString);
         }
@@ -599,7 +559,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            return _n == 1 ? l(_x._1.Value) : _;
+            return _n == 1 ? l(_x._1) : _;
         }
 
         /// <summary>
@@ -611,7 +571,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            return _n == 1 ? l(_x._1.Value) : _();
+            return _n == 1 ? l(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="double"/>.
@@ -620,7 +580,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="double"/>.</returns>
         public bool TryMatch(out double d)
         {
-            d = _n == 2 ? _x._2.Value : default;
+            d = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -634,7 +594,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
                 return true;
             }
             return false;
@@ -650,7 +610,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d = _x._2.Value;
+                d = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "double", TypeString);
@@ -667,7 +627,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "double", TypeString);
@@ -684,7 +644,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
             }
             else
             {
@@ -704,7 +664,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return d(_x._2.Value);
+                return d(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "double", TypeString);
         }
@@ -719,7 +679,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            return _n == 2 ? d(_x._2.Value) : _;
+            return _n == 2 ? d(_x._2) : _;
         }
 
         /// <summary>
@@ -731,7 +691,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            return _n == 2 ? d(_x._2.Value) : _();
+            return _n == 2 ? d(_x._2) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_disable if it is of type <see cref="object"/>.
@@ -740,7 +700,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_disable contained a value of type <see cref="object"/>.</returns>
         public bool TryMatch(out object o)
         {
-            o = _n == 3 ? _x._3.Value : default;
+            o = _n == 3 ? _x._3 : default;
             return _n == 3;
         }
 
@@ -754,7 +714,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
                 return true;
             }
             return false;
@@ -770,7 +730,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o = _x._3.Value;
+                o = _x._3;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_disable", "object", TypeString);
@@ -787,7 +747,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_disable", "object", TypeString);
@@ -804,7 +764,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
             }
             else
             {
@@ -824,7 +784,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                return o(_x._3.Value);
+                return o(_x._3);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_disable", "object", TypeString);
         }
@@ -839,7 +799,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            return _n == 3 ? o(_x._3.Value) : _;
+            return _n == 3 ? o(_x._3) : _;
         }
 
         /// <summary>
@@ -851,7 +811,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            return _n == 3 ? o(_x._3.Value) : _();
+            return _n == 3 ? o(_x._3) : _();
         }
 
         /// <summary>
@@ -871,13 +831,13 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    l(_x._1.Value);
+                    l(_x._1);
                     break;
                 case 2:
-                    d(_x._2.Value);
+                    d(_x._2);
                     break;
                 case 3:
-                    o(_x._3.Value);
+                    o(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
@@ -902,13 +862,13 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_disable");
                     break;
                 case 1:
-                    l(_x._1.Value);
+                    l(_x._1);
                     break;
                 case 2:
-                    d(_x._2.Value);
+                    d(_x._2);
                     break;
                 case 3:
-                    o(_x._3.Value);
+                    o(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_disable");
@@ -933,11 +893,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return l(_x._1.Value);
+                    return l(_x._1);
                 case 2:
-                    return d(_x._2.Value);
+                    return d(_x._2);
                 case 3:
-                    return o(_x._3.Value);
+                    return o(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
             }
@@ -960,11 +920,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_disable");
                 case 1:
-                    return l(_x._1.Value);
+                    return l(_x._1);
                 case 2:
-                    return d(_x._2.Value);
+                    return d(_x._2);
                 case 3:
-                    return o(_x._3.Value);
+                    return o(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_disable");
             }

--- a/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-struct-nullable-enable.out.cs
@@ -285,68 +285,28 @@ namespace dotVariant._G.Foo
     [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
     internal readonly struct Variant_struct_nullable_enable
     {
-        [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union
         {
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_1 _1;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_2 _2;
-            [global::System.Runtime.InteropServices.FieldOffset(0)]
-            public readonly Value_3 _3;
-
+            public readonly long _1;
             public Union(long value)
             {
-                _2 = default;
-                _3 = default;
-                _1 = new Value_1(value);
+                _2 = default!;
+                _3 = default!;
+                _1 = value;
             }
+            public readonly double _2;
             public Union(double value)
             {
-                _1 = default;
-                _3 = default;
-                _2 = new Value_2(value);
+                _1 = default!;
+                _3 = default!;
+                _2 = value;
             }
+            public readonly object _3;
             public Union(object value)
             {
-                _1 = default;
-                _2 = default;
-                _3 = new Value_3(value);
-            }
-        }
-
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_1
-        {
-            public readonly long Value;
-            public readonly object _dummy1;
-
-            public Value_1(long value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_2
-        {
-            public readonly double Value;
-            public readonly object _dummy1;
-
-            public Value_2(double value)
-            {
-                _dummy1 = null!;
-                Value = value;
-            }
-        }
-        [global::System.Diagnostics.DebuggerNonUserCode]
-        private readonly struct Value_3
-        {
-            public readonly object Value;
-
-            public Value_3(object value)
-            {
-                Value = value;
+                _1 = default!;
+                _2 = default!;
+                _3 = value;
             }
         }
 
@@ -373,11 +333,11 @@ namespace dotVariant._G.Foo
         public static explicit operator global::dotVariant.GeneratorSupport.Discriminator(in Variant_struct_nullable_enable v)
             => (global::dotVariant.GeneratorSupport.Discriminator)v._n;
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_1<long>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_1<long>(v._x._1);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_2<double>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_2<double>(v._x._2);
         public static explicit operator global::dotVariant.GeneratorSupport.Accessor_3<object>(in Variant_struct_nullable_enable v)
-            => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3.Value);
+            => new global::dotVariant.GeneratorSupport.Accessor_3<object>(v._x._3);
 
         /// <summary>
         /// <see langword="true"/> if Variant_struct_nullable_enable was constructed without a value.
@@ -422,11 +382,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return "";
                 case 1:
-                    return _x._1.Value.ToString();
+                    return _x._1.ToString();
                 case 2:
-                    return _x._2.Value.ToString();
+                    return _x._2.ToString();
                 case 3:
-                    return _x._3.Value.ToString() ?? "null";
+                    return _x._3.ToString() ?? "null";
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_struct_nullable_enable");
             }
@@ -444,11 +404,11 @@ namespace dotVariant._G.Foo
                     case 0:
                         return null;
                     case 1:
-                        return _x._1.Value;
+                        return _x._1;
                     case 2:
-                        return _x._2.Value;
+                        return _x._2;
                     case 3:
-                        return _x._3.Value;
+                        return _x._3;
                     default:
                         return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant_struct_nullable_enable");
                 }
@@ -466,11 +426,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return true;
                 case 1:
-                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1.Value, other._x._1.Value);
+                    return global::System.Collections.Generic.EqualityComparer<long>.Default.Equals(_x._1, other._x._1);
                 case 2:
-                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2.Value, other._x._2.Value);
+                    return global::System.Collections.Generic.EqualityComparer<double>.Default.Equals(_x._2, other._x._2);
                 case 3:
-                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3.Value, other._x._3.Value);
+                    return global::System.Collections.Generic.EqualityComparer<object>.Default.Equals(_x._3, other._x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_struct_nullable_enable");
             }
@@ -483,11 +443,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return 0;
                 case 1:
-                    return global::System.HashCode.Combine(_x._1.Value);
+                    return global::System.HashCode.Combine(_x._1);
                 case 2:
-                    return global::System.HashCode.Combine(_x._2.Value);
+                    return global::System.HashCode.Combine(_x._2);
                 case 3:
-                    return global::System.HashCode.Combine(_x._3.Value);
+                    return global::System.HashCode.Combine(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_struct_nullable_enable");
             }
@@ -500,7 +460,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="long"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out long l)
         {
-            l = _n == 1 ? _x._1.Value : default;
+            l = _n == 1 ? _x._1 : default;
             return _n == 1;
         }
 
@@ -514,7 +474,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
                 return true;
             }
             return false;
@@ -530,7 +490,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l = _x._1.Value;
+                l = _x._1;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "long", TypeString);
@@ -547,7 +507,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "long", TypeString);
@@ -564,7 +524,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                l(_x._1.Value);
+                l(_x._1);
             }
             else
             {
@@ -584,7 +544,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 1)
             {
-                return l(_x._1.Value);
+                return l(_x._1);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "long", TypeString);
         }
@@ -599,7 +559,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<long, TResult> l, TResult _)
         {
-            return _n == 1 ? l(_x._1.Value) : _;
+            return _n == 1 ? l(_x._1) : _;
         }
 
         /// <summary>
@@ -611,7 +571,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="l"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<long, TResult> l, global::System.Func<TResult> _)
         {
-            return _n == 1 ? l(_x._1.Value) : _();
+            return _n == 1 ? l(_x._1) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="double"/>.
@@ -620,7 +580,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="double"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out double d)
         {
-            d = _n == 2 ? _x._2.Value : default;
+            d = _n == 2 ? _x._2 : default;
             return _n == 2;
         }
 
@@ -634,7 +594,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
                 return true;
             }
             return false;
@@ -650,7 +610,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d = _x._2.Value;
+                d = _x._2;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "double", TypeString);
@@ -667,7 +627,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "double", TypeString);
@@ -684,7 +644,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                d(_x._2.Value);
+                d(_x._2);
             }
             else
             {
@@ -704,7 +664,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 2)
             {
-                return d(_x._2.Value);
+                return d(_x._2);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "double", TypeString);
         }
@@ -719,7 +679,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<double, TResult> d, TResult _)
         {
-            return _n == 2 ? d(_x._2.Value) : _;
+            return _n == 2 ? d(_x._2) : _;
         }
 
         /// <summary>
@@ -731,7 +691,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="d"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<double, TResult> d, global::System.Func<TResult> _)
         {
-            return _n == 2 ? d(_x._2.Value) : _();
+            return _n == 2 ? d(_x._2) : _();
         }
         /// <summary>
         /// Retrieve the value stored within Variant_struct_nullable_enable if it is of type <see cref="object"/>.
@@ -740,7 +700,7 @@ namespace dotVariant._G.Foo
         /// <returns><see langword="true"/> if Variant_struct_nullable_enable contained a value of type <see cref="object"/>.</returns>
         public bool TryMatch([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out object? o)
         {
-            o = _n == 3 ? _x._3.Value : default;
+            o = _n == 3 ? _x._3 : default;
             return _n == 3;
         }
 
@@ -754,7 +714,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
                 return true;
             }
             return false;
@@ -770,7 +730,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o = _x._3.Value;
+                o = _x._3;
                 return;
             }
             throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_struct_nullable_enable", "object", TypeString);
@@ -787,7 +747,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
                 return;
             }
             global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_struct_nullable_enable", "object", TypeString);
@@ -804,7 +764,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                o(_x._3.Value);
+                o(_x._3);
             }
             else
             {
@@ -824,7 +784,7 @@ namespace dotVariant._G.Foo
         {
             if (_n == 3)
             {
-                return o(_x._3.Value);
+                return o(_x._3);
             }
             return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_struct_nullable_enable", "object", TypeString);
         }
@@ -839,7 +799,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<object, TResult> o, TResult _)
         {
-            return _n == 3 ? o(_x._3.Value) : _;
+            return _n == 3 ? o(_x._3) : _;
         }
 
         /// <summary>
@@ -851,7 +811,7 @@ namespace dotVariant._G.Foo
         /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="o"/> or <paramref name="_"/> is rethrown.</exception>
         public TResult Match<TResult>(global::System.Func<object, TResult> o, global::System.Func<TResult> _)
         {
-            return _n == 3 ? o(_x._3.Value) : _();
+            return _n == 3 ? o(_x._3) : _();
         }
 
         /// <summary>
@@ -871,13 +831,13 @@ namespace dotVariant._G.Foo
                     _();
                     break;
                 case 1:
-                    l(_x._1.Value);
+                    l(_x._1);
                     break;
                 case 2:
-                    d(_x._2.Value);
+                    d(_x._2);
                     break;
                 case 3:
-                    o(_x._3.Value);
+                    o(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
@@ -902,13 +862,13 @@ namespace dotVariant._G.Foo
                     global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_struct_nullable_enable");
                     break;
                 case 1:
-                    l(_x._1.Value);
+                    l(_x._1);
                     break;
                 case 2:
-                    d(_x._2.Value);
+                    d(_x._2);
                     break;
                 case 3:
-                    o(_x._3.Value);
+                    o(_x._3);
                     break;
                 default:
                     global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_struct_nullable_enable");
@@ -933,11 +893,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return _();
                 case 1:
-                    return l(_x._1.Value);
+                    return l(_x._1);
                 case 2:
-                    return d(_x._2.Value);
+                    return d(_x._2);
                 case 3:
-                    return o(_x._3.Value);
+                    return o(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
             }
@@ -960,11 +920,11 @@ namespace dotVariant._G.Foo
                 case 0:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_struct_nullable_enable");
                 case 1:
-                    return l(_x._1.Value);
+                    return l(_x._1);
                 case 2:
-                    return d(_x._2.Value);
+                    return d(_x._2);
                 case 3:
-                    return o(_x._3.Value);
+                    return o(_x._3);
                 default:
                     return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_struct_nullable_enable");
             }

--- a/src/dotVariant.Generator/templates/Union.scriban-cs
+++ b/src/dotVariant.Generator/templates/Union.scriban-cs
@@ -115,7 +115,8 @@ it had to store all values side-by-side.
 ## ~}}
 {{~
 func $storage(param)
-    ret is_generic ? "_x._" + param.Index : "_x._" + param.Index + ".Value";
+    #ret is_generic ? "_x._" + param.Index : "_x._" + param.Index + ".Value";
+    ret "_x._" + param.Index;
 end
 ~}}
 {{~ ## STORAGE WRAPPER ## ~}}
@@ -131,7 +132,7 @@ namespace dotVariant._G{{ if Variant.Namespace; "." + Variant.Namespace; end }}
         where {{ $tp.Identifier }} : {{ array.join $tp.Constraints ", " }}
     {{~ end ~}}
     {
-        {{~ if !is_generic ~}}
+        {{~ if false #!is_generic ~}}
         {{~ ## NON-GENERIC UNION TYPE ## ~}}
         [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit)]
         private readonly struct Union

--- a/src/dotVariant.Test/Variants.cs
+++ b/src/dotVariant.Test/Variants.cs
@@ -43,6 +43,33 @@ namespace dotVariant.Test.Variants
         }
     }
 
+    [Variant]
+    public sealed partial class NestedValueTypeReferenceTypeMix
+    {
+        static partial void VariantOf(A a, B b, C c, D d, string s);
+
+        public struct A
+        {
+            public int I;
+            public string S;
+        }
+        public struct B
+        {
+            public string S;
+            public int I;
+        }
+        public struct C
+        {
+            public A A;
+            public B B;
+        }
+        public struct D
+        {
+            public B B;
+            public A A;
+        }
+    }
+
 #if NULLABLE_ENABLED
 
     [Variant]


### PR DESCRIPTION
Unfortunately it doesn't work in all cases and especially not with
transitive compound types, resulting in type load exceptions.

Need to come up with a more conservative layout compression algorithm.