### PR TITLE
Implemented NoImplicitConversionAttribute

### DIFF
--- a/src/dotVariant.Generator.Test/GeneratorTools.cs
+++ b/src/dotVariant.Generator.Test/GeneratorTools.cs
@@ -116,6 +116,7 @@ namespace dotVariant.Generator.Test
             new Dictionary<string, string>()
                 {
                     { "VariantAttribute.cs", LoadSample("VariantAttribute.cs") },
+                    { "NoImplicitConversionAttribute.cs", LoadSample("NoImplicitConversionAttribute.cs") },
                 }
                 .ToImmutableDictionary();
     }

--- a/src/dotVariant.Generator.Test/RenderInfo.Params.cs
+++ b/src/dotVariant.Generator.Test/RenderInfo.Params.cs
@@ -156,6 +156,16 @@ namespace dotVariant.Generator.Test
                     ri => Assert.That(ri.Params[0].EmitImplicitCast, Is.True)
                 ),
                 (
+                    "emit no implicit cast for explicitly attributed parameters",
+                    @"
+                    [dotVariant.Variant]
+                    public partial class Variant
+                    {
+                        static partial void VariantOf([dotVariant.NoImplicitConversion] int a);
+                    }",
+                    ri => Assert.That(ri.Params[0].EmitImplicitCast, Is.False)
+                ),
+                (
                     "emit no implicit cast for base types",
                     @"
                     [dotVariant.Variant]

--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -83,6 +83,7 @@ namespace dotVariant.Generator.Test
                     ("Variant-generic-unbounded", "Foo.Variant{T}"),
                     ("Variant-nullable-value-type", "Foo.Variant_nullable_value_type"),
                     ("Variant-public", "Foo.Variant_public"),
+                    ("Variant-no-implicit-conversion", "Foo.Variant_no_implicit_conversion"),
                     ("Variant-struct-nullable-disable", "Foo.Variant_struct_nullable_disable"),
                     ("Variant-struct-nullable-enable", "Foo.Variant_struct_nullable_enable"),
                 }

--- a/src/dotVariant.Generator.Test/diagnostics/NoImplicitConversionForBaseClasses.cs
+++ b/src/dotVariant.Generator.Test/diagnostics/NoImplicitConversionForBaseClasses.cs
@@ -9,3 +9,9 @@ partial class Variant1
 {
     static partial void VariantOf(int a, object b); // expected-warning:49 dotVariant.NoImplicitConversionForBaseClasses
 }
+
+[dotVariant.Variant]
+partial class Variant2
+{
+    static partial void VariantOf(int a, [dotVariant.NoImplicitConversion] object b);
+}

--- a/src/dotVariant.Generator.Test/diagnostics/NoImplicitConversionForInterfaces.cs
+++ b/src/dotVariant.Generator.Test/diagnostics/NoImplicitConversionForInterfaces.cs
@@ -9,3 +9,9 @@ partial class Variant1
 {
     static partial void VariantOf(int a, System.Collections.IEnumerable b); // expected-warning:73 dotVariant.NoImplicitConversionForInterfaces
 }
+
+[dotVariant.Variant]
+partial class Variant2
+{
+    static partial void VariantOf(int a, [dotVariant.NoImplicitConversion] System.Collections.IEnumerable b);
+}

--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="diagnostics/**/*" />
-    <EmbeddedResource Include="samples/**/*" />
+    <EmbeddedResource Include="samples/**/*" WithCulture="false" />
     <!--
       Embed the support sources so we don't have a dependency on the runtime library
       (which might contain generated code and fail to build while generator tests are failing)

--- a/src/dotVariant.Generator.Test/samples/Variant-no-implicit-conversion.in.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-no-implicit-conversion.in.cs
@@ -1,0 +1,16 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable disable
+
+namespace Foo
+{
+    [dotVariant.Variant]
+    partial class Variant_no_implicit_conversion
+    {
+        static partial void VariantOf([dotVariant.NoImplicitConversion] int i, string s);
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-no-implicit-conversion.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-no-implicit-conversion.out.cs
@@ -1,0 +1,1389 @@
+﻿//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable disable
+namespace Foo
+{
+    [global::System.Diagnostics.DebuggerTypeProxy(typeof(Variant_no_implicit_conversion.__DebuggerTypeProxy))]
+    [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
+    partial class Variant_no_implicit_conversion
+        : global::System.IEquatable<Variant_no_implicit_conversion>
+    {
+        private readonly global::dotVariant._G.Foo.Variant_no_implicit_conversion _variant;
+
+        /// <summary>
+        /// Create a Variant_no_implicit_conversion with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public Variant_no_implicit_conversion(int i)
+            => _variant = new global::dotVariant._G.Foo.Variant_no_implicit_conversion(i);
+        /// <summary>
+        /// Create a Variant_no_implicit_conversion with a value of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public Variant_no_implicit_conversion(string s)
+            => _variant = new global::dotVariant._G.Foo.Variant_no_implicit_conversion(s);
+
+        /// <summary>
+        /// Create a Variant_no_implicit_conversion with a value of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static implicit operator Variant_no_implicit_conversion(string s)
+            => new Variant_no_implicit_conversion(s);
+
+        /// <summary>
+        /// Create a Variant_no_implicit_conversion with a value of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static Variant_no_implicit_conversion Create(int i)
+            => new Variant_no_implicit_conversion(i);
+        /// <summary>
+        /// Create a Variant_no_implicit_conversion with a value of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static Variant_no_implicit_conversion Create(string s)
+            => new Variant_no_implicit_conversion(s);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool IsEmpty
+            => _variant.IsEmpty;
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Index"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public byte Index
+            => _variant.Index;
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override bool Equals(object other)
+            => other is Variant_no_implicit_conversion v
+            && Equals(v);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool Equals(Variant_no_implicit_conversion other)
+            => !(other is null) && _variant.Equals(other._variant);
+
+        /// <summary>Compare two Variant_no_implicit_conversion objects for equality.</summary>
+        /// <param name="lhs">The first <see cref="Variant_no_implicit_conversion" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant_no_implicit_conversion" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant_no_implicit_conversion)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator ==(Variant_no_implicit_conversion lhs, Variant_no_implicit_conversion rhs)
+            => lhs?.Equals(rhs) ?? (rhs is null);
+
+        /// <summary>Compare two Variant_no_implicit_conversion objects for inequality.</summary>
+        /// <param name="lhs">The first <see cref="Variant_no_implicit_conversion" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant_no_implicit_conversion" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are not considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant_no_implicit_conversion)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator !=(Variant_no_implicit_conversion lhs, Variant_no_implicit_conversion rhs)
+            => !(lhs == rhs);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override int GetHashCode()
+            => _variant.GetHashCode();
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override string ToString()
+            => _variant.ToString();
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.UnsafeGet(global::dotVariant.Accessor._1)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public int UnsafeGet(global::dotVariant.Accessor._1 accessor)
+            => _variant.UnsafeGet(accessor);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.TryMatch(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out int i)
+            => _variant.TryMatch(out i);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.TryMatch(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<int> i)
+            => _variant.TryMatch(i);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(out int)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out int i)
+            => _variant.Match(out i);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(global::System.Action{int})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<int> i)
+            => _variant.Match(i);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(global::System.Action{int}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<int> i, global::System.Action _)
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{int, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<int, TResult> i)
+            => _variant.Match(i);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{int, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{int, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+            => _variant.Match(i, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.UnsafeGet(global::dotVariant.Accessor._2)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public string UnsafeGet(global::dotVariant.Accessor._2 accessor)
+            => _variant.UnsafeGet(accessor);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.TryMatch(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out string s)
+            => _variant.TryMatch(out s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.TryMatch(global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<string> s)
+            => _variant.TryMatch(s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(out string)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out string s)
+            => _variant.Match(out s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match(global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<string> s, global::System.Action _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
+            => _variant.Match(s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{string, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+            => _variant.Match(s, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Match{TResult}(global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            => _variant.Match(s, _);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Visit(global::System.Action{int}, global::System.Action{string})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s)
+            => _variant.Visit(i, s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Visit(global::System.Action{int}, global::System.Action{string}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
+            => _variant.Visit(i, s, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{string, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
+            => _variant.Visit(i, s);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant_no_implicit_conversion.Visit{TResult}(global::System.Func{int, TResult}, global::System.Func{string, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+            => _variant.Visit(i, s, _);
+
+        private sealed class __DebuggerTypeProxy
+        {
+            public object Value { get; }
+            public __DebuggerTypeProxy(Variant_no_implicit_conversion v)
+            {
+                Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf(default, default);
+                #pragma warning restore 8604, 8625
+            }
+        }
+    }
+}
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+    internal readonly struct Variant_no_implicit_conversion
+    {
+        private readonly struct Union
+        {
+            public readonly int _1;
+            public Union(int value)
+            {
+                _2 = default;
+                _1 = value;
+            }
+            public readonly string _2;
+            public Union(string value)
+            {
+                _1 = default;
+                _2 = value;
+            }
+        }
+
+        private readonly Union _x;
+
+        /// <summary>
+        /// The 1-based index of the currently stored type,
+        /// counted left-ro-right from the <see cref="global::Foo.Variant_no_implicit_conversion.VariantOf"/> parameter list.
+        /// <c>0</c> if the variant is empty.
+        /// </summary>
+        public readonly byte Index;
+
+        public Variant_no_implicit_conversion(int i)
+        {
+            Index = 1;
+            _x = new Union(i);
+        }
+        public Variant_no_implicit_conversion(string s)
+        {
+            Index = 2;
+            _x = new Union(s);
+        }
+
+
+        /// <summary>
+        /// <see langword="true"/> if Variant_no_implicit_conversion was constructed without a value.
+        /// </summary>
+        public bool IsEmpty => this.Index == 0;
+
+        /// <summary>
+        /// The string representation of the stored value's type.
+        /// </summary>
+        public string TypeString
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "int";
+                    case 2:
+                        return "string";
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_no_implicit_conversion");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+        /// </summary>
+        public override string ToString()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return "";
+                case 1:
+                    return _x._1.ToString();
+                case 2:
+                    return _x._2?.ToString() ?? "null";
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant_no_implicit_conversion");
+            }
+        }
+
+        /// <summary>
+        /// The stored value cast to type <see cref="object"/>.
+        /// </summary>
+        public object AsObject
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1;
+                    case 2:
+                        return _x._2;
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object>("Foo.Variant_no_implicit_conversion");
+                }
+            }
+        }
+
+        public bool Equals(in Variant_no_implicit_conversion other)
+        {
+            if (this.Index != other.Index)
+            {
+                return false;
+            }
+            switch (Index)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<int>.Default.Equals(_x._1, other._x._1);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(_x._2, other._x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant_no_implicit_conversion");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return 0;
+                case 1:
+                    return global::System.HashCode.Combine(_x._1);
+                case 2:
+                    return global::System.HashCode.Combine(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant_no_implicit_conversion");
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the stored value assuming it is of type <see cref="int"/>.
+        ///
+        /// <b>Only call this if you have ensured that <c>Index == 1</c>,
+        /// otherwise the correctness of the returned value is not guaranteed,
+        /// nor that any value is returned at all.</b>
+        /// </summary>
+        public int UnsafeGet(global::dotVariant.Accessor._1 _)
+            => _x._1;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns><see langword="true"/> if Variant_no_implicit_conversion contained a value of type <see cref="int"/>.</returns>
+        public bool TryMatch(out int i)
+        {
+            i = this.Index == 1 ? _x._1 : default;
+            return this.Index == 1;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns><see langword="true"/> if Variant_no_implicit_conversion contained a value of type <see cref="int"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<int> i)
+        {
+            if (this.Index == 1)
+            {
+                i(_x._1);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">Receives the stored value if it is of type <see cref="int"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="int"/>.</exception>
+        public void Match(out int i)
+        {
+            if (this.Index == 1)
+            {
+                i = _x._1;
+                return;
+            }
+            throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_no_implicit_conversion", "int", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="int"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> is rethrown.</exception>
+        public void Match(global::System.Action<int> i)
+        {
+            if (this.Index == 1)
+            {
+                i(_x._1);
+                return;
+            }
+            global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_no_implicit_conversion", "int", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
+        public void Match(global::System.Action<int> i, global::System.Action _)
+        {
+            if (this.Index == 1)
+            {
+                i(_x._1);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="i"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="int"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i)
+        {
+            if (this.Index == 1)
+            {
+                return i(_x._1);
+            }
+            return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_no_implicit_conversion", "int", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="i"/>, or <paramref name="_"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, TResult _)
+        {
+            return this.Index == 1 ? i(_x._1) : _;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="int"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="i">The delegate to invoke with the stored value if it is of type <see cref="int"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="i"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<int, TResult> i, global::System.Func<TResult> _)
+        {
+            return this.Index == 1 ? i(_x._1) : _();
+        }
+        /// <summary>
+        /// Retrieve the stored value assuming it is of type <see cref="string"/>.
+        ///
+        /// <b>Only call this if you have ensured that <c>Index == 2</c>,
+        /// otherwise the correctness of the returned value is not guaranteed,
+        /// nor that any value is returned at all.</b>
+        /// </summary>
+        public string UnsafeGet(global::dotVariant.Accessor._2 _)
+            => _x._2;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns><see langword="true"/> if Variant_no_implicit_conversion contained a value of type <see cref="string"/>.</returns>
+        public bool TryMatch(out string s)
+        {
+            s = this.Index == 2 ? _x._2 : default;
+            return this.Index == 2;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/>.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns><see langword="true"/> if Variant_no_implicit_conversion contained a value of type <see cref="string"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<string> s)
+        {
+            if (this.Index == 2)
+            {
+                s(_x._2);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="s">Receives the stored value if it is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="string"/>.</exception>
+        public void Match(out string s)
+        {
+            if (this.Index == 2)
+            {
+                s = _x._2;
+                return;
+            }
+            throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant_no_implicit_conversion", "string", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="string"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> is rethrown.</exception>
+        public void Match(global::System.Action<string> s)
+        {
+            if (this.Index == 2)
+            {
+                s(_x._2);
+                return;
+            }
+            global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant_no_implicit_conversion", "string", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
+        public void Match(global::System.Action<string> s, global::System.Action _)
+        {
+            if (this.Index == 2)
+            {
+                s(_x._2);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="s"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion does not contain a value of type <see cref="string"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s)
+        {
+            if (this.Index == 2)
+            {
+                return s(_x._2);
+            }
+            return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant_no_implicit_conversion", "string", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="s"/>, or <paramref name="_"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, TResult _)
+        {
+            return this.Index == 2 ? s(_x._2) : _;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant_no_implicit_conversion if it is of type <see cref="string"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="s">The delegate to invoke with the stored value if it is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="s"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+        {
+            return this.Index == 2 ? s(_x._2) : _();
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_no_implicit_conversion,
+        /// and invoke a special delegate if Variant_no_implicit_conversion is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_no_implicit_conversion is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s, global::System.Action _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    i(_x._1);
+                    break;
+                case 2:
+                    s(_x._2);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_no_implicit_conversion");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_no_implicit_conversion,
+        /// and throw an exception if Variant_no_implicit_conversion is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<int> i, global::System.Action<string> s)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_no_implicit_conversion");
+                    break;
+                case 1:
+                    i(_x._1);
+                    break;
+                case 2:
+                    s(_x._2);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_no_implicit_conversion");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant_no_implicit_conversion and return the result,
+        /// and invoke a special delegate if Variant_no_implicit_conversion is empty and return its result.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant_no_implicit_conversion is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s, global::System.Func<TResult> _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return i(_x._1);
+                case 2:
+                    return s(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_no_implicit_conversion");
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant_no_implicit_conversion and return the result,
+        /// and throw an exception if Variant_no_implicit_conversion is empty.
+        /// </summary>
+        /// <param name="i">The delegate to invoke if the stored value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the stored value is of type <see cref="string"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant_no_implicit_conversion is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_no_implicit_conversion");
+                case 1:
+                    return i(_x._1);
+                case 2:
+                    return s(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_no_implicit_conversion");
+            }
+        }
+    }
+}
+
+
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
+    /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
+    /// </summary>
+    internal static partial class Variant_no_implicit_conversionEx
+    {
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and dropping all others.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and dropping all others.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i,
+                TResult _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s,
+                TResult _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="int"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="string"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException"/>
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant_no_implicit_conversion.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant_no_implicit_conversion");
+                        yield break;
+                    case 1:
+                        yield return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        yield return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_no_implicit_conversion");
+                        yield break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant_no_implicit_conversion-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        yield return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant_no_implicit_conversion");
+                        yield break;
+                }
+            }
+        }
+    }
+}
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
+    /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
+    /// </summary>
+    internal static partial class Variant_no_implicit_conversionEx
+    {
+        /// <summary>
+        /// Projects each <see cref="int"/> element of an observable sequence
+        /// into a new form and drops all other elements.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i)
+        {
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(_source, _variant => _variant.Index == 1),
+                _variant => i(_variant.UnsafeGet(new global::dotVariant.Accessor._1())));
+        }
+        /// <summary>
+        /// Projects each <see cref="string"/> element of an observable sequence
+        /// into a new form and drops all other elements.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s)
+        {
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(_source, _variant => _variant.Index == 2),
+                _variant => s(_variant.UnsafeGet(new global::dotVariant.Accessor._2())));
+        }
+
+        /// <summary>
+        /// Projects each <see cref="int"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback value.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i,
+                TResult _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _;
+                }
+            });
+        }
+        /// <summary>
+        /// Projects each <see cref="string"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback value.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s,
+                TResult _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 2)
+                {
+                    return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    return _;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each <see cref="int"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback selector result.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="i">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _();
+                }
+            });
+        }
+        /// <summary>
+        /// Projects each <see cref="string"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback selector result.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="s">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 2)
+                {
+                    return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    return _();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant_no_implicit_conversion");
+                    case 1:
+                        return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    case 2:
+                        return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_no_implicit_conversion");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="i">The delegate to invoke if the element's value is of type <see cref="int"/>.</param>
+        /// <param name="s">The delegate to invoke if the element's value is of type <see cref="string"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<int, TResult> i, global::System.Func<string, TResult> s,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return i(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    case 2:
+                        return s(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant_no_implicit_conversion");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant_no_implicit_conversion elements into one independent sub-sequences per value type,
+        /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>The first sub-sequence to produce an OnError message terminates the resulting sequence with OnError.</item>
+        ///     <item>When all sub-sequences terminate with OnCompleted (even before the source does) the resulting sequence terminates.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<string>, global::System.IObservable<TResult>> s)
+        {
+            return VisitMany(_source, (_1, _2) =>
+            {
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), s(_2));
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant_no_implicit_conversion elements into one independent sub-sequences per value type,
+        /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>The first sub-sequence to produce an OnError message terminates the resulting sequence with OnError.</item>
+        ///     <item>When all sub-sequences terminate with OnCompleted (even before the source does) the resulting sequence terminates.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="i">Transform an observable sequence of <see cref="int"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="s">Transform an observable sequence of <see cref="string"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<TResult>> i, global::System.Func<global::System.IObservable<string>, global::System.IObservable<TResult>> s,
+                global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
+        {
+            return VisitMany(_source, (_1, _2, _0) =>
+            {
+                return global::System.Reactive.Linq.Observable.Merge(i(_1), s(_2), _(_0));
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant_no_implicit_conversion elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver(false);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1, _mo.Subject2).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant_no_implicit_conversion elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult>(
+                this global::System.IObservable<global::Foo.Variant_no_implicit_conversion> _source,
+                global::System.Func<global::System.IObservable<int>, global::System.IObservable<string>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver(true);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1, _mo.Subject2, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        private sealed class VisitManyObserver
+            : global::System.IObserver<global::Foo.Variant_no_implicit_conversion>, global::System.IDisposable
+        {
+            public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
+            public readonly global::System.Reactive.Subjects.Subject<int> Subject1 = new global::System.Reactive.Subjects.Subject<int>();
+            public readonly global::System.Reactive.Subjects.Subject<string> Subject2 = new global::System.Reactive.Subjects.Subject<string>();
+            private readonly bool _accept0;
+
+            public VisitManyObserver(bool _accept0)
+            {
+                this._accept0 = _accept0;
+            }
+
+            public void Dispose()
+            {
+                Subject1.Dispose();
+                Subject2.Dispose();
+                Subject0.Dispose();
+            }
+
+            public void OnNext(global::Foo.Variant_no_implicit_conversion _variant)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        if (_accept0)
+                        {
+                            Subject0.OnNext(global::System.Reactive.Unit.Default);
+                        }
+                        else
+                        {
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant_no_implicit_conversion"));
+                        }
+                        break;
+                    case 1:
+                        Subject1.OnNext(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        Subject2.OnNext(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant_no_implicit_conversion"));
+                        break;
+                }
+            }
+
+            public void OnError(global::System.Exception _ex)
+            {
+                Subject1.OnError(_ex);
+                Subject2.OnError(_ex);
+                if (_accept0)
+                {
+                    Subject0.OnError(_ex);
+                }
+            }
+
+            public void OnCompleted()
+            {
+                Subject1.OnCompleted();
+                Subject2.OnCompleted();
+                if (_accept0)
+                {
+                    Subject0.OnCompleted();
+                }
+            }
+        }
+
+    }
+}

--- a/src/dotVariant.Generator/Diagnose.cs
+++ b/src/dotVariant.Generator/Diagnose.cs
@@ -211,6 +211,12 @@ namespace dotVariant.Generator
                 }
             }
 
+            private static bool CheckNoImplicitConversionAttribute(ISymbol p)
+            {
+                const string attributeName = nameof(dotVariant) + "." + nameof(NoImplicitConversionAttribute);
+                return !p.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attributeName);
+            }
+
             public static IEnumerable<Diagnostic> NoImplicitConversionForBaseClasses(
                 ITypeSymbol type,
                 MethodDeclarationSyntax syntax,
@@ -220,7 +226,7 @@ namespace dotVariant.Generator
             {
                 foreach (var p in options)
                 {
-                    if (Inspect.IsAncestorOf(p.Type, type))
+                    if (Inspect.IsAncestorOf(p.Type, type) && CheckNoImplicitConversionAttribute(p))
                     {
                         yield return MakeWarning(
                             nameof(NoImplicitConversionForBaseClasses),
@@ -240,7 +246,7 @@ namespace dotVariant.Generator
             {
                 foreach (var p in options)
                 {
-                    if (p.Type.TypeKind == TypeKind.Interface)
+                    if (p.Type.TypeKind == TypeKind.Interface && CheckNoImplicitConversionAttribute(p))
                     {
                         yield return MakeWarning(
                             nameof(NoImplicitConversionForInterfaces),

--- a/src/dotVariant.Generator/Diagnose.cs
+++ b/src/dotVariant.Generator/Diagnose.cs
@@ -211,12 +211,6 @@ namespace dotVariant.Generator
                 }
             }
 
-            private static bool CheckNoImplicitConversionAttribute(ISymbol p)
-            {
-                const string attributeName = nameof(dotVariant) + "." + nameof(NoImplicitConversionAttribute);
-                return !p.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attributeName);
-            }
-
             public static IEnumerable<Diagnostic> NoImplicitConversionForBaseClasses(
                 ITypeSymbol type,
                 MethodDeclarationSyntax syntax,
@@ -226,7 +220,7 @@ namespace dotVariant.Generator
             {
                 foreach (var p in options)
                 {
-                    if (Inspect.IsAncestorOf(p.Type, type) && CheckNoImplicitConversionAttribute(p))
+                    if (Inspect.IsAncestorOf(p.Type, type) && !Inspect.HasImplicitConversionDisabled(p))
                     {
                         yield return MakeWarning(
                             nameof(NoImplicitConversionForBaseClasses),
@@ -246,7 +240,7 @@ namespace dotVariant.Generator
             {
                 foreach (var p in options)
                 {
-                    if (p.Type.TypeKind == TypeKind.Interface && CheckNoImplicitConversionAttribute(p))
+                    if (p.Type.TypeKind == TypeKind.Interface && !Inspect.HasImplicitConversionDisabled(p))
                     {
                         yield return MakeWarning(
                             nameof(NoImplicitConversionForInterfaces),

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -97,6 +97,12 @@ namespace dotVariant.Generator
         public static int NumReferenceFields(IParameterSymbol param)
             => NumReferenceFields(param.Type);
 
+        public static bool HasImplicitConversionDisabled(IParameterSymbol param)
+        {
+            const string attributeName = nameof(dotVariant) + "." + nameof(NoImplicitConversionAttribute);
+            return param.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attributeName);
+        }
+
         public static int NumReferenceFields(ITypeSymbol type)
             => type.IsReferenceType
                 ? 1

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -201,13 +201,15 @@ namespace dotVariant.Generator
             var emitNullable = desc.NullableContext.HasFlag(NullableContext.AnnotationsEnabled);
             var disposable = compilation.GetTypeByMetadataName(typeof(IDisposable).FullName)!;
 
+            const string attributeName = nameof(dotVariant) + "." + nameof(NoImplicitConversionAttribute);
+
             var paramDescriptors =
                 desc
                 .Options
                 .Select((p, i) => new ParamInfo(
                     CanBeNull: CanBeNull(p, desc.NullableContext),
                     DiagType: p.Type.WithNullableAnnotation(p.NullableAnnotation).ToDisplayString(DiagFormat),
-                    EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type)),
+                    EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type) || p.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attributeName)),
                     Identifier: p.ToDisplayString(IdentifierFormat),
                     Index: i + 1,
                     IsDisposable: Implements(p, disposable),

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -201,15 +201,13 @@ namespace dotVariant.Generator
             var emitNullable = desc.NullableContext.HasFlag(NullableContext.AnnotationsEnabled);
             var disposable = compilation.GetTypeByMetadataName(typeof(IDisposable).FullName)!;
 
-            const string attributeName = nameof(dotVariant) + "." + nameof(NoImplicitConversionAttribute);
-
             var paramDescriptors =
                 desc
                 .Options
                 .Select((p, i) => new ParamInfo(
                     CanBeNull: CanBeNull(p, desc.NullableContext),
                     DiagType: p.Type.WithNullableAnnotation(p.NullableAnnotation).ToDisplayString(DiagFormat),
-                    EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type) || p.GetAttributes().Any(a => a.AttributeClass?.ToDisplayString() == attributeName)),
+                    EmitImplicitCast: !(p.Type.TypeKind == TypeKind.Interface || IsAncestorOf(p.Type, desc.Type) || HasImplicitConversionDisabled(p)),
                     Identifier: p.ToDisplayString(IdentifierFormat),
                     Index: i + 1,
                     IsDisposable: Implements(p, disposable),

--- a/src/dotVariant.Runtime/NoImplicitConversionAttribute.cs
+++ b/src/dotVariant.Runtime/NoImplicitConversionAttribute.cs
@@ -1,0 +1,16 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using System;
+
+namespace dotVariant
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public sealed class NoImplicitConversionAttribute : Attribute
+    {
+        public NoImplicitConversionAttribute() { }
+    }
+}


### PR DESCRIPTION
to prevent dotVariant from generating an implicit conversion for a union value.

* Changed samples embedded resources to work with current .Net 7 preview(it tried to embedded .in.cs files as indian language specific resource files)