### PR TITLE
Finer grained determination of visibility for extension methods

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/dotVariant.Generator.Test/GeneratorTools.cs
+++ b/src/dotVariant.Generator.Test/GeneratorTools.cs
@@ -21,7 +21,7 @@ namespace dotVariant.Generator.Test
 {
     internal static class GeneratorTools
     {
-        public static Dictionary<string, string> GetGeneratedOutput(IDictionary<string, string> sources, Func<ISourceGenerator> makeGenerator, bool failOnInvalidSource = false)
+        public static Dictionary<string, string> GetGeneratedOutput(IDictionary<string, string> sources, Func<IIncrementalGenerator> makeGenerator, bool failOnInvalidSource = false)
         {
             var compilation = Compile(sources);
 
@@ -41,10 +41,10 @@ namespace dotVariant.Generator.Test
         }
 
         public static Dictionary<string, string> GetGeneratedOutput<TGenerator>(IDictionary<string, string> sources, bool failOnInvalidSource = false)
-            where TGenerator : ISourceGenerator, new()
+            where TGenerator : IIncrementalGenerator, new()
             => GetGeneratedOutput(sources, () => new TGenerator(), failOnInvalidSource);
 
-        public static ImmutableArray<Diagnostic> GetGeneratorDiagnostics(IDictionary<string, string> sources, Func<ISourceGenerator> makeGenerator)
+        public static ImmutableArray<Diagnostic> GetGeneratorDiagnostics(IDictionary<string, string> sources, Func<IIncrementalGenerator> makeGenerator)
         {
             var compilation = Compile(sources);
 
@@ -57,7 +57,7 @@ namespace dotVariant.Generator.Test
         }
 
         public static ImmutableArray<Diagnostic> GetGeneratorDiagnostics<TGenerator>(IDictionary<string, string> sources)
-            where TGenerator : ISourceGenerator, new()
+            where TGenerator : IIncrementalGenerator, new()
             => GetGeneratorDiagnostics(sources, () => new TGenerator());
 
         public static CSharpCompilation Compile(

--- a/src/dotVariant.Generator.Test/RenderInfo.cs
+++ b/src/dotVariant.Generator.Test/RenderInfo.cs
@@ -22,12 +22,11 @@ namespace dotVariant.Generator.Test
         {
             var compilation = Compile(SupportSources.Add("input", source), version);
             var generator = new SourceGenerator();
-            var driver = CSharpGeneratorDriver.Create(
-                new[] { generator },
-                optionsProvider: new AnalyzerConfigOptionsProvider(msBuildProperties),
-                parseOptions: new CSharpParseOptions(version));
+            var driver = CSharpGeneratorDriver.Create(generator)
+                .WithUpdatedAnalyzerConfigOptions(new AnalyzerConfigOptionsProvider(msBuildProperties))
+                .WithUpdatedParseOptions(new CSharpParseOptions(version));
             _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out var _, out var _);
-            return generator.RenderInfos;
+            return generator.RenderInfos.ToImmutableArray();
         }
     }
 }

--- a/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
+++ b/src/dotVariant.Generator.Test/SourceGenerator.Test.cs
@@ -22,17 +22,21 @@ namespace dotVariant.Generator.Test
     internal static class SourceGenerator_Test
     {
         [TestCaseSource(nameof(TranslationCases))]
-        public static void Translation(string typeName, string fileName, string input, string expected)
+        public static void Translation(string[] typeNames, string fileName, string input, string expected)
         {
             var sources = SupportSources.Add("input", input);
             var outputs = GetGeneratedOutput<SourceGenerator>(sources, true);
-            var file =
-                Path.Combine(
-                    $"{typeof(SourceGenerator).Assembly.GetName().Name}",
-                    $"{typeof(SourceGenerator).FullName}",
-                    $"{typeName}.cs");
-            var output = outputs[file];
-            output = _copyrightHeader + output;
+
+            var output = _copyrightHeader;
+            foreach (var typeName in typeNames)
+            {
+                var file =
+                    Path.Combine(
+                        $"{typeof(SourceGenerator).Assembly.GetName().Name}",
+                        $"{typeof(SourceGenerator).FullName}",
+                        $"{typeName}.cs");
+                output += outputs[file];
+            }
 
             if (output != expected)
             {
@@ -69,23 +73,24 @@ namespace dotVariant.Generator.Test
         }
 
         public static IEnumerable<TestCaseData> TranslationCases()
-            => new (string FileName, string TypeName)[]
+            => new (string FileName, string[] TypeName)[]
                 {
-                    ("Variant-class-nullable-disable", "Foo.Variant_class_nullable_disable"),
-                    ("Variant-class-nullable-enable", "Foo.Variant_class_nullable_enable"),
-                    ("Variant-disposable", "Foo.Variant_disposable"),
-                    ("Variant-generic-class", "Foo.Variant{T}"),
-                    ("Variant-generic-class-nullable", "Foo.Variant{T}"),
-                    ("Variant-generic-multiple", "Foo.Variant{T1, T2, T3}"),
-                    ("Variant-generic-notnull", "Foo.Variant{T}"),
-                    ("Variant-generic-struct", "Foo.Variant{T}"),
-                    ("Variant-generic-T-as-nullable", "Foo.Variant{T1, T2, T3, T4, T5, T6}"),
-                    ("Variant-generic-unbounded", "Foo.Variant{T}"),
-                    ("Variant-nullable-value-type", "Foo.Variant_nullable_value_type"),
-                    ("Variant-public", "Foo.Variant_public"),
-                    ("Variant-no-implicit-conversion", "Foo.Variant_no_implicit_conversion"),
-                    ("Variant-struct-nullable-disable", "Foo.Variant_struct_nullable_disable"),
-                    ("Variant-struct-nullable-enable", "Foo.Variant_struct_nullable_enable"),
+                    ("Variant-class-nullable-disable",new[] {  "Foo.Variant_class_nullable_disable" }),
+                    ("Variant-class-nullable-enable", new[] { "Foo.Variant_class_nullable_enable" }),
+                    ("Variant-disposable", new[] { "Foo.Variant_disposable" }),
+                    ("Variant-generic-class", new[] { "Foo.Variant{T}" }),
+                    ("Variant-generic-class-nullable", new[] { "Foo.Variant{T}" }),
+                    ("Variant-generic-multiple", new[] { "Foo.Variant{T1, T2, T3}" }),
+                    ("Variant-generic-notnull", new[] { "Foo.Variant{T}" }),
+                    ("Variant-generic-struct", new[] { "Foo.Variant{T}" }),
+                    ("Variant-generic-T-as-nullable", new[] { "Foo.Variant{T1, T2, T3, T4, T5, T6}" }),
+                    ("Variant-generic-unbounded", new[] { "Foo.Variant{T}" }),
+                    ("Variant-nullable-value-type", new[] { "Foo.Variant_nullable_value_type" }),
+                    ("Variant-public", new[] { "Foo.Variant_public" }),
+                    ("Variant-no-implicit-conversion", new[] { "Foo.Variant_no_implicit_conversion" }),
+                    ("Variant-struct-nullable-disable", new[] { "Foo.Variant_struct_nullable_disable" }),
+                    ("Variant-struct-nullable-enable", new[] { "Foo.Variant_struct_nullable_enable" }),
+                    ("Variant-generic-same-name", new[] { "Foo.Variant{T}", "Foo.Variant{T1, T2}" })
                 }
                 .Select(
                     test => new TestCaseData(

--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="System.Interactive" Version="5.0.0" />

--- a/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
+++ b/src/dotVariant.Generator.Test/dotVariant.Generator.Test.csproj
@@ -6,13 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="System.Interactive" Version="5.0.0" />
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="System.Interactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
+    <PackageReference Include="Verify.NUnit" Version="20.4.0" />
+    <PackageReference Include="Verify.SourceGenerators" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-T-as-nullable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-T-as-nullable.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -1702,7 +1702,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T1_T2_T3_T4_T5_T6_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -2388,7 +2388,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T1_T2_T3_T4_T5_T6_Ex
     {
         /// <summary>
         /// Projects each <see cref="T1?"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-class-nullable.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-class-nullable.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -518,7 +518,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -679,7 +679,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Projects each <see cref="T"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-class.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-class.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -518,7 +518,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -679,7 +679,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Projects each <see cref="T"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-multiple.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-multiple.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -1017,7 +1017,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T1_T2_T3_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -1378,7 +1378,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T1_T2_T3_Ex
     {
         /// <summary>
         /// Projects each <see cref="T1"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-notnull.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-notnull.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -518,7 +518,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -679,7 +679,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Projects each <see cref="T"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-same-name.in.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-same-name.in.cs
@@ -1,0 +1,22 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable enable
+namespace Foo
+{
+    [dotVariant.Variant]
+    public partial class Variant<T>
+    {
+        static partial void VariantOf(T value);
+    }
+
+
+    [dotVariant.Variant]
+    internal partial class Variant<T1, T2>
+    {
+        static partial void VariantOf(T1 value1, T2 value2);
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-same-name.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-same-name.out.cs
@@ -1,0 +1,2354 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+#nullable enable
+namespace Foo
+{
+    [global::System.Diagnostics.DebuggerTypeProxy(typeof(Variant<>.__DebuggerTypeProxy))]
+    [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
+    partial class Variant<T>
+        : global::System.IEquatable<Variant<T>>
+    {
+        private readonly global::dotVariant._G.Foo.Variant<T> _variant;
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T"/>.
+        /// </summary>
+        /// <param name="value">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public Variant(T value)
+            => _variant = new global::dotVariant._G.Foo.Variant<T>(value);
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T"/>.
+        /// </summary>
+        /// <param name="value">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static implicit operator Variant<T>(T value)
+            => new Variant<T>(value);
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T"/>.
+        /// </summary>
+        /// <param name="value">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static Variant<T> Create(T value)
+            => new Variant<T>(value);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool IsEmpty
+            => _variant.IsEmpty;
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Index"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public byte Index
+            => _variant.Index;
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override bool Equals(object? other)
+            => other is Variant<T> v
+            && Equals(v);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool Equals(Variant<T>? other)
+            => !(other is null) && _variant.Equals(other._variant);
+
+        /// <summary>Compare two Variant<T> objects for equality.</summary>
+        /// <param name="lhs">The first <see cref="Variant<T>" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant<T>" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant<T>?)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator ==(Variant<T>? lhs, Variant<T>? rhs)
+            => lhs?.Equals(rhs) ?? (rhs is null);
+
+        /// <summary>Compare two Variant<T> objects for inequality.</summary>
+        /// <param name="lhs">The first <see cref="Variant<T>" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant<T>" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are not considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant<T>?)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator !=(Variant<T>? lhs, Variant<T>? rhs)
+            => !(lhs == rhs);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override int GetHashCode()
+            => _variant.GetHashCode();
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override string ToString()
+            => _variant.ToString();
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.UnsafeGet(global::dotVariant.Accessor._1)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public T UnsafeGet(global::dotVariant.Accessor._1 accessor)
+            => _variant.UnsafeGet(accessor);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.TryMatch(out T?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out T? value)
+            => _variant.TryMatch(out value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.TryMatch(global::System.Action{T})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<T> value)
+            => _variant.TryMatch(value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match(out T?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out T? value)
+            => _variant.Match(out value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match(global::System.Action{T})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T> value)
+            => _variant.Match(value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match(global::System.Action{T}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T> value, global::System.Action _)
+            => _variant.Match(value, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match{TResult}(global::System.Func{T, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T, TResult> value)
+            => _variant.Match(value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match{TResult}(global::System.Func{T, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T, TResult> value, TResult _)
+            => _variant.Match(value, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Match{TResult}(global::System.Func{T, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T, TResult> value, global::System.Func<TResult> _)
+            => _variant.Match(value, _);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Visit(global::System.Action{T})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<T> value)
+            => _variant.Visit(value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Visit(global::System.Action{T}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<T> value, global::System.Action _)
+            => _variant.Visit(value, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Visit{TResult}(global::System.Func{T, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<T, TResult> value)
+            => _variant.Visit(value);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T}.Visit{TResult}(global::System.Func{T, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<T, TResult> value, global::System.Func<TResult> _)
+            => _variant.Visit(value, _);
+
+        private sealed class __DebuggerTypeProxy
+        {
+            public object? Value { get; }
+            public __DebuggerTypeProxy(Variant<T> v)
+            {
+                Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf(default);
+                #pragma warning restore 8604, 8625
+            }
+        }
+    }
+}
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+    internal readonly struct Variant<T>
+    {
+        private readonly struct Union
+        {
+            public readonly T _1;
+            public Union(T value)
+            {
+                _1 = value;
+            }
+        }
+
+        private readonly Union _x;
+
+        /// <summary>
+        /// The 1-based index of the currently stored type,
+        /// counted left-ro-right from the <see cref="global::Foo.Variant{T}.VariantOf"/> parameter list.
+        /// <c>0</c> if the variant is empty.
+        /// </summary>
+        public readonly byte Index;
+
+        public Variant(T value)
+        {
+            Index = 1;
+            _x = new Union(value);
+        }
+
+
+        /// <summary>
+        /// <see langword="true"/> if Variant was constructed without a value.
+        /// </summary>
+        public bool IsEmpty => this.Index == 0;
+
+        /// <summary>
+        /// The string representation of the stored value's type.
+        /// </summary>
+        public string TypeString
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "T";
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant<T>");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+        /// </summary>
+        public override string ToString()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return "";
+                case 1:
+                    return _x._1?.ToString() ?? "null";
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant<T>");
+            }
+        }
+
+        /// <summary>
+        /// The stored value cast to type <see cref="object"/>.
+        /// </summary>
+        public object? AsObject
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1;
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant<T>");
+                }
+            }
+        }
+
+        public bool Equals(in Variant<T> other)
+        {
+            if (this.Index != other.Index)
+            {
+                return false;
+            }
+            switch (Index)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<T>.Default.Equals(_x._1, other._x._1);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant<T>");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return 0;
+                case 1:
+                    return global::System.HashCode.Combine(_x._1);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant<T>");
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the stored value assuming it is of type <see cref="T"/>.
+        ///
+        /// <b>Only call this if you have ensured that <c>Index == 1</c>,
+        /// otherwise the correctness of the returned value is not guaranteed,
+        /// nor that any value is returned at all.</b>
+        /// </summary>
+        public T UnsafeGet(global::dotVariant.Accessor._1 _)
+            => _x._1;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T"/>.
+        /// </summary>
+        /// <param name="value">Receives the stored value if it is of type <see cref="T"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T"/>.</returns>
+        public bool TryMatch(out T? value)
+        {
+            value = this.Index == 1 ? _x._1 : default;
+            return this.Index == 1;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/>.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<T> value)
+        {
+            if (this.Index == 1)
+            {
+                value(_x._1);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value">Receives the stored value if it is of type <see cref="T"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T"/>.</exception>
+        public void Match(out T? value)
+        {
+            if (this.Index == 1)
+            {
+                value = _x._1;
+                return;
+            }
+            throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant<T>", "T", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> is rethrown.</exception>
+        public void Match(global::System.Action<T> value)
+        {
+            if (this.Index == 1)
+            {
+                value(_x._1);
+                return;
+            }
+            global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant<T>", "T", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> or <paramref name="_"/> is rethrown.</exception>
+        public void Match(global::System.Action<T> value, global::System.Action _)
+        {
+            if (this.Index == 1)
+            {
+                value(_x._1);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="value"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T, TResult> value)
+        {
+            if (this.Index == 1)
+            {
+                return value(_x._1);
+            }
+            return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant<T>", "T", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="value"/>, or <paramref name="_"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T, TResult> value, TResult _)
+        {
+            return this.Index == 1 ? value(_x._1) : _;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="value">The delegate to invoke with the stored value if it is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T, TResult> value, global::System.Func<TResult> _)
+        {
+            return this.Index == 1 ? value(_x._1) : _();
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant,
+        /// and invoke a special delegate if Variant is empty.
+        /// </summary>
+        /// <param name="value">The delegate to invoke if the stored value is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<T> value, global::System.Action _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    value(_x._1);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T>");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant,
+        /// and throw an exception if Variant is empty.
+        /// </summary>
+        /// <param name="value">The delegate to invoke if the stored value is of type <see cref="T"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<T> value)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant<T>");
+                    break;
+                case 1:
+                    value(_x._1);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T>");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant and return the result,
+        /// and invoke a special delegate if Variant is empty and return its result.
+        /// </summary>
+        /// <param name="value">The delegate to invoke if the stored value is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<T, TResult> value, global::System.Func<TResult> _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return value(_x._1);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T>");
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant and return the result,
+        /// and throw an exception if Variant is empty.
+        /// </summary>
+        /// <param name="value">The delegate to invoke if the stored value is of type <see cref="T"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<T, TResult> value)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant<T>");
+                case 1:
+                    return value(_x._1);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T>");
+            }
+        }
+    }
+}
+
+
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
+    /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
+    /// </summary>
+    public static partial class Variant_T_Ex
+    {
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T"/> and dropping all others.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                TResult _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException"/>
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value">The delegate to invoke if the element's value is of type <see cref="T"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult, T>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant<T>");
+                        yield break;
+                    case 1:
+                        yield return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T>");
+                        yield break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value">The delegate to invoke if the element's value is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult, T>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T>");
+                        yield break;
+                }
+            }
+        }
+    }
+}
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
+    /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
+    /// </summary>
+    public static partial class Variant_T_Ex
+    {
+        /// <summary>
+        /// Projects each <see cref="T"/> element of an observable sequence
+        /// into a new form and drops all other elements.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value)
+        {
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(_source, _variant => _variant.Index == 1),
+                _variant => value(_variant.UnsafeGet(new global::dotVariant.Accessor._1())));
+        }
+
+        /// <summary>
+        /// Projects each <see cref="T"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback value.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                TResult _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each <see cref="T"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback selector result.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="value">The delegate to invoke if the element's value is of type <see cref="T"/>.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant<T>");
+                    case 1:
+                        return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T>");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="value">The delegate to invoke if the element's value is of type <see cref="T"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<T, TResult> value,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return value(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T>");
+                }
+            });
+        }
+
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>The first sub-sequence to produce an OnError message terminates the resulting sequence with OnError.</item>
+        ///     <item>When all sub-sequences terminate with OnCompleted (even before the source does) the resulting sequence terminates.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="value">Transform an observable sequence of <see cref="T"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<global::System.IObservable<T>, global::System.IObservable<TResult>> value,
+                global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
+        {
+            return VisitMany(_source, (_1, _0) =>
+            {
+                return global::System.Reactive.Linq.Observable.Merge(value(_1), _(_0));
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<global::System.IObservable<T>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver<T>(false);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T>(
+                this global::System.IObservable<global::Foo.Variant<T>> _source,
+                global::System.Func<global::System.IObservable<T>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver<T>(true);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        private sealed class VisitManyObserver<T>
+            : global::System.IObserver<global::Foo.Variant<T>>, global::System.IDisposable
+        {
+            public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
+            public readonly global::System.Reactive.Subjects.Subject<T> Subject1 = new global::System.Reactive.Subjects.Subject<T>();
+            private readonly bool _accept0;
+
+            public VisitManyObserver(bool _accept0)
+            {
+                this._accept0 = _accept0;
+            }
+
+            public void Dispose()
+            {
+                Subject1.Dispose();
+                Subject0.Dispose();
+            }
+
+            public void OnNext(global::Foo.Variant<T> _variant)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        if (_accept0)
+                        {
+                            Subject0.OnNext(global::System.Reactive.Unit.Default);
+                        }
+                        else
+                        {
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant<T>"));
+                        }
+                        break;
+                    case 1:
+                        Subject1.OnNext(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    default:
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant<T>"));
+                        break;
+                }
+            }
+
+            public void OnError(global::System.Exception _ex)
+            {
+                Subject1.OnError(_ex);
+                if (_accept0)
+                {
+                    Subject0.OnError(_ex);
+                }
+            }
+
+            public void OnCompleted()
+            {
+                Subject1.OnCompleted();
+                if (_accept0)
+                {
+                    Subject0.OnCompleted();
+                }
+            }
+        }
+
+    }
+}
+#nullable enable
+namespace Foo
+{
+    [global::System.Diagnostics.DebuggerTypeProxy(typeof(Variant<,>.__DebuggerTypeProxy))]
+    [global::System.Diagnostics.DebuggerDisplay("{_variant.AsObject}", Type = "{_variant.TypeString,nq}")]
+    partial class Variant<T1, T2>
+        : global::System.IEquatable<Variant<T1, T2>>
+    {
+        private readonly global::dotVariant._G.Foo.Variant<T1, T2> _variant;
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T1"/>.
+        /// </summary>
+        /// <param name="value1">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public Variant(T1 value1)
+            => _variant = new global::dotVariant._G.Foo.Variant<T1, T2>(value1);
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T2"/>.
+        /// </summary>
+        /// <param name="value2">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public Variant(T2 value2)
+            => _variant = new global::dotVariant._G.Foo.Variant<T1, T2>(value2);
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T1"/>.
+        /// </summary>
+        /// <param name="value1">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static implicit operator Variant<T1, T2>(T1 value1)
+            => new Variant<T1, T2>(value1);
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T2"/>.
+        /// </summary>
+        /// <param name="value2">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static implicit operator Variant<T1, T2>(T2 value2)
+            => new Variant<T1, T2>(value2);
+
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T1"/>.
+        /// </summary>
+        /// <param name="value1">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static Variant<T1, T2> Create(T1 value1)
+            => new Variant<T1, T2>(value1);
+        /// <summary>
+        /// Create a Variant with a value of type <see cref="T2"/>.
+        /// </summary>
+        /// <param name="value2">The value to initlaize the variant with.</param>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static Variant<T1, T2> Create(T2 value2)
+            => new Variant<T1, T2>(value2);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.IsEmpty"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool IsEmpty
+            => _variant.IsEmpty;
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Index"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public byte Index
+            => _variant.Index;
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override bool Equals(object? other)
+            => other is Variant<T1, T2> v
+            && Equals(v);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool Equals(Variant<T1, T2>? other)
+            => !(other is null) && _variant.Equals(other._variant);
+
+        /// <summary>Compare two Variant<T1, T2> objects for equality.</summary>
+        /// <param name="lhs">The first <see cref="Variant<T1, T2>" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant<T1, T2>" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant<T1, T2>?)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator ==(Variant<T1, T2>? lhs, Variant<T1, T2>? rhs)
+            => lhs?.Equals(rhs) ?? (rhs is null);
+
+        /// <summary>Compare two Variant<T1, T2> objects for inequality.</summary>
+        /// <param name="lhs">The first <see cref="Variant<T1, T2>" /> to compare.</param>
+        /// <param name="rhs">The second <see cref="Variant<T1, T2>" /> to compare.</param>
+        /// <returns><see langword="true" /> if <paramref name="lhs"/> and <paramref name="rhs"/> are not considered equal; otherwise, <see langword="false" />.</returns>
+        /// <seealso cref="Equals(Variant<T1, T2>?)" />
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public static bool operator !=(Variant<T1, T2>? lhs, Variant<T1, T2>? rhs)
+            => !(lhs == rhs);
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override int GetHashCode()
+            => _variant.GetHashCode();
+
+        /// <inheritdoc/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public override string ToString()
+            => _variant.ToString();
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.UnsafeGet(global::dotVariant.Accessor._1)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public T1 UnsafeGet(global::dotVariant.Accessor._1 accessor)
+            => _variant.UnsafeGet(accessor);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.TryMatch(out T1?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out T1? value1)
+            => _variant.TryMatch(out value1);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.TryMatch(global::System.Action{T1})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<T1> value1)
+            => _variant.TryMatch(value1);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(out T1?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out T1? value1)
+            => _variant.Match(out value1);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(global::System.Action{T1})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T1> value1)
+            => _variant.Match(value1);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(global::System.Action{T1}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T1> value1, global::System.Action _)
+            => _variant.Match(value1, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T1, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1)
+            => _variant.Match(value1);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T1, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1, TResult _)
+            => _variant.Match(value1, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T1, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<TResult> _)
+            => _variant.Match(value1, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.UnsafeGet(global::dotVariant.Accessor._2)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public T2 UnsafeGet(global::dotVariant.Accessor._2 accessor)
+            => _variant.UnsafeGet(accessor);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.TryMatch(out T2?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(out T2? value2)
+            => _variant.TryMatch(out value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.TryMatch(global::System.Action{T2})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public bool TryMatch(global::System.Action<T2> value2)
+            => _variant.TryMatch(value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(out T2?)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(out T2? value2)
+            => _variant.Match(out value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(global::System.Action{T2})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T2> value2)
+            => _variant.Match(value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match(global::System.Action{T2}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Match(global::System.Action<T2> value2, global::System.Action _)
+            => _variant.Match(value2, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T2, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2)
+            => _variant.Match(value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T2, TResult}, TResult)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2, TResult _)
+            => _variant.Match(value2, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Match{TResult}(global::System.Func{T2, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2, global::System.Func<TResult> _)
+            => _variant.Match(value2, _);
+
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Visit(global::System.Action{T1}, global::System.Action{T2})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<T1> value1, global::System.Action<T2> value2)
+            => _variant.Visit(value1, value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Visit(global::System.Action{T1}, global::System.Action{T2}, global::System.Action)"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public void Visit(global::System.Action<T1> value1, global::System.Action<T2> value2, global::System.Action _)
+            => _variant.Visit(value1, value2, _);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Visit{TResult}(global::System.Func{T1, TResult}, global::System.Func{T2, TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2)
+            => _variant.Visit(value1, value2);
+
+        /// <inheritdoc cref="global::dotVariant._G.Foo.Variant{T1, T2}.Visit{TResult}(global::System.Func{T1, TResult}, global::System.Func{T2, TResult}, global::System.Func{TResult})"/>
+        [global::System.Diagnostics.DebuggerNonUserCode]
+        public TResult Visit<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2, global::System.Func<TResult> _)
+            => _variant.Visit(value1, value2, _);
+
+        private sealed class __DebuggerTypeProxy
+        {
+            public object? Value { get; }
+            public __DebuggerTypeProxy(Variant<T1, T2> v)
+            {
+                Value = v._variant.AsObject;
+                #pragma warning disable 8604 // Possible null reference argument for parameter
+                #pragma warning disable 8625 // Cannot convert null literal to non-nullable reference type
+                VariantOf(default, default);
+                #pragma warning restore 8604, 8625
+            }
+        }
+    }
+}
+
+namespace dotVariant._G.Foo
+{
+    [global::System.Diagnostics.DebuggerNonUserCode]
+    [global::System.Diagnostics.DebuggerDisplay("{AsObject}", Type = "{TypeString,nq}")]
+    internal readonly struct Variant<T1, T2>
+    {
+        private readonly struct Union
+        {
+            public readonly T1 _1;
+            public Union(T1 value)
+            {
+                _2 = default!;
+                _1 = value;
+            }
+            public readonly T2 _2;
+            public Union(T2 value)
+            {
+                _1 = default!;
+                _2 = value;
+            }
+        }
+
+        private readonly Union _x;
+
+        /// <summary>
+        /// The 1-based index of the currently stored type,
+        /// counted left-ro-right from the <see cref="global::Foo.Variant{T1, T2}.VariantOf"/> parameter list.
+        /// <c>0</c> if the variant is empty.
+        /// </summary>
+        public readonly byte Index;
+
+        public Variant(T1 value1)
+        {
+            Index = 1;
+            _x = new Union(value1);
+        }
+        public Variant(T2 value2)
+        {
+            Index = 2;
+            _x = new Union(value2);
+        }
+
+
+        /// <summary>
+        /// <see langword="true"/> if Variant was constructed without a value.
+        /// </summary>
+        public bool IsEmpty => this.Index == 0;
+
+        /// <summary>
+        /// The string representation of the stored value's type.
+        /// </summary>
+        public string TypeString
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return "<empty>";
+                    case 1:
+                        return "T1";
+                    case 2:
+                        return "T2";
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant<T1, T2>");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The stored value's <see cref="object.ToString()"/> result, or <c>""</c> if empty.
+        /// </summary>
+        public override string ToString()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return "";
+                case 1:
+                    return _x._1?.ToString() ?? "null";
+                case 2:
+                    return _x._2?.ToString() ?? "null";
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<string>("Foo.Variant<T1, T2>");
+            }
+        }
+
+        /// <summary>
+        /// The stored value cast to type <see cref="object"/>.
+        /// </summary>
+        public object? AsObject
+        {
+            get
+            {
+                switch (this.Index)
+                {
+                    case 0:
+                        return null;
+                    case 1:
+                        return _x._1;
+                    case 2:
+                        return _x._2;
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<object?>("Foo.Variant<T1, T2>");
+                }
+            }
+        }
+
+        public bool Equals(in Variant<T1, T2> other)
+        {
+            if (this.Index != other.Index)
+            {
+                return false;
+            }
+            switch (Index)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return global::System.Collections.Generic.EqualityComparer<T1>.Default.Equals(_x._1, other._x._1);
+                case 2:
+                    return global::System.Collections.Generic.EqualityComparer<T2>.Default.Equals(_x._2, other._x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<bool>("Foo.Variant<T1, T2>");
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return 0;
+                case 1:
+                    return global::System.HashCode.Combine(_x._1);
+                case 2:
+                    return global::System.HashCode.Combine(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<int>("Foo.Variant<T1, T2>");
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the stored value assuming it is of type <see cref="T1"/>.
+        ///
+        /// <b>Only call this if you have ensured that <c>Index == 1</c>,
+        /// otherwise the correctness of the returned value is not guaranteed,
+        /// nor that any value is returned at all.</b>
+        /// </summary>
+        public T1 UnsafeGet(global::dotVariant.Accessor._1 _)
+            => _x._1;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T1"/>.
+        /// </summary>
+        /// <param name="value1">Receives the stored value if it is of type <see cref="T1"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T1"/>.</returns>
+        public bool TryMatch(out T1? value1)
+        {
+            value1 = this.Index == 1 ? _x._1 : default;
+            return this.Index == 1;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/>.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T1"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<T1> value1)
+        {
+            if (this.Index == 1)
+            {
+                value1(_x._1);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T1"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value1">Receives the stored value if it is of type <see cref="T1"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T1"/>.</exception>
+        public void Match(out T1? value1)
+        {
+            if (this.Index == 1)
+            {
+                value1 = _x._1;
+                return;
+            }
+            throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant<T1, T2>", "T1", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T1"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> is rethrown.</exception>
+        public void Match(global::System.Action<T1> value1)
+        {
+            if (this.Index == 1)
+            {
+                value1(_x._1);
+                return;
+            }
+            global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant<T1, T2>", "T1", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> or <paramref name="_"/> is rethrown.</exception>
+        public void Match(global::System.Action<T1> value1, global::System.Action _)
+        {
+            if (this.Index == 1)
+            {
+                value1(_x._1);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="value1"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T1"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1)
+        {
+            if (this.Index == 1)
+            {
+                return value1(_x._1);
+            }
+            return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant<T1, T2>", "T1", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="value1"/>, or <paramref name="_"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1, TResult _)
+        {
+            return this.Index == 1 ? value1(_x._1) : _;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T1"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke with the stored value if it is of type <see cref="T1"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value1"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<TResult> _)
+        {
+            return this.Index == 1 ? value1(_x._1) : _();
+        }
+        /// <summary>
+        /// Retrieve the stored value assuming it is of type <see cref="T2"/>.
+        ///
+        /// <b>Only call this if you have ensured that <c>Index == 2</c>,
+        /// otherwise the correctness of the returned value is not guaranteed,
+        /// nor that any value is returned at all.</b>
+        /// </summary>
+        public T2 UnsafeGet(global::dotVariant.Accessor._2 _)
+            => _x._2;
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T2"/>.
+        /// </summary>
+        /// <param name="value2">Receives the stored value if it is of type <see cref="T2"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T2"/>.</returns>
+        public bool TryMatch(out T2? value2)
+        {
+            value2 = this.Index == 2 ? _x._2 : default;
+            return this.Index == 2;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/>.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <returns><see langword="true"/> if Variant contained a value of type <see cref="T2"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> is rethrown.</exception>
+        public bool TryMatch(global::System.Action<T2> value2)
+        {
+            if (this.Index == 2)
+            {
+                value2(_x._2);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieve the value stored within Variant if it is of type <see cref="T2"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value2">Receives the stored value if it is of type <see cref="T2"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T2"/>.</exception>
+        public void Match(out T2? value2)
+        {
+            if (this.Index == 2)
+            {
+                value2 = _x._2;
+                return;
+            }
+            throw global::dotVariant.GeneratorSupport.Errors.MakeMismatchError("Foo.Variant<T1, T2>", "T2", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/>,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T2"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> is rethrown.</exception>
+        public void Match(global::System.Action<T2> value2)
+        {
+            if (this.Index == 2)
+            {
+                value2(_x._2);
+                return;
+            }
+            global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError("Foo.Variant<T1, T2>", "T2", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/>,
+        /// otherwise invoke an alternative delegate.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> or <paramref name="_"/> is rethrown.</exception>
+        public void Match(global::System.Action<T2> value2, global::System.Action _)
+        {
+            if (this.Index == 2)
+            {
+                value2(_x._2);
+            }
+            else
+            {
+                _();
+            }
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/> and return the result,
+        /// otherwise throw <see cref="global::System.InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <returns>The value returned from invoking <paramref name="value2"/>.</returns>
+        /// <exception cref="global::System.InvalidOperationException">Variant does not contain a value of type <see cref="T2"/>.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2)
+        {
+            if (this.Index == 2)
+            {
+                return value2(_x._2);
+            }
+            return global::dotVariant.GeneratorSupport.Errors.ThrowMismatchError<TResult>("Foo.Variant<T1, T2>", "T2", TypeString);
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/> and return the result,
+        /// otherwise return a provided value.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <param name="_">The value to return if the stored value is of a different type.</param>
+        /// <returns>The value returned from invoking <paramref name="value2"/>, or <paramref name="_"/>.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2, TResult _)
+        {
+            return this.Index == 2 ? value2(_x._2) : _;
+        }
+
+        /// <summary>
+        /// Invoke a delegate with the value stored within Variant if it is of type <see cref="T2"/> and return the result,
+        /// otherwise invoke an alternative delegate and return its result.
+        /// </summary>
+        /// <param name="value2">The delegate to invoke with the stored value if it is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if the stored value is of a different type.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from <paramref name="value2"/> or <paramref name="_"/> is rethrown.</exception>
+        public TResult Match<TResult>(global::System.Func<T2, TResult> value2, global::System.Func<TResult> _)
+        {
+            return this.Index == 2 ? value2(_x._2) : _();
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant,
+        /// and invoke a special delegate if Variant is empty.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke if the stored value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the stored value is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<T1> value1, global::System.Action<T2> value2, global::System.Action _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    _();
+                    break;
+                case 1:
+                    value1(_x._1);
+                    break;
+                case 2:
+                    value2(_x._2);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T1, T2>");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant,
+        /// and throw an exception if Variant is empty.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke if the stored value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the stored value is of type <see cref="T2"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        public void Visit(global::System.Action<T1> value1, global::System.Action<T2> value2)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant<T1, T2>");
+                    break;
+                case 1:
+                    value1(_x._1);
+                    break;
+                case 2:
+                    value2(_x._2);
+                    break;
+                default:
+                    global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T1, T2>");
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of type of the value stored within Variant and return the result,
+        /// and invoke a special delegate if Variant is empty and return its result.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke if the stored value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the stored value is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if Variant is empty.</param>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2, global::System.Func<TResult> _)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return _();
+                case 1:
+                    return value1(_x._1);
+                case 2:
+                    return value2(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T1, T2>");
+            }
+        }
+
+        /// <summary>
+        /// Invoke the delegate whose parameter type matches that of the value stored within Variant and return the result,
+        /// and throw an exception if Variant is empty.
+        /// </summary>
+        /// <param name="value1">The delegate to invoke if the stored value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the stored value is of type <see cref="T2"/>.</param>
+        /// <exception cref="global::System.InvalidOperationException">Variant is empty.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The return type of all delegates, and by extension the return type of this function.</typeparam>
+        public TResult Visit<TResult>(global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2)
+        {
+            switch (this.Index)
+            {
+                case 0:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant<T1, T2>");
+                case 1:
+                    return value1(_x._1);
+                case 2:
+                    return value2(_x._2);
+                default:
+                    return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T1, T2>");
+            }
+        }
+    }
+}
+
+
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
+    /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
+    /// </summary>
+    internal static partial class Variant_T1_T2_Ex
+    {
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T1"/> and dropping all others.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T2"/> and dropping all others.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T1"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1,
+                TResult _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T2"/> and replacing all others by a fallback value.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2,
+                TResult _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    yield return _;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T1"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 1)
+                {
+                    yield return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
+        /// containing a value of type <see cref="T2"/> and replacing all others with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                if (_variant.Index == 2)
+                {
+                    yield return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    yield return _();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and throwing <see cref="global::System.InvalidOperationException"/>
+        /// if an element is empty.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value1">The delegate to invoke if the element's value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the element's value is of type <see cref="T2"/>.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.InvalidOperationException">The sequence encountered an empty Variant.</exception>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError("Foo.Variant<T1, T2>");
+                        yield break;
+                    case 1:
+                        yield return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        yield return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T1, T2>");
+                        yield break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Transform a Variant-based enumerable sequence by applying a selector function to each element
+        /// wich matches the type stored within the value, and replacing empty elements with the result of a fallback selector.
+        /// </summary>
+        /// <param name="_source">An enumerable sequence whose elements to match on.</param>
+        /// <param name="value1">The delegate to invoke if the element's value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the element's value is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An enumerable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <exception cref="global::System.Exception">Any exception thrown from a delegate is rethrown.</exception>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.Collections.Generic.IEnumerable<TResult>
+            Visit<TResult, T1, T2>(
+                this global::System.Collections.Generic.IEnumerable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2,
+                global::System.Func<TResult> _)
+        {
+            foreach (var _variant in _source)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        yield return _();
+                        break;
+                    case 1:
+                        yield return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        yield return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        global::dotVariant.GeneratorSupport.Errors.ThrowInternalError("Foo.Variant<T1, T2>");
+                        yield break;
+                }
+            }
+        }
+    }
+}
+namespace Foo
+{
+    /// <summary>
+    /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
+    /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
+    /// </summary>
+    internal static partial class Variant_T1_T2_Ex
+    {
+        /// <summary>
+        /// Projects each <see cref="T1"/> element of an observable sequence
+        /// into a new form and drops all other elements.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1)
+        {
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(_source, _variant => _variant.Index == 1),
+                _variant => value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1())));
+        }
+        /// <summary>
+        /// Projects each <see cref="T2"/> element of an observable sequence
+        /// into a new form and drops all other elements.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2)
+        {
+            return global::System.Reactive.Linq.Observable.Select(
+                global::System.Reactive.Linq.Observable.Where(_source, _variant => _variant.Index == 2),
+                _variant => value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2())));
+        }
+
+        /// <summary>
+        /// Projects each <see cref="T1"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback value.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1,
+                TResult _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _;
+                }
+            });
+        }
+        /// <summary>
+        /// Projects each <see cref="T2"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback value.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2,
+                TResult _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 2)
+                {
+                    return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    return _;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each <see cref="T1"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback selector result.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value1">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 1)
+                {
+                    return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                }
+                else
+                {
+                    return _();
+                }
+            });
+        }
+        /// <summary>
+        /// Projects each <see cref="T2"/> element of an observable sequence
+        /// into a new form and replaces all other elements by a fallback selector result.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to match on.</param>
+        /// <param name="value2">Function applied to matching elements and whose value to surface from the resulting sequence.</param>
+        /// <param name="_">Value to produce for elements which do not match the desired type.</param>
+        /// <returns>An observable sequence that contains the matched and transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Match<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T2, TResult> value2,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                if (_variant.Index == 2)
+                {
+                    return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                }
+                else
+                {
+                    return _();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="value1">The delegate to invoke if the element's value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the element's value is of type <see cref="T2"/>.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowEmptyError<TResult>("Foo.Variant<T1, T2>");
+                    case 1:
+                        return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    case 2:
+                        return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T1, T2>");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Projects each element of an observable sequence into a new form depending on its contained value type,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <param name="_source">An observable sequence whose elements to visit.</param>
+        /// <param name="value1">The delegate to invoke if the element's value is of type <see cref="T1"/>.</param>
+        /// <param name="value2">The delegate to invoke if the element's value is of type <see cref="T2"/>.</param>
+        /// <param name="_">The delegate to invoke if an element is empty.</param>
+        /// <returns>An observable sequence that contains the transformed elements of the input sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            Visit<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<T1, TResult> value1, global::System.Func<T2, TResult> value2,
+                global::System.Func<TResult> _)
+        {
+            return global::System.Reactive.Linq.Observable.Select(_source, _variant =>
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        return _();
+                    case 1:
+                        return value1(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                    case 2:
+                        return value2(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                    default:
+                        return global::dotVariant.GeneratorSupport.Errors.ThrowInternalError<TResult>("Foo.Variant<T1, T2>");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>The first sub-sequence to produce an OnError message terminates the resulting sequence with OnError.</item>
+        ///     <item>When all sub-sequences terminate with OnCompleted (even before the source does) the resulting sequence terminates.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="value1">Transform an observable sequence of <see cref="T1"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="value2">Transform an observable sequence of <see cref="T2"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<global::System.IObservable<T1>, global::System.IObservable<TResult>> value1, global::System.Func<global::System.IObservable<T2>, global::System.IObservable<TResult>> value2)
+        {
+            return VisitMany(_source, (_1, _2) =>
+            {
+                return global::System.Reactive.Linq.Observable.Merge(value1(_1), value2(_2));
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// transforming each sub-sequence by the provided selector, and merges the resulting values into one observable sequence.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>The first sub-sequence to produce an OnError message terminates the resulting sequence with OnError.</item>
+        ///     <item>When all sub-sequences terminate with OnCompleted (even before the source does) the resulting sequence terminates.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="value1">Transform an observable sequence of <see cref="T1"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="value2">Transform an observable sequence of <see cref="T2"/> values into an observable sequence of <typeparamref name="TResult"/> values.</param>
+        /// <param name="_">Transform a sequence of <see cref="global::System.Reactive.Unit"/> values (each representing an empty variant) into a sequence of <typeparamref name="TResult"/> values.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<global::System.IObservable<T1>, global::System.IObservable<TResult>> value1, global::System.Func<global::System.IObservable<T2>, global::System.IObservable<TResult>> value2,
+                global::System.Func<global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _)
+        {
+            return VisitMany(_source, (_1, _2, _0) =>
+            {
+                return global::System.Reactive.Linq.Observable.Merge(value1(_1), value2(_2), _(_0));
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector,
+        /// failing with <see cref="global::System.InvalidOperationException"/> if an element is empty.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<global::System.IObservable<T1>, global::System.IObservable<T2>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver<T1, T2>(false);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1, _mo.Subject2).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        /// <summary>
+        /// Splits the observable sequence of Variant elements into one independent sub-sequences per value type,
+        /// and combines the resulting values into one observable sequence according to the combining selector.
+        /// </summary>
+        /// <remarks>
+        /// <list type="bullet">
+        ///     <item>While the subscription to the source is active the sub-sequences are hot.</item>
+        ///     <item>Multiple subscriptions and repeated subscriptions within the sub-sequences will not cause repeated subscriptions to the source.</item>
+        ///     <item>Once the source sequence terminates it cannot be re-subscribed to with operators like <c>Repeat</c> or <c>Retry</c> from within a sub-sequence.</item>
+        ///     <item>How termination (successful or error) of sub-sequences affects the resulting sequence depends on the combining operation.</item>
+        /// </list>
+        /// </remarks>
+        /// <param name="_source">An observable sequence whose elements to split into sub-sequences.</param>
+        /// <param name="_selector">Combine the individual sub-sequences into one resulting sequence.</param>
+        /// <returns>An observable sequence that contains the elements of all sub-sequence.</returns>
+        /// <typeparam name="TResult">The resulting sequence's element type.</typeparam>
+        public static global::System.IObservable<TResult>
+            VisitMany<TResult, T1, T2>(
+                this global::System.IObservable<global::Foo.Variant<T1, T2>> _source,
+                global::System.Func<global::System.IObservable<T1>, global::System.IObservable<T2>, global::System.IObservable<global::System.Reactive.Unit>, global::System.IObservable<TResult>> _selector)
+        {
+            return global::System.Reactive.Linq.Observable.Create<TResult>(_o =>
+            {
+                var _mo = new VisitManyObserver<T1, T2>(true);
+                return global::System.Reactive.Disposables.StableCompositeDisposable.Create(
+                    _selector(_mo.Subject1, _mo.Subject2, _mo.Subject0).Subscribe(_o),
+                    global::System.ObservableExtensions.SubscribeSafe(_source, _mo),
+                    _mo);
+            });
+        }
+
+        private sealed class VisitManyObserver<T1, T2>
+            : global::System.IObserver<global::Foo.Variant<T1, T2>>, global::System.IDisposable
+        {
+            public readonly global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit> Subject0 = new global::System.Reactive.Subjects.Subject<global::System.Reactive.Unit>();
+            public readonly global::System.Reactive.Subjects.Subject<T1> Subject1 = new global::System.Reactive.Subjects.Subject<T1>();
+            public readonly global::System.Reactive.Subjects.Subject<T2> Subject2 = new global::System.Reactive.Subjects.Subject<T2>();
+            private readonly bool _accept0;
+
+            public VisitManyObserver(bool _accept0)
+            {
+                this._accept0 = _accept0;
+            }
+
+            public void Dispose()
+            {
+                Subject1.Dispose();
+                Subject2.Dispose();
+                Subject0.Dispose();
+            }
+
+            public void OnNext(global::Foo.Variant<T1, T2> _variant)
+            {
+                switch (_variant.Index)
+                {
+                    case 0:
+                        if (_accept0)
+                        {
+                            Subject0.OnNext(global::System.Reactive.Unit.Default);
+                        }
+                        else
+                        {
+                            OnError(global::dotVariant.GeneratorSupport.Errors.MakeEmptyError("Foo.Variant<T1, T2>"));
+                        }
+                        break;
+                    case 1:
+                        Subject1.OnNext(_variant.UnsafeGet(new global::dotVariant.Accessor._1()));
+                        break;
+                    case 2:
+                        Subject2.OnNext(_variant.UnsafeGet(new global::dotVariant.Accessor._2()));
+                        break;
+                    default:
+                        OnError(global::dotVariant.GeneratorSupport.Errors.MakeInternalError("Foo.Variant<T1, T2>"));
+                        break;
+                }
+            }
+
+            public void OnError(global::System.Exception _ex)
+            {
+                Subject1.OnError(_ex);
+                Subject2.OnError(_ex);
+                if (_accept0)
+                {
+                    Subject0.OnError(_ex);
+                }
+            }
+
+            public void OnCompleted()
+            {
+                Subject1.OnCompleted();
+                Subject2.OnCompleted();
+                if (_accept0)
+                {
+                    Subject0.OnCompleted();
+                }
+            }
+        }
+
+    }
+}

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-struct.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-struct.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -518,7 +518,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -679,7 +679,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Projects each <see cref="T"/> element of an observable sequence

--- a/src/dotVariant.Generator.Test/samples/Variant-generic-unbounded.out.cs
+++ b/src/dotVariant.Generator.Test/samples/Variant-generic-unbounded.out.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -517,7 +517,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Transform a Variant-based enumerable sequence by applying a selector function to those elements
@@ -673,7 +673,7 @@ namespace Foo
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    public static partial class VariantEx
+    public static partial class Variant_T_Ex
     {
         /// <summary>
         /// Projects each <see cref="T"/> element of an observable sequence

--- a/src/dotVariant.Generator/CompilationInfo.cs
+++ b/src/dotVariant.Generator/CompilationInfo.cs
@@ -1,0 +1,22 @@
+﻿//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace dotVariant.Generator;
+
+public readonly record struct CompilationInfo(LanguageVersion LanguageVersion, bool HasReactive,
+    INamedTypeSymbol DisposableInterface, bool HasHashCode)
+{
+    public static CompilationInfo FromCompilation(CSharpCompilation compilation)
+    {
+        var hasReactive = compilation.GetTypeByMetadataName("System.Reactive.Linq.Observable") is not null;
+        var disposableInterface = compilation.GetTypeByMetadataName("System.IDisposable")!;
+        var hasHashCode = compilation.GetTypeByMetadataName("System.HashCode") is not null;
+        return new(compilation.LanguageVersion, hasReactive, disposableInterface, hasHashCode);
+    }
+}

--- a/src/dotVariant.Generator/CompilationInfo.cs
+++ b/src/dotVariant.Generator/CompilationInfo.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -6,6 +6,7 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using System;
 
 namespace dotVariant.Generator;
 
@@ -15,7 +16,7 @@ public readonly record struct CompilationInfo(LanguageVersion LanguageVersion, b
     public static CompilationInfo FromCompilation(CSharpCompilation compilation)
     {
         var hasReactive = compilation.GetTypeByMetadataName("System.Reactive.Linq.Observable") is not null;
-        var disposableInterface = compilation.GetTypeByMetadataName("System.IDisposable")!;
+        var disposableInterface = compilation.GetTypeByMetadataName(typeof(IDisposable).FullName)!;
         var hasHashCode = compilation.GetTypeByMetadataName("System.HashCode") is not null;
         return new(compilation.LanguageVersion, hasReactive, disposableInterface, hasHashCode);
     }

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -25,11 +25,11 @@ namespace dotVariant.Generator
             return new(type, syntax, options, nullability);
         }
 
-        public string SanitizedTypeName => (Type.ContainingNamespace.MetadataName + Type.MetadataName)
-                // If the contains type parameters replace angle brackets as those are not allowed in AddSource()
-                .Replace('<', '{')
-                .Replace('>', '}')
-                // Escaped names like @class or @event aren't supported either
-                .Replace('@', '.');
+        public string HintName => $"{Type.ToString()
+            // If the contains type parameters replace angle brackets as those are not allowed in AddSource()
+            .Replace('<', '{')
+            .Replace('>', '}')
+            // Escaped names like @class or @event aren't supported either
+            .Replace('@', '.')}.cs";
     }
 }

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -10,7 +10,7 @@ using System.Collections.Immutable;
 
 namespace dotVariant.Generator
 {
-    public sealed record Descriptor(
+    public readonly record struct Descriptor(
         INamedTypeSymbol Type,
         TypeDeclarationSyntax Syntax,
         ImmutableArray<IParameterSymbol> Options,

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -25,7 +25,7 @@ namespace dotVariant.Generator
             return new(type, syntax, options, nullability);
         }
 
-        public string SanitizedTypeName => Type.Name
+        public string SanitizedTypeName => (Type.ContainingNamespace.MetadataName + Type.MetadataName)
                 // If the contains type parameters replace angle brackets as those are not allowed in AddSource()
                 .Replace('<', '{')
                 .Replace('>', '}')

--- a/src/dotVariant.Generator/Descriptor.cs
+++ b/src/dotVariant.Generator/Descriptor.cs
@@ -24,5 +24,12 @@ namespace dotVariant.Generator
             var options = Inspect.GetOptions(type);
             return new(type, syntax, options, nullability);
         }
+
+        public string SanitizedTypeName => Type.Name
+                // If the contains type parameters replace angle brackets as those are not allowed in AddSource()
+                .Replace('<', '{')
+                .Replace('>', '}')
+                // Escaped names like @class or @event aren't supported either
+                .Replace('@', '.');
     }
 }

--- a/src/dotVariant.Generator/DiagnosedResult.cs
+++ b/src/dotVariant.Generator/DiagnosedResult.cs
@@ -1,0 +1,66 @@
+// 
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace dotVariant.Generator;
+
+/// <summary>A result type carrying <see cref="Diagnostic"/> values and a <typeparamref name="TValue"/> if any only if no errors are diagnosed.</summary>
+/// <typeparam name="TValue">The type of the value</typeparam>
+public readonly struct DiagnosedResult<TValue> : IEquatable<DiagnosedResult<TValue>>
+{
+    public DiagnosedResult(ImmutableArray<Diagnostic> diagnostics, Func<TValue> valueFactory)
+    {
+        HasErrors = diagnostics.Any(static d => d.Severity >= DiagnosticSeverity.Error);
+        Diagnostics = diagnostics;
+        ValueOrDefault = HasErrors ? default : valueFactory();
+    }
+
+    private DiagnosedResult(ImmutableArray<Diagnostic> diagnostics, bool hasErrors, TValue? valueOrDefault)
+    {
+        HasErrors = hasErrors;
+        Diagnostics = diagnostics;
+        ValueOrDefault = valueOrDefault;
+    }
+
+    public readonly ImmutableArray<Diagnostic> Diagnostics;
+    public readonly TValue? ValueOrDefault;
+    public readonly bool HasErrors;
+
+    public bool TryGetValue(out TValue value)
+    {
+        value = ValueOrDefault!;
+        return !HasErrors;
+    }
+
+    public DiagnosedResult<TResult> Select<TResult>(Func<TValue, TResult> selector)
+    {
+        var result = HasErrors ? default : selector(ValueOrDefault!);
+        return new DiagnosedResult<TResult>(Diagnostics, HasErrors, result);
+    }
+
+    public bool Equals(DiagnosedResult<TValue> other)
+    {
+        return EqualityComparer<TValue?>.Default.Equals(ValueOrDefault, other.ValueOrDefault) && HasErrors == other.HasErrors;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is DiagnosedResult<TValue> other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (EqualityComparer<TValue?>.Default.GetHashCode(ValueOrDefault) * 397) ^ HasErrors.GetHashCode();
+        }
+    }
+}

--- a/src/dotVariant.Generator/DiagnosedResult.cs
+++ b/src/dotVariant.Generator/DiagnosedResult.cs
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -14,33 +14,39 @@ namespace dotVariant.Generator;
 
 /// <summary>A result type carrying <see cref="Diagnostic"/> values and a <typeparamref name="TValue"/> if any only if no errors are diagnosed.</summary>
 /// <typeparam name="TValue">The type of the value</typeparam>
+/// <remarks>Diagnosed result ignores diagnostics during equality comparison to improve caching consistency.</remarks>
 public readonly struct DiagnosedResult<TValue> : IEquatable<DiagnosedResult<TValue>>
+    where TValue: IEquatable<TValue>
 {
+    private readonly bool _noErrors;
+
     public DiagnosedResult(ImmutableArray<Diagnostic> diagnostics, Func<TValue> valueFactory)
     {
-        HasErrors = diagnostics.Any(static d => d.Severity >= DiagnosticSeverity.Error);
+        _noErrors = !diagnostics.Any(static d => d.Severity >= DiagnosticSeverity.Error);
         Diagnostics = diagnostics;
         ValueOrDefault = HasErrors ? default : valueFactory();
     }
 
     private DiagnosedResult(ImmutableArray<Diagnostic> diagnostics, bool hasErrors, TValue? valueOrDefault)
     {
-        HasErrors = hasErrors;
+        _noErrors = !hasErrors;
         Diagnostics = diagnostics;
         ValueOrDefault = valueOrDefault;
     }
 
     public readonly ImmutableArray<Diagnostic> Diagnostics;
     public readonly TValue? ValueOrDefault;
-    public readonly bool HasErrors;
+
+    public bool HasErrors => !_noErrors;
 
     public bool TryGetValue(out TValue value)
     {
         value = ValueOrDefault!;
-        return !HasErrors;
+        return _noErrors;
     }
 
     public DiagnosedResult<TResult> Select<TResult>(Func<TValue, TResult> selector)
+        where TResult : IEquatable<TResult>
     {
         var result = HasErrors ? default : selector(ValueOrDefault!);
         return new DiagnosedResult<TResult>(Diagnostics, HasErrors, result);
@@ -48,7 +54,7 @@ public readonly struct DiagnosedResult<TValue> : IEquatable<DiagnosedResult<TVal
 
     public bool Equals(DiagnosedResult<TValue> other)
     {
-        return EqualityComparer<TValue?>.Default.Equals(ValueOrDefault, other.ValueOrDefault) && HasErrors == other.HasErrors;
+        return HasErrors == other.HasErrors && EqualityComparer<TValue?>.Default.Equals(ValueOrDefault, other.ValueOrDefault);
     }
 
     public override bool Equals(object? obj)
@@ -60,7 +66,7 @@ public readonly struct DiagnosedResult<TValue> : IEquatable<DiagnosedResult<TVal
     {
         unchecked
         {
-            return (EqualityComparer<TValue?>.Default.GetHashCode(ValueOrDefault) * 397) ^ HasErrors.GetHashCode();
+            return HasErrors ? 1337 : EqualityComparer<TValue?>.Default.GetHashCode(ValueOrDefault);
         }
     }
 }

--- a/src/dotVariant.Generator/Inspect.cs
+++ b/src/dotVariant.Generator/Inspect.cs
@@ -64,11 +64,11 @@ namespace dotVariant.Generator
         public static Accessibility EffectiveAccessibility(ITypeSymbol type)
             => type.DeclaredAccessibility;
 
-        public static bool ImplementsDispose(ITypeSymbol type, CSharpCompilation compilation)
+        public static bool ImplementsDispose(ITypeSymbol type, INamedTypeSymbol disposableInterface)
         {
             var dispose =
                 FindMethod(
-                    compilation.GetTypeByMetadataName($"{nameof(System)}.{nameof(IDisposable)}")!,
+                    disposableInterface,
                     m => m.Name == nameof(IDisposable.Dispose));
             return type.FindImplementationForInterfaceMember(dispose!) is not null;
         }

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -37,7 +37,7 @@ namespace dotVariant.Generator
         /// <param name="Version">
         /// Integer of the form ABB where A=major and BB=minor version of the language (i.e. 703 -> 7.3)
         /// </param>
-        public sealed record LanguageInfo(
+        public readonly record struct LanguageInfo(
             string Nullable,
             int Version);
 
@@ -45,7 +45,7 @@ namespace dotVariant.Generator
         /// The namespace in which to generate extension method implementations.
         /// If <see langword="null"/> use the global namespace.
         /// </param>
-        public sealed record OptionsInfo(
+        public readonly record struct OptionsInfo(
             string? ExtensionClassNamespace);
 
         /// <param name="HasHashCode">
@@ -54,7 +54,7 @@ namespace dotVariant.Generator
         /// <param name="HasSystemReactiveLinq">
         /// <see langword="true"/> if <see cref="System.Reactive.Linq"/> namespace is found.
         /// </param>
-        public sealed record RuntimeInfo(
+        public readonly record struct RuntimeInfo(
             bool HasHashCode,
             bool HasSystemReactiveLinq);
 
@@ -102,7 +102,7 @@ namespace dotVariant.Generator
         /// <param name="UserDefined">
         /// Contains info about relevant members the user has defined.
         /// </param>
-        public sealed record VariantInfo(
+        public readonly record struct VariantInfo(
             string? Accessibility,
             bool CanBeNull,
             string DiagType,
@@ -121,7 +121,7 @@ namespace dotVariant.Generator
             /// <param name="Dispose">
             /// <see langword="true"/> if a user-defined <see cref="IDisposable.Dispose()"/> exists.
             /// </param>
-            public sealed record UserDefinitions(
+            public readonly record struct UserDefinitions(
                 bool Dispose);
 
             /// <param name="Constraints">
@@ -130,7 +130,7 @@ namespace dotVariant.Generator
             /// <param name="Identifier">
             /// Identifier of the generic parameter.
             /// </param>
-            public sealed record GenericInfo(
+            public readonly record struct GenericInfo(
                 ImmutableArray<string> Constraints,
                 string Identifier);
         }
@@ -175,7 +175,7 @@ namespace dotVariant.Generator
         /// <param name="Type">
         /// The fully qualified name of the type including type parameter list, without nullability annotation.
         /// </param>
-        public sealed record ParamInfo(
+        public readonly record struct ParamInfo(
             bool CanBeNull,
             string DiagType,
             bool EmitImplicitCast,

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -261,7 +261,7 @@ namespace dotVariant.Generator
 
         private static string TypeParameterQualifiedName(INamedTypeSymbol type)
         {
-            return type.TypeParameters.IsDefaultOrEmpty ? type.Name : $"{type.Name}_{string.Join("_", type.TypeParameters.Select(p => p.Name))}";
+            return type.TypeParameters.IsDefaultOrEmpty ? type.Name : $"{type.Name}_{string.Join("_", type.TypeParameters.Select(p => p.Name))}_";
         }
 
         private static string DetermineOutType(IParameterSymbol p, bool emitNullable, LanguageVersion version)

--- a/src/dotVariant.Generator/RenderInfo.cs
+++ b/src/dotVariant.Generator/RenderInfo.cs
@@ -24,7 +24,7 @@ namespace dotVariant.Generator
     /// <param name="Params">Properties of the parameters provided to <c>VariantOf</c>.</param>
     /// <param name="Runtime">Information about the .NET runtime we are generating code for.</param>
     /// <param name="Variant">Properties of the variant class.</param>
-    public sealed record RenderInfo(
+    public readonly record struct RenderInfo(
         RenderInfo.LanguageInfo Language,
         RenderInfo.OptionsInfo Options,
         ImmutableArray<RenderInfo.ParamInfo> Params,

--- a/src/dotVariant.Generator/SourceGenerator.cs
+++ b/src/dotVariant.Generator/SourceGenerator.cs
@@ -71,7 +71,7 @@ namespace dotVariant.Generator
                     return source.Select(tuple =>
                     {
                         var (desc, compInfo) = tuple;
-                        return (desc.SanitizedTypeName, RenderInfo.FromDescriptor(desc, compInfo, analyzerOptionProvider, ct));
+                        return (desc.HintName, RenderInfo.FromDescriptor(desc, compInfo, analyzerOptionProvider, ct));
                     });
                 });
 

--- a/src/dotVariant.Generator/SourceGenerator.cs
+++ b/src/dotVariant.Generator/SourceGenerator.cs
@@ -7,6 +7,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace dotVariant.Generator
@@ -14,6 +15,10 @@ namespace dotVariant.Generator
     [Generator]
     public sealed class SourceGenerator : IIncrementalGenerator
     {
+#if DEBUG
+        public List<RenderInfo> RenderInfos { get; } = new();
+#endif
+
         public void Initialize(IncrementalGeneratorInitializationContext generatorContext)
         {
             var variantDecls = generatorContext.SyntaxProvider.CreateSyntaxProvider((node, ct) =>
@@ -62,6 +67,9 @@ namespace dotVariant.Generator
                     }
                     var desc = Descriptor.FromDeclaration(decl.Symbol, decl.Syntax, decl.Nullable);
                     var renderInfo = RenderInfo.FromDescriptor(desc, compInfo, analyzerOptionProvider, ct);
+#if DEBUG
+                    RenderInfos.Add(renderInfo);
+#endif
                     return (desc, renderInfo);
                 });
 

--- a/src/dotVariant.Generator/ValueProviderExtensions.cs
+++ b/src/dotVariant.Generator/ValueProviderExtensions.cs
@@ -1,0 +1,36 @@
+//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace dotVariant.Generator
+{
+	public static class ValueProviderExtensions
+	{
+		public static IncrementalValuesProvider<TResult> SelectNotNull<TSource, TResult>(
+				this IncrementalValuesProvider<TSource> source, Func<TSource, CancellationToken, TResult?> selector)
+				where TResult : struct
+		{
+			return source.SelectMany((source, ct) =>
+					selector(source, ct) is { } result ? ImmutableArray.Create(result) : ImmutableArray<TResult>.Empty);
+		}
+
+		public static IncrementalValuesProvider<TSource> SelectNotNull<TSource>(this IncrementalValuesProvider<TSource?> source)
+				where TSource : struct
+		{
+			return source.SelectMany(static (source, _) =>
+					source is { } result ? ImmutableArray.Create(result) : ImmutableArray<TSource>.Empty);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static T? AsNullable<T>(this T value) where T : struct => value;
+	}
+}

--- a/src/dotVariant.Generator/VariantDecl.cs
+++ b/src/dotVariant.Generator/VariantDecl.cs
@@ -1,0 +1,17 @@
+﻿//
+// Copyright Miro Knejp 2021.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+//
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace dotVariant.Generator;
+
+public readonly record struct VariantDecl(INamedTypeSymbol Symbol, TypeDeclarationSyntax Syntax,
+    NullableContext Nullable, IEnumerable<Diagnostic> Diags)
+{
+    public const string AttributeName = nameof(dotVariant) + "." + nameof(VariantAttribute);
+}

--- a/src/dotVariant.Generator/VariantDecl.cs
+++ b/src/dotVariant.Generator/VariantDecl.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright Miro Knejp 2021.
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
@@ -6,12 +6,12 @@
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace dotVariant.Generator;
 
 public readonly record struct VariantDecl(INamedTypeSymbol Symbol, TypeDeclarationSyntax Syntax,
-    NullableContext Nullable, IEnumerable<Diagnostic> Diags)
+    NullableContext Nullable, ImmutableArray<Diagnostic> Diags)
 {
     public const string AttributeName = nameof(dotVariant) + "." + nameof(VariantAttribute);
 }

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -8,13 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <!-- Transitive closure of generator runtime dependencies -->
-    <PackageReference Include="Scriban" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Interactive" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="Scriban" Version="5.7.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Interactive" Version="6.0.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator/dotVariant.Generator.csproj
+++ b/src/dotVariant.Generator/dotVariant.Generator.csproj
@@ -9,16 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <!-- Transitive closure of generator runtime dependencies -->
     <PackageReference Include="Scriban" Version="5.7.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Interactive" Version="6.0.1" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.6.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IEnumerable.scriban-cs
@@ -19,7 +19,7 @@ namespace {{ Options.ExtensionClassNamespace }}
     /// Extensions which allow for easy and powerful integration into `System.Linq`-like queries
     /// on <see cref="global::System.Collections.Generic.IEnumerable{T}" /> sequences, that let you manipulate a stream of variants based on the contained type.
     /// </summary>
-    {{ Variant.ExtensionsAccessibility }} static partial class {{ Variant.Name }}Ex
+    {{ Variant.ExtensionsAccessibility }} static partial class {{ Variant.TypeParameterQualifiedName }}Ex
     {
         {{~ ## Match(IEnumerable<V>, Func<A, R>) ## ~}}
         {{~ for $p in Params ~}}

--- a/src/dotVariant.Generator/templates/IObservable.scriban-cs
+++ b/src/dotVariant.Generator/templates/IObservable.scriban-cs
@@ -19,7 +19,7 @@ namespace {{ Options.ExtensionClassNamespace }}
     /// Extensions which allow for easy and powerful integration into `System.Reactive.Linq`-like queries
     /// on <see cref="global::System.IObservable{T}" /> sequences, that let you manipulate an asynchronous stream of variants based on the contained type.
     /// </summary>
-    {{ Variant.ExtensionsAccessibility }} static partial class {{ Variant.Name }}Ex
+    {{ Variant.ExtensionsAccessibility }} static partial class {{ Variant.TypeParameterQualifiedName }}Ex
     {
         {{~ ## Match(IObservable<V>, Func<A, R>) ## ~}}
         {{~ for $p in Params ~}}

--- a/src/dotVariant.Test-net452/dotVariant.Test-net452.csproj
+++ b/src/dotVariant.Test-net452/dotVariant.Test-net452.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
 
   <Import Project="..\dotVariant.Test\dotVariant.Test.projitems" Label="Shared" />

--- a/src/dotVariant.Test/Variant+TryMatch.cs
+++ b/src/dotVariant.Test/Variant+TryMatch.cs
@@ -46,7 +46,9 @@ namespace dotVariant.Test
             {
                 var v = new Class_int_float_string(1);
                 Assert.That(v.TryMatch(out float _), Is.False);
+#pragma warning disable CS8601
                 Assert.That(v.TryMatch(out string _), Is.False);
+#pragma warning restore CS8601
             }
 
             [Test]
@@ -54,7 +56,9 @@ namespace dotVariant.Test
             {
                 var v = new Class_int_float_string(1f);
                 Assert.That(v.TryMatch(out int _), Is.False);
+#pragma warning disable CS8601
                 Assert.That(v.TryMatch(out string _), Is.False);
+#pragma warning restore CS8601
             }
 
             [Test]

--- a/src/dotVariant.sln
+++ b/src/dotVariant.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotVariant.Runtime", "dotVa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotVariant.Test-net5.0", "dotVariant.Test-net5.0\dotVariant.Test-net5.0.csproj", "{5FA8381B-0576-498A-9968-006A38839D3C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotVariant.Test-net45", "dotVariant.Test-net45\dotVariant.Test-net45.csproj", "{1305501C-65AB-4338-848F-3D2B919B7255}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotVariant.Test-net452", "dotVariant.Test-net452\dotVariant.Test-net452.csproj", "{1305501C-65AB-4338-848F-3D2B919B7255}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "dotVariant.Test", "dotVariant.Test\dotVariant.Test.shproj", "{193D7A79-92BF-46BE-BB02-60360DA0883D}"
 EndProject
@@ -29,11 +29,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		dotVariant.Test\dotVariant.Test.projitems*{1305501c-65ab-4338-848f-3d2b919b7255}*SharedItemsImports = 5
-		dotVariant.Test\dotVariant.Test.projitems*{193d7a79-92bf-46be-bb02-60360da0883d}*SharedItemsImports = 13
-		dotVariant.Test\dotVariant.Test.projitems*{5fa8381b-0576-498a-9968-006a38839d3c}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -69,5 +64,10 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5601C60A-02E6-42A8-B802-79FCCC6CD6C3}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		dotVariant.Test\dotVariant.Test.projitems*{1305501c-65ab-4338-848f-3d2b919b7255}*SharedItemsImports = 5
+		dotVariant.Test\dotVariant.Test.projitems*{193d7a79-92bf-46be-bb02-60360da0883d}*SharedItemsImports = 13
+		dotVariant.Test\dotVariant.Test.projitems*{5fa8381b-0576-498a-9968-006a38839d3c}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/dotVariant/dotVariant.csproj
+++ b/src/dotVariant/dotVariant.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <None Include="$(GeneratorOutputPath)/dotVariant.dll" Pack="true" PackagePath="lib/$(TargetFramework)" Link="lib/$(TargetFramework)/%(Filename)%(Extension)" />
-    <None Include="../dotVariant.Generator/licenses/**" Pack="true" PackagePath="licenses" Link="licenses/%(RecursiveDir)%(Filename)%(Extension)"/>
+    <None Include="../dotVariant.Generator/licenses/**" Pack="true" PackagePath="licenses" Link="licenses/%(RecursiveDir)%(Filename)%(Extension)" />
     <None Include="build/*" Pack="true" PackagePath="build" />
   </ItemGroup>
 
   <Target Name="dotVariant-GatherGeneratorDependencies" AfterTargets="Build">
     <MSBuild Projects="../dotVariant.Generator/dotVariant.Generator.csproj" Targets="GetTargetPath">
-      <Output TaskParameter="TargetOutputs" ItemName="GeneratorOutputs"/>
+      <Output TaskParameter="TargetOutputs" ItemName="GeneratorOutputs" />
     </MSBuild>
     <!--<Message Importance="high" Text="%(GeneratorOutputs.Identity)" />-->
     <ItemGroup>


### PR DESCRIPTION
# Finer grained determination of visibility for extension methods

## Synopsis

- **Fixes #44**
- **Depends on #57**

## Subject

Changes the naming of the generated extension class with generic types to the following format:

```
{{ Variant.Type.Name }}_{{ join "_" Variant.TypeParameters }}_Ex
```

